### PR TITLE
Make qfile-daemon-dvm more flexible

### DIFF
--- a/dispvm/qfile-daemon-dvm
+++ b/dispvm/qfile-daemon-dvm
@@ -171,6 +171,10 @@ class QfileDaemonDvm:
 
 def main():
     exec_index = sys.argv[1]
+    if exec_index == "FINISH":
+        QfileDaemonDvm.finish_disposable(sys.argv[2])
+        return
+
     src_vmname = sys.argv[2]
     user = sys.argv[3]
     # accessed directly by get_dvm()
@@ -183,6 +187,10 @@ def main():
     qfile = QfileDaemonDvm(src_vmname)
     dispvm = qfile.get_dvm()
     if dispvm is not None:
+        if exec_index == "LAUNCH":
+            print dispvm.name
+            return
+
         print >>sys.stderr, "time=%s, starting VM process" % (str(time.time()))
         subprocess.call(['/usr/lib/qubes/qrexec-client', '-d', dispvm.name,
                          user+':exec /usr/lib/qubes/qubes-rpc-multiplexer ' +

--- a/dispvm/qfile-daemon-dvm
+++ b/dispvm/qfile-daemon-dvm
@@ -187,6 +187,6 @@ def main():
         subprocess.call(['/usr/lib/qubes/qrexec-client', '-d', dispvm.name,
                          user+':exec /usr/lib/qubes/qubes-rpc-multiplexer ' +
                          exec_index + " " + src_vmname])
-        qfile.finish_disposable(dispvm.name)
+        QfileDaemonDvm.finish_disposable(dispvm.name)
 
 main()

--- a/dispvm/qfile-daemon-dvm
+++ b/dispvm/qfile-daemon-dvm
@@ -150,7 +150,7 @@ class QfileDaemonDvm:
         return self.do_get_dvm()
 
     @staticmethod
-    def remove_disposable_from_qdb(name):
+    def finish_disposable(name):
         qvm_collection = QubesVmCollection()
         qvm_collection.lock_db_for_writing()
         qvm_collection.load()
@@ -158,6 +158,12 @@ class QfileDaemonDvm:
         if vm is None:
             qvm_collection.unlock_db()
             return False
+
+        try:
+            vm.force_shutdown()
+        except QubesException:
+            # VM already destroyed
+            pass
         qvm_collection.pop(vm.qid)
         qvm_collection.save()
         qvm_collection.unlock_db()
@@ -181,11 +187,6 @@ def main():
         subprocess.call(['/usr/lib/qubes/qrexec-client', '-d', dispvm.name,
                          user+':exec /usr/lib/qubes/qubes-rpc-multiplexer ' +
                          exec_index + " " + src_vmname])
-        try:
-            dispvm.force_shutdown()
-        except QubesException:
-            # VM already destroyed
-            pass
-        qfile.remove_disposable_from_qdb(dispvm.name)
+        qfile.finish_disposable(dispvm.name)
 
 main()


### PR DESCRIPTION
qfile-daemon-dvm currently assumes you want to start a dispVM, run exactly one qrexec service, and tear down the dispVM when that service is done. It also does not tell you the name of the dispVM while it's running.

I often wanted to do something like start a dispVM, run a service, then e.g. attach a block device, then run another service etc. The PR allows this in a minimalistic fashion: If the action is LAUNCH instead of qubes.SomeService, then just start the dispVM, write its name to stdout, and quit. If the action is FINISH, then tear down the named dispVM. (Uppercase words, because you can already use DEFAULT in the username argument to request that the service is run as the default user.)