### PR TITLE
Fix typos and clarify descriptions

### DIFF
--- a/doc/qvm-tools/qvm-add-appvm.rst
+++ b/doc/qvm-tools/qvm-add-appvm.rst
@@ -6,7 +6,7 @@ NAME
 ====
 qvm-add-appvm - add an already installed appvm to the Qubes DB
 
-WARNING: Noramlly you would not need this command, and you would use qvm-create instead!
+WARNING: Normally you should not need this command, and you should use qvm-create instead!
 
 :Date:   2012-04-10
 

--- a/doc/qvm-tools/qvm-backup-restore.rst
+++ b/doc/qvm-tools/qvm-backup-restore.rst
@@ -21,21 +21,21 @@ OPTIONS
 --skip-broken
     Do not restore VMs that have missing templates or netvms
 --ignore-missing
-    Ignore missing templates or netvms, restore VMs anyway
+    Ignore missing templates and netvms, and restore the VMs anyway
 --skip-conflicting
     Do not restore VMs that are already present on the host
 --force-root
-    Force to run, even with root privileges
+    Force to run with root privileges
 --replace-template=REPLACE_TEMPLATE
-    Restore VMs using another template, syntax: old-template-name:new-template-name (might be repeated)
+    Restore VMs using another template, syntax: old-template-name:new-template-name (can be repeated)
 -x EXCLUDE, --exclude=EXCLUDE
-    Skip restore of specified VM (might be repeated)
+    Skip restore of specified VM (can be repeated)
 --skip-dom0-home
-    Do not restore dom0 user home dir
+    Do not restore dom0's user home directory
 --ignore-username-mismatch
-    Ignore dom0 username mismatch while restoring homedir
+    Ignore dom0 username mismatch when restoring dom0's user home directory
 -d APPVM, --dest-vm=APPVM
-    The AppVM to send backups to
+    Restore from a backup located in a specific AppVM
 -e, --encrypted
     The backup is encrypted
 -z, --compressed

--- a/doc/qvm-tools/qvm-prefs.rst
+++ b/doc/qvm-tools/qvm-prefs.rst
@@ -134,7 +134,7 @@ mac
 
     Can be used to force specific of virtual ethernet card in the VM. Setting
     to ``auto`` will use automatic-generated MAC - based on VM id. Especially
-    useful when some licencing depending on static MAC address.
+    useful when licensing requires a static MAC address.
     For template-based HVM ``auto`` mode means to clone template MAC.
 
 default_user
@@ -147,7 +147,7 @@ debug
     Accepted values: ``on``, ``off``
 
     Enables debug mode for VM. This can be used to turn on/off verbose logging
-    in many qubes components at once (gui virtualization, VM kernel, some other
+    in many Qubes components at once (gui virtualization, VM kernel, some other
     services).
     For template-based HVM, enabling debug mode also disables automatic reset
     root.img (actually volatile.img) before each VM startup, so changes made to
@@ -172,7 +172,7 @@ guiagent_installed
     This HVM have gui agent installed. This option disables full screen GUI
     virtualization and enables per-window seemless GUI mode. This option will
     be automatically turned on during Qubes Windows Tools installation, but if
-    you install qubes gui agent in some other OS, you need to turn this option
+    you install Qubes gui agent in some other OS, you need to turn this option
     on manually. You can turn this option off to troubleshoot some early HVM OS
     boot problems (enter safe mode etc), but the option will be automatically
     enabled at first VM normal startup (and will take effect from the next

--- a/doc/qvm-tools/qvm-revert-template-changes.rst
+++ b/doc/qvm-tools/qvm-revert-template-changes.rst
@@ -17,7 +17,7 @@ OPTIONS
 -h, --help
     Show this help message and exit
 --force
-    Do not prompt for comfirmation
+    Do not prompt for confirmation
 
 AUTHORS
 =======

--- a/doc/qvm-tools/qvm-service.rst
+++ b/doc/qvm-tools/qvm-service.rst
@@ -30,7 +30,7 @@ OPTIONS
 SUPPORTED SERVICES
 ==================
 
-This list can be incomplete as VM can implement any additional service without knowlege of qubes-core code.
+This list can be incomplete as VM can implement any additional service without knowledge of qubes-core code.
 
 meminfo-writer
     Default: enabled everywhere excluding NetVM
@@ -38,7 +38,7 @@ meminfo-writer
     This service reports VM memory usage to dom0, which effectively enables dynamic memory management for the VM.
 
     *Note:* this service is enforced to be set by dom0 code. If you try to
-    remove it (reset to defult state), will be recreated with the rule: enabled
+    remove it (reset to default state), will be recreated with the rule: enabled
     if VM have no PCI devices assigned, otherwise disabled.
 
 qubes-dvm


### PR DESCRIPTION
These commits fix the typos which were reintroduced in https://github.com/QubesOS/qubes-doc/commit/7658852df4ba159202a975742bace7e4fbde19eb and makes further language improvements.