### PR TITLE
Quoting the destination as proposed in #1672

### DIFF
--- a/qvm-tools/qubes-hcl-report
+++ b/qvm-tools/qubes-hcl-report
@@ -209,7 +209,7 @@ versions:
     FIXLINK
 
 ---
-" >> $HOME/$FILENAME.yml
+" >> "$HOME/$FILENAME.yml"
 
 
 if [[ "$SUPPORT_FILES" == 1 ]]

--- a/qvm-tools/qubes-hcl-report
+++ b/qvm-tools/qubes-hcl-report
@@ -217,7 +217,7 @@ if [[ "$SUPPORT_FILES" == 1 ]]
 
     # cpio
     cd $TEMP_DIR
-    find -print0 |cpio --quiet -o -H crc --null |gzip  >$HOME/$FILENAME.cpio.gz
+    find -print0 | cpio --quiet -o -H crc --null | gzip  > "$HOME/$FILENAME.cpio.gz"
     cd
 fi
 
@@ -225,7 +225,7 @@ fi
 if [[ "$COPY2VM" != "dom0" ]]
  then
     # Copy to VM
-    qvm-start -q $COPY2VM 2>/dev/null
+    qvm-start -q $COPY2VM 2> /dev/null
 
     if [[ -f "$HOME/$FILENAME.cpio.gz" ]]
       then

--- a/qvm-tools/qubes-hcl-report
+++ b/qvm-tools/qubes-hcl-report
@@ -229,12 +229,12 @@ if [[ "$COPY2VM" != "dom0" ]]
 
     if [[ -f "$HOME/$FILENAME.cpio.gz" ]]
       then
-        cat $HOME/$FILENAME.cpio.gz | qvm-run -a -q --pass-io $COPY2VM "cat >/home/user/$FILENAME.cpio.gz"
+        cat "$HOME/$FILENAME.cpio.gz" | qvm-run -a -q --pass-io $COPY2VM "cat >/home/user/$FILENAME.cpio.gz"
     fi
 
     if [[ -f "$HOME/$FILENAME.yml" ]]
       then
-        cat $HOME/$FILENAME.yml | qvm-run -a -q --pass-io $COPY2VM "cat >/home/user/$FILENAME.yml"
+        cat "$HOME/$FILENAME.yml" | qvm-run -a -q --pass-io $COPY2VM "cat >/home/user/$FILENAME.yml"
     fi
 
 fi

--- a/qvm-tools/qubes-hcl-report
+++ b/qvm-tools/qubes-hcl-report
@@ -229,12 +229,12 @@ if [[ "$COPY2VM" != "dom0" ]]
 
     if [[ -f "$HOME/$FILENAME.cpio.gz" ]]
       then
-        cat "$HOME/$FILENAME.cpio.gz" | qvm-run -a -q --pass-io $COPY2VM "cat >/home/user/$FILENAME.cpio.gz"
+        cat "$HOME/$FILENAME.cpio.gz" | qvm-run -a -q --pass-io $COPY2VM "cat > \"/home/user/$FILENAME.cpio.gz\""
     fi
 
     if [[ -f "$HOME/$FILENAME.yml" ]]
       then
-        cat "$HOME/$FILENAME.yml" | qvm-run -a -q --pass-io $COPY2VM "cat >/home/user/$FILENAME.yml"
+        cat "$HOME/$FILENAME.yml" | qvm-run -a -q --pass-io $COPY2VM "cat > \"/home/user/$FILENAME.yml\""
     fi
 
 fi


### PR DESCRIPTION
As pointed in [issue #1672](https://github.com/QubesOS/qubes-issues/issues/1672):

I've got this:

```
/usr/bin/qubes-hcl-report: line 158: $HOME/$FILENAME.yml: ambiguous redirect
```

Fixed by double quoting the 'redirect to' path. I'm sending a pull request.