### PR TITLE
Refactor common functionality from XenStorage & XenPool to QubesVmStorage & Pool

### DIFF
--- a/core/storage/__init__.py
+++ b/core/storage/__init__.py
@@ -65,6 +65,25 @@ class QubesVmStorage(object):
         # Additional drive (currently used only by HVM)
         self.drive = None
 
+    def format_disk_dev(self, path, script, vdev, rw=True, type="disk",
+                        domain=None):
+        if path is None:
+            return ''
+        template = "    <disk type='block' device='{type}'>\n" \
+                   "      <driver name='phy'/>\n" \
+                   "      <source dev='{path}'/>\n" \
+                   "      <target dev='{vdev}' bus='xen'/>\n" \
+                   "{params}" \
+                   "    </disk>\n"
+        params = ""
+        if not rw:
+            params += "      <readonly/>\n"
+        if domain:
+            params += "      <backenddomain name='%s'/>\n" % domain
+        if script:
+            params += "      <script path='%s'/>\n" % script
+        return template.format(path=path, vdev=vdev, type=type, params=params)
+
     def get_config_params(self):
         raise NotImplementedError
 

--- a/core/storage/__init__.py
+++ b/core/storage/__init__.py
@@ -57,6 +57,10 @@ class QubesVmStorage(object):
         else:
             self.root_img_size = defaults['root_img_size']
 
+        self.root_dev = "xvda"
+        self.private_dev = "xvdb"
+        self.volatile_dev = "xvdc"
+        self.modules_dev = "xvdd"
 
         # For now compute this path still in QubesVm
         self.modules_img = modules_img

--- a/core/storage/__init__.py
+++ b/core/storage/__init__.py
@@ -382,22 +382,17 @@ class Pool(object):
                 string (str) absolute path to the directory where the vm files
                              are stored
         """
-        # TODO: This is a hack, circular dependencies problem?
-        from qubes.qubes import (QubesAppVm, QubesDisposableVm, QubesHVm, 
-                                 QubesNetVm, QubesTemplateHVm, QubesTemplateVm)
-        vm_type = type(vm)
-
-        if vm_type in [QubesAppVm, QubesHVm]:
+        if vm.is_appvm():
             subdir = 'appvms'
-        elif vm_type in [QubesTemplateVm, QubesTemplateHVm]:
+        elif vm.is_template():
             subdir = 'vm-templates'
-        elif issubclass(vm_type, QubesNetVm):
+        elif vm.is_netvm():
             subdir = 'servicevms'
-        elif vm_type is QubesDisposableVm:
+        elif vm.is_disposablevm():
             subdir = 'appvms'
             return os.path.join(pool_dir, subdir, vm.template.name + '-dvm')
         else:
-            raise QubesException(str(vm_type) + ' unknown vm type')
+            raise QubesException(vm.type() + ' unknown vm type')
 
         return os.path.join(pool_dir, subdir, vm.name)
 

--- a/core/storage/xen.py
+++ b/core/storage/xen.py
@@ -49,11 +49,6 @@ class XenStorage(QubesVmStorage):
 
         super(XenStorage, self).__init__(vm, **kwargs)
 
-        self.root_dev = "xvda"
-        self.private_dev = "xvdb"
-        self.volatile_dev = "xvdc"
-        self.modules_dev = "xvdd"
-
         self.vmdir = vmdir
 
         if self.vm.is_template():

--- a/core/storage/xen.py
+++ b/core/storage/xen.py
@@ -28,9 +28,7 @@ import re
 import subprocess
 import sys
 
-from qubes.qubes import (QubesAppVm, QubesDisposableVm, QubesException,
-                         QubesHVm, QubesNetVm, QubesTemplateHVm,
-                         QubesTemplateVm, defaults, vm_files)
+from qubes.qubes import QubesException, vm_files
 from qubes.storage import Pool, QubesVmStorage
 
 
@@ -275,64 +273,8 @@ class XenStorage(QubesVmStorage):
 class XenPool(Pool):
 
     def __init__(self, vm, dir_path):
-        assert vm is not None
-        assert dir_path is not None
-
-        appvms_path = os.path.join(dir_path, 'appvms')
-        servicevms_path = os.path.join(dir_path, 'servicevms')
-        vm_templates_path = os.path.join(dir_path, 'vm-templates')
-
-        self._create_dir_if_not_exists(dir_path)
-        self._create_dir_if_not_exists(appvms_path)
-        self._create_dir_if_not_exists(servicevms_path)
-        self._create_dir_if_not_exists(vm_templates_path)
-
-        self.vmdir = self._vmdir_path(vm, dir_path)
-        self.vm = vm
-        self.dir_path = dir_path
+        super(XenPool, self).__init__(vm, dir_path)
 
     def getStorage(self):
         """ Returns an instantiated ``XenStorage``. """
-        return defaults['storage_class'](self.vm, vmdir=self.vmdir)
-
-    def _vmdir_path(self, vm, pool_dir):
-        """ Get the vm dir depending on the type of the VM.
-
-            The default QubesOS file storage saves the vm images in three
-            different directories depending on the ``QubesVM`` type:
-
-            * ``appvms`` for ``QubesAppVm`` or ``QubesHvm``
-            * ``vm-templates`` for ``QubesTemplateVm`` or ``QubesTemplateHvm``
-            * ``servicevms`` for any subclass of  ``QubesNetVm``
-
-            Args:
-                vm: a QubesVM
-                pool_dir: the root directory of the pool
-
-            Returns:
-                string (str) absolute path to the directory where the vm files
-                             are stored
-        """
-        vm_type = type(vm)
-
-        if vm_type in [QubesAppVm, QubesHVm]:
-            subdir = 'appvms'
-        elif vm_type in [QubesTemplateVm, QubesTemplateHVm]:
-            subdir = 'vm-templates'
-        elif issubclass(vm_type, QubesNetVm):
-            subdir = 'servicevms'
-        elif vm_type is QubesDisposableVm:
-            subdir = 'appvms'
-            return os.path.join(pool_dir, subdir, vm.template.name + '-dvm')
-        else:
-            raise QubesException(str(vm_type) + ' unknown vm type')
-
-        return os.path.join(pool_dir, subdir, vm.name)
-
-    def _create_dir_if_not_exists(self, path):
-        """ Check if a directory exists in if not it is created.
-
-            This method does not create any parent directories.
-        """
-        if not os.path.exists(path):
-            os.mkdir(path)
+        return XenStorage(self.vm, vmdir=self.vmdir)


### PR DESCRIPTION
I noticed that some of the logic used by XenStorage and XenPool is general enough to be reused. I also fixed the circular dependency in `Pool.vmdir_path()`, like @marmarek proposed [here](https://groups.google.com/d/msg/qubes-devel/HfuwNkOIOzU/9vddyzxICAAJ)

See also [qubes-dev:  Circular dependencies when refactoring functionality from XenPool to Pool ](https://groups.google.com/forum/#!topic/qubes-devel/HfuwNkOIOzU)