### PR TITLE
Nicely print list of excluded VMs

### DIFF
--- a/core/backup.py
+++ b/core/backup.py
@@ -357,8 +357,8 @@ def backup_prepare(vms_list=None, exclude_list=None,
 
     vms_not_for_backup = [vm.name for vm in qvm_collection.values()
                           if not vm.backup_content]
-    print_callback("VMs not selected for backup: %s" % " ".join(
-        vms_not_for_backup))
+    print_callback("VMs not selected for backup:\n%s" % "\n".join(sorted(
+        vms_not_for_backup)))
 
     if there_are_running_vms:
         raise QubesException("Please shutdown all VMs before proceeding.")


### PR DESCRIPTION
Prints a sorted list of VMs not selected for backup, one name per line.
(Fixes QubesOS/qubes-issues#1023)