### PR TITLE
qvm-create: Don't allow the user to manually create dispNN names

### DIFF
--- a/qvm-tools/qvm-create
+++ b/qvm-tools/qvm-create
@@ -130,6 +130,10 @@ def main():
     if options.offline_mode:
         vmm.offline_mode = True
 
+    if re.match('^disp\d+$', vmname):
+        print >> sys.stderr, 'The name "{0}" is reserved for internal use.'.format(vmname)
+        exit(1)
+
     qvm_collection = QubesVmCollection()
     qvm_collection.lock_db_for_writing()
     qvm_collection.load()


### PR DESCRIPTION
Currently the user can manually create VMs matching the dispVM naming pattern. It seems prudent to disallow this to prevent confusion and possible mistaken applications of policy.