### PR TITLE
libvirtError in _update_libvirt_domain is no longer silently swallowed.

### DIFF
--- a/core-modules/000QubesVm.py
+++ b/core-modules/000QubesVm.py
@@ -729,6 +729,8 @@ class QubesVm(object):
                 raise QubesException("HVM domains not supported on this "
                                      "machine. Check BIOS settings for "
                                      "VT-x/AMD-V extensions.")
+            else:
+                raise e
         self.uuid = uuid.UUID(bytes=self._libvirt_domain.UUID())
 
     @property


### PR DESCRIPTION
I had some issue with fstrim and the missing else had caused the code to continue and fail later with a non-descriptive error message. This commit makes the error message more descriptive and helpful.

Should I pull this patch also to master?

Maybe I will be able to provide at least a reproduction case for the original failure, but the roots are quite old. In mycase, the xxx-dvm VM partially existed. That is, there was a directory in /var/lib/qubes/appvms (this was reported clearly by the qvm-trim-template), there was a file in /etc/libvirt/libxl/ (a hint to this fact was reported after this patch), but qvm-remove did not know anything about the VM.