### PR TITLE
implemented dom0 qubes.GetRandomizedTime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,10 @@ endif
 	cp qubes-rpc-policy/qubes.NotifyUpdates.policy $(DESTDIR)/etc/qubes-rpc/policy/qubes.NotifyUpdates
 	cp qubes-rpc-policy/qubes.NotifyTools.policy $(DESTDIR)/etc/qubes-rpc/policy/qubes.NotifyTools
 	cp qubes-rpc-policy/qubes.GetImageRGBA.policy $(DESTDIR)/etc/qubes-rpc/policy/qubes.GetImageRGBA
+	cp qubes-rpc-policy/qubes.GetRandomizedTime.policy $(DESTDIR)/etc/qubes-rpc/policy/qubes.GetTime
 	cp qubes-rpc/qubes.NotifyUpdates $(DESTDIR)/etc/qubes-rpc/
 	cp qubes-rpc/qubes.NotifyTools $(DESTDIR)/etc/qubes-rpc/
+	cp qubes-rpc/qubes.GetRandomizedTime $(DESTDIR)/etc/qubes-rpc/
 	cp qubes-rpc/qubes-notify-updates $(DESTDIR)/usr/libexec/qubes/
 	cp qubes-rpc/qubes-notify-tools $(DESTDIR)/usr/libexec/qubes/
 	mkdir -p "$(DESTDIR)$(FILESDIR)"

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ endif
 	cp qubes-rpc-policy/qubes.NotifyUpdates.policy $(DESTDIR)/etc/qubes-rpc/policy/qubes.NotifyUpdates
 	cp qubes-rpc-policy/qubes.NotifyTools.policy $(DESTDIR)/etc/qubes-rpc/policy/qubes.NotifyTools
 	cp qubes-rpc-policy/qubes.GetImageRGBA.policy $(DESTDIR)/etc/qubes-rpc/policy/qubes.GetImageRGBA
-	cp qubes-rpc-policy/qubes.GetRandomizedTime.policy $(DESTDIR)/etc/qubes-rpc/policy/qubes.GetTime
+	cp qubes-rpc-policy/qubes.GetRandomizedTime.policy $(DESTDIR)/etc/qubes-rpc/policy/qubes.GetRandomizedTime
 	cp qubes-rpc/qubes.NotifyUpdates $(DESTDIR)/etc/qubes-rpc/
 	cp qubes-rpc/qubes.NotifyTools $(DESTDIR)/etc/qubes-rpc/
 	cp qubes-rpc/qubes.GetRandomizedTime $(DESTDIR)/etc/qubes-rpc/

--- a/qubes-rpc-policy/qubes.GetRandomizedTime.policy
+++ b/qubes-rpc-policy/qubes.GetRandomizedTime.policy
@@ -1,0 +1,6 @@
+## Note that policy parsing stops at the first match,
+## so adding anything below "$anyvm $anyvm action" line will have no effect
+
+## Please use a single # to start your custom comments
+
+$anyvm	dom0	allow

--- a/qubes-rpc/qubes.GetRandomizedTime
+++ b/qubes-rpc/qubes.GetRandomizedTime
@@ -25,13 +25,10 @@ set -e
 
 ## Get a random 0 or 1.
 ## Will use this to decide to use plus or minus.
-##
-## Thanks to
-## http://linux.byexamples.com/archives/128/generating-random-numbers/
-ZERO_OR_ONE="$(( 0+($(od -An -N2 -i /dev/random) )%(0+2) ))"
+ZERO_OR_ONE="$(shuf -i0-1 -n1 --random-source=/dev/random)"
 
 ## Create a random number between 0 and 180.
-DELAY="$(( $(od -An -N2 -i /dev/random)%(180-0+1) ))"
+DELAY="$(shuf -i0-180 -n1 --random-source=/dev/random)"
 
 ## Create a random number between 0 and 999999999.
 ##

--- a/qubes-rpc/qubes.GetRandomizedTime
+++ b/qubes-rpc/qubes.GetRandomizedTime
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# The Qubes OS Project, http://www.qubes-os.org
+#
+# Copyright (C) 2016 Patrick Schleizer <adrelanos@riseup.net>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+## Similar code as Boot Clock Randomization.
+## https://www.whonix.org/wiki/Boot_Clock_Randomization
+
+set -e
+
+## Get a random 0 or 1.
+## Will use this to decide to use plus or minus.
+##
+## Thanks to
+## http://linux.byexamples.com/archives/128/generating-random-numbers/
+ZERO_OR_ONE="$(( 0+($(od -An -N2 -i /dev/random) )%(0+2) ))"
+
+## Create a random number between 0 and 180.
+DELAY="$(( $(od -An -N2 -i /dev/random)%(180-0+1) ))"
+
+## Create a random number between 0 and 999999999.
+##
+## Thanks to
+## https://stackoverflow.com/questions/22887891/how-can-i-get-a-random-dev-random-number-between-0-and-999999999-in-bash
+NANOSECONDS="$(shuf -i0-999999999 -n1 --random-source=/dev/random)"
+
+## Examples NANOSECONDS:
+## 117752805
+## 38653957
+
+## Add leading zeros, because `date` expects 9 digits.
+NANOSECONDS="$(printf '%0*d\n' 9 "$NANOSECONDS")"
+
+## Using
+## printf '%0*d\n' 9 "38653957"
+##  38653957
+## becomes
+## 038653957
+
+## Examples NANOSECONDS:
+## 117752805
+## 038653957
+
+if [ "$ZERO_OR_ONE" = "0" ]; then
+  PLUS_OR_MINUS="-"
+elif [ "$ZERO_OR_ONE" = "1" ]; then
+  PLUS_OR_MINUS="+"
+else
+  exit 2
+fi
+
+#OLD_TIME="$(date)"
+#OLD_TIME_NANOSECONDS="$(date +%s.%N)"
+
+OLD_UNIXTIME="$(date +%s)"
+
+NEW_TIME="$(( $OLD_UNIXTIME $PLUS_OR_MINUS $DELAY ))"
+
+NEW_TIME_NANOSECONDS="$NEW_TIME.$NANOSECONDS"
+
+echo "$NEW_TIME_NANOSECONDS"
+
+## Testing the `date` syntax:
+## date --date @1396733199.112834496
+## date --date "@$NEW_TIME_NANOSECONDS"

--- a/rpm_spec/core-dom0.spec
+++ b/rpm_spec/core-dom0.spec
@@ -247,8 +247,10 @@ fi
 %attr(0664,root,qubes) %config(noreplace) /etc/qubes-rpc/policy/qubes.NotifyTools
 %attr(0664,root,qubes) %config(noreplace) /etc/qubes-rpc/policy/qubes.NotifyUpdates
 %attr(0664,root,qubes) %config(noreplace) /etc/qubes-rpc/policy/qubes.VMShell
+%attr(0664,root,qubes) %config(noreplace) /etc/qubes-rpc/policy/qubes.GetRandomizedTime
 /etc/qubes-rpc/qubes.NotifyTools
 /etc/qubes-rpc/qubes.NotifyUpdates
+/etc/qubes-rpc/qubes.GetRandomizedTime
 %attr(2770,root,qubes) %dir /var/log/qubes
 %attr(0770,root,qubes) %dir /var/run/qubes
 /etc/xdg/autostart/qubes-guid.desktop


### PR DESCRIPTION
Required for fixing 'sys-whonix doesn't connect to Tor after system suspend'.

https://github.com/QubesOS/qubes-issues/issues/1764