### PR TITLE
fix qvm-ls display of cpu_time

### DIFF
--- a/core/qubes.py
+++ b/core/qubes.py
@@ -224,7 +224,7 @@ class QubesHost(object):
                 cputime = vm.get_cputime()
                 previous[vm.xid] = {}
                 previous[vm.xid]['cpu_time'] = (
-                        cputime / vm.vcpus)
+                        cputime / max(vm.vcpus, 1))
                 previous[vm.xid]['cpu_usage'] = 0
             time.sleep(wait_time)
 

--- a/qvm-tools/qvm-ls
+++ b/qvm-tools/qvm-ls
@@ -148,7 +148,7 @@ def main():
 
     if (options.cpu):
         qhost = QubesHost()
-        (measure_time, cpu_usages) = qhost.measure_cpu_usage()
+        (measure_time, cpu_usages) = qhost.measure_cpu_usage(qvm_collection)
         fields_to_display += ["cpu"]
 
     if (options.mem):


### PR DESCRIPTION
qhost.measure_cpu_usage expects the qvm_collection as parameter. Also
the number of vcpus of dom0 seems to be 0, leading to a div by 0. A more
complete fix would probably involve e.g. a new num_cores property which
would contain number of vcpu for vhosts and number of actual cores for
dom0.

For now this is a partial solution.