### PR TITLE
Fixed #1930: Delete autostart Symlink when deleting a VM

### DIFF
--- a/core-modules/000QubesVm.py
+++ b/core-modules/000QubesVm.py
@@ -1412,6 +1412,11 @@ class QubesVm(object):
                     e.get_error_code())
                 raise
 
+        if os.path.exists("/etc/systemd/system/multi-user.target.wants/qubes-vm@" + self.name + ".service") == True:
+            retcode = subprocess.call(["sudo", "rm", "/etc/systemd/system/multi-user.target.wants/qubes-vm@" + self.name + ".service"])
+            if retcode != 0:
+                raise QubesException("Failed to delete autostart entry for VM")
+
         self.storage.remove_from_disk()
 
     def write_firewall_conf(self, conf):

--- a/core-modules/000QubesVm.py
+++ b/core-modules/000QubesVm.py
@@ -1412,8 +1412,8 @@ class QubesVm(object):
                     e.get_error_code())
                 raise
 
-        if os.path.exists("/etc/systemd/system/multi-user.target.wants/qubes-vm@" + self.name + ".service") == True:
-            retcode = subprocess.call(["sudo", "rm", "/etc/systemd/system/multi-user.target.wants/qubes-vm@" + self.name + ".service"])
+        if os.path.exists("/etc/systemd/system/multi-user.target.wants/qubes-vm@" + self.name + ".service"):
+            subprocess.call(["sudo", "systemctl", "-q", "disable","qubes-vm@" + self.name + ".service"])
             if retcode != 0:
                 raise QubesException("Failed to delete autostart entry for VM")
 


### PR DESCRIPTION
This patch fixes Issue #1930.
When deleting a VM the autostart Symlink is deleted if it exists.