### PR TITLE
libvirtError in _update_libvirt_domain is no longer silently swallowed.

### DIFF
--- a/core-modules/000QubesVm.py
+++ b/core-modules/000QubesVm.py
@@ -732,6 +732,8 @@ class QubesVm(object):
                 raise QubesException("HVM domains not supported on this "
                                      "machine. Check BIOS settings for "
                                      "VT-x/AMD-V extensions.")
+            else:
+                raise e
         self.uuid = uuid.UUID(bytes=self._libvirt_domain.UUID())
 
     @property


### PR DESCRIPTION
I had some issue with fstrim and the missing else had caused the code to continue and fail later with a non-descriptive error message. This commit makes the error message more descriptive and helpful.

The same as https://github.com/QubesOS/qubes-core-admin/pull/10, but ported for master.