### PR TITLE
Simplified Storage API

### DIFF
--- a/doc/manpages/qvm-block.rst
+++ b/doc/manpages/qvm-block.rst
@@ -86,6 +86,15 @@ Detach the volume with *POOL_NAME:VOLUME_ID* from domain *VMNAME*
 
 aliases: d, dt
 
+revert
+^^^^^^
+
+| :command:`qvm-block revert` [-h] [--verbose] [--quiet] *POOL_NAME:VOLUME_ID*
+
+Revert a volume to previous revision.
+
+aliases: rv, r
+
 Authors
 -------
 

--- a/doc/manpages/qvm-clone.rst
+++ b/doc/manpages/qvm-clone.rst
@@ -1,30 +1,39 @@
 .. program:: qvm-clone
 
-===========================================================================
 :program:`qvm-clone` -- Clones an existing VM by copying all its disk files
 ===========================================================================
 
 Synopsis
-========
-:command:`qvm-clone` [*options*] <*src-name*> <*new-name*>
+--------
+:command:`qvm-clone` [-h] [--verbose] [--quiet] [-p *POOL:VOLUME* | -P POOL] *VMNAME* *NEWVM*
 
 Options
-=======
+-------
 
 .. option:: --help, -h
 
     Show this help message and exit
 
+.. option:: -P POOL
+
+    Pool to use for the new domain. All volumes besides snapshots volumes are
+    imported in to the specified POOL. ~HIS IS WHAT YOU WANT TO USE NORMALLY.
+
+.. option:: --pool=POOL:VOLUME, -p POOL:VOLUME
+
+    Specify the pool to use for the specific volume
+
 .. option:: --quiet, -q
 
     Be quiet
 
-.. option:: --path=DIR_PATH, -p DIR_PATH
+.. option:: --verbose, -v
 
-    Specify path to the template directory
+    Increase verbosity
 
 Authors
-=======
+-------
 | Joanna Rutkowska <joanna at invisiblethingslab dot com>
 | Rafal Wojtczuk <rafal at invisiblethingslab dot com>
 | Marek Marczykowski <marmarek at invisiblethingslab dot com>
+| Bahtiar `kalkin-` Gadimov <bahtiar at gadimov dot de> 

--- a/doc/manpages/qvm-create.rst
+++ b/doc/manpages/qvm-create.rst
@@ -32,7 +32,7 @@ Options
    The new domain class name (default: **AppVM** for
    :py:class:`qubes.vm.appvm.AppVM`).
 
-.. option:: --prop=NAME=VALUE, --property=NAME=VALUE, -p NAME=VALUE
+.. option:: --prop=NAME=VALUE, --property=NAME=VALUE
 
    Set domain's property, like "internal", "memory" or "vcpus". Any property may
    be set this way, even "qid".
@@ -57,9 +57,14 @@ Options
    Use provided :file:`root.img` instead of default/empty one (file will be
    *moved*). This option is mutually exclusive with :option:`--root-copy-from`.
 
-.. option:: --pool=POOL_NAME:VOLUME_NAME, -P POOL_NAME:VOLUME_NAME
+.. option:: -P POOL
 
-    Specify the pool to use for a volume
+    Pool to use for the new domain. All volumes besides snapshots volumes are
+    imported in to the specified POOL. ~HIS IS WHAT YOU WANT TO USE NORMALLY.
+
+.. option:: --pool=POOL:VOLUME, -p POOL:VOLUME
+
+    Specify the pool to use for the specific volume
 
 Options for internal use
 ------------------------

--- a/qubes/__init__.py
+++ b/qubes/__init__.py
@@ -32,22 +32,12 @@ Qubes OS
 
 from __future__ import absolute_import
 
+import __builtin__
 import collections
-import errno
-import grp
-import logging
 import os
 import os.path
-import sys
-import tempfile
-import time
 
-import __builtin__
-
-import jinja2
 import lxml.etree
-import pkg_resources
-
 import qubes.config
 import qubes.events
 import qubes.exc
@@ -439,7 +429,7 @@ class PropertyHolder(qubes.events.Emitter):
         propvalues = {}
 
         all_names = set(prop.__name__ for prop in self.property_list())
-        for key in list(kwargs.keys()):
+        for key in list(kwargs):
             if not key in all_names:
                 continue
             propvalues[key] = kwargs.pop(key)

--- a/qubes/app.py
+++ b/qubes/app.py
@@ -36,13 +36,14 @@ import tempfile
 import time
 import uuid
 
-import jinja2
 import lxml.etree
+
+import jinja2
 import libvirt
 
 try:
-    import xen.lowlevel.xs
-    import xen.lowlevel.xc
+    import xen.lowlevel.xs  # pylint: disable=wrong-import-order
+    import xen.lowlevel.xc  # pylint: disable=wrong-import-order
 except ImportError:
     pass
 
@@ -58,12 +59,12 @@ else:
     raise RuntimeError("Qubes works only on POSIX or WinNT systems")
 
 
-import qubes
-import qubes.ext
-import qubes.utils
-import qubes.vm.adminvm
-import qubes.vm.qubesvm
-import qubes.vm.templatevm
+import qubes  # pylint: disable=wrong-import-position
+import qubes.ext  # pylint: disable=wrong-import-position
+import qubes.utils  # pylint: disable=wrong-import-position
+import qubes.vm.adminvm  # pylint: disable=wrong-import-position
+import qubes.vm.qubesvm  # pylint: disable=wrong-import-position
+import qubes.vm.templatevm  # pylint: disable=wrong-import-position
 
 
 class VirDomainWrapper(object):

--- a/qubes/app.py
+++ b/qubes/app.py
@@ -415,7 +415,6 @@ class VMCollection(object):
 
         return value
 
-
     def __getitem__(self, key):
         if isinstance(key, int):
             return self._dict[key]
@@ -858,7 +857,6 @@ class Qubes(qubes.PropertyHolder):
                 'no such VM class: {!r}'.format(clsname))
         # don't catch TypeError
 
-
     def add_new_vm(self, cls, qid=None, **kwargs):
         '''Add new Virtual Machine to colletion
 
@@ -871,9 +869,10 @@ class Qubes(qubes.PropertyHolder):
         # override it with default template)
         if 'template' not in kwargs and hasattr(cls, 'template'):
             kwargs['template'] = self.default_template
+        elif 'template' in kwargs and isinstance(kwargs['template'], str):
+            kwargs['template'] = self.domains[kwargs['template']]
 
         return self.domains.add(cls(self, None, qid=qid, **kwargs))
-
 
     def get_label(self, label):
         '''Get label as identified by index or name

--- a/qubes/backup.py
+++ b/qubes/backup.py
@@ -2178,7 +2178,7 @@ class BackupRestore(object):
                         vm.features['backup-path']),
                         new_vm.dir_path)
 
-                new_vm.verify_files()
+                new_vm.storage.verify()
             except Exception as err:
                 self.log.error("ERROR: {0}".format(err))
                 self.log.warning("*** Skipping VM: {0}".format(vm.name))

--- a/qubes/backup.py
+++ b/qubes/backup.py
@@ -343,7 +343,7 @@ class Backup(object):
             # TODO this is file pool specific. Change it to a more general
             # solution
             if vm.volumes['private'] is not None:
-                path_to_private_img = vm.volumes['private'].vid
+                path_to_private_img = vm.volumes['private'].path
                 vm_files.append(self.FileToBackup(path_to_private_img, subdir))
 
             vm_files.append(self.FileToBackup(vm.icon_path, subdir))
@@ -358,7 +358,7 @@ class Backup(object):
             if vm.updateable:
                 # TODO this is file pool specific. Change it to a more general
                 # solution
-                path_to_root_img = vm.volumes['root'].vid
+                path_to_root_img = vm.volumes['root'].path
                 vm_files.append(self.FileToBackup(path_to_root_img, subdir))
             files_to_backup[vm.qid] = self.VMToBackup(vm, vm_files, subdir)
 
@@ -1725,11 +1725,10 @@ class BackupRestore(object):
             # wait for other processes (if any)
             for proc in self.processes_to_kill_on_cancel:
                 proc.wait()
-
-            if vmproc.returncode != 0:
-                raise qubes.exc.QubesException(
-                    "Backup completed, but VM receiving it reported an error "
-                    "(exit code {})".format(vmproc.returncode))
+                if proc.returncode != 0:
+                    raise qubes.exc.QubesException(
+                        "Backup completed, but VM receiving it reported an error "
+                        "(exit code {})".format(proc.returncode))
 
             if filename and filename != "EOF":
                 raise qubes.exc.QubesException(

--- a/qubes/ext/qubesmanager.py
+++ b/qubes/ext/qubesmanager.py
@@ -29,8 +29,8 @@
 .. warning:: API defined here is not declared stable.
 '''
 
-import qubes.ext
 import dbus
+import qubes.ext
 
 
 class QubesManager(qubes.ext.Extension):

--- a/qubes/storage/__init__.py
+++ b/qubes/storage/__init__.py
@@ -30,6 +30,8 @@ from __future__ import absolute_import
 import os
 import os.path
 import string  # pylint: disable=deprecated-module
+import time
+from datetime import datetime
 
 import lxml.etree
 import pkg_resources
@@ -520,3 +522,8 @@ def pool_drivers():
     """ Return a list of EntryPoints names """
     return [ep.name
             for ep in pkg_resources.iter_entry_points(STORAGE_ENTRY_POINT)]
+
+
+def isodate(seconds=time.time()):
+    ''' Helper method which returns an iso date '''
+    return datetime.utcfromtimestamp(seconds).isoformat("T")

--- a/qubes/storage/domain.py
+++ b/qubes/storage/domain.py
@@ -21,7 +21,7 @@
 #
 ''' Manages block devices in a domain '''
 
-import string
+import string  # pylint: disable=deprecated-module
 
 from qubes.storage import Pool, Volume
 
@@ -99,15 +99,12 @@ class DomainPool(Pool):
 class DomainVolume(Volume):
     ''' A volume provided by a block device in an domain '''
 
-    def __init__(self, name, pool, desc, mode, size):
-        if mode == 'w':
-            volume_type = 'read-write'
-        else:
-            volume_type = 'read-only'
+    def __init__(self, name, pool, desc, mode, **kwargs):
+        rw = (mode == 'w')
 
-        super(DomainVolume, self).__init__(desc,
-                                           pool,
-                                           volume_type,
-                                           vid=name,
-                                           size=size,
-                                           removable=True)
+        super(DomainVolume, self).__init__(desc, pool, vid=name, removable=True,
+                                           rw=rw, **kwargs)
+
+    @property
+    def revisions(self):
+        return {}

--- a/qubes/tests/__init__.py
+++ b/qubes/tests/__init__.py
@@ -820,7 +820,7 @@ class BackupTestsMixin(SystemTestsMixin):
             name=vmname, template=template, provides_network=True, label='red')
         testnet.create_on_disk()
         vms.append(testnet)
-        self.fill_image(testnet.volumes['private'].vid, 20*1024*1024)
+        self.fill_image(testnet.volumes['private'].path, 20*1024*1024)
 
         vmname = self.make_vm_name('test1')
         if self.verbose:
@@ -831,7 +831,7 @@ class BackupTestsMixin(SystemTestsMixin):
         testvm1.netvm = testnet
         testvm1.create_on_disk()
         vms.append(testvm1)
-        self.fill_image(testvm1.volumes['private'].vid, 100*1024*1024)
+        self.fill_image(testvm1.volumes['private'].path, 100*1024*1024)
 
         vmname = self.make_vm_name('testhvm1')
         if self.verbose:
@@ -841,7 +841,7 @@ class BackupTestsMixin(SystemTestsMixin):
                                       hvm=True,
                                       label='red')
         testvm2.create_on_disk()
-        self.fill_image(testvm2.volumes['root'].vid, 1024 * 1024 * 1024, True)
+        self.fill_image(testvm2.volumes['root'].path, 1024 * 1024 * 1024, True)
         vms.append(testvm2)
 
         vmname = self.make_vm_name('template')
@@ -850,7 +850,7 @@ class BackupTestsMixin(SystemTestsMixin):
         testvm3 = self.app.add_new_vm(qubes.vm.templatevm.TemplateVM,
             name=vmname, label='red')
         testvm3.create_on_disk()
-        self.fill_image(testvm3.root_img, 100*1024*1024, True)
+        self.fill_image(testvm3.volumes['root'].path, 100 * 1024 * 1024, True)
         vms.append(testvm3)
 
         vmname = self.make_vm_name('custom')

--- a/qubes/tests/int/backup.py
+++ b/qubes/tests/int/backup.py
@@ -26,7 +26,6 @@
 
 import os
 
-import unittest
 import sys
 import qubes
 import qubes.exc
@@ -77,10 +76,13 @@ class TC_00_Backup(qubes.tests.BackupTestsMixin, qubes.tests.QubesTestCase):
         hvmtemplate = self.app.add_new_vm(
             qubes.vm.templatevm.TemplateVM, name=vmname, hvm=True, label='red')
         hvmtemplate.create_on_disk()
-        self.fill_image(os.path.join(hvmtemplate.dir_path, '00file'),
-                        195*1024*1024-4096*3)
-        self.fill_image(hvmtemplate.private_img, 195*1024*1024-4096*3)
-        self.fill_image(hvmtemplate.root_img, 1024*1024*1024, sparse=True)
+        self.fill_image(
+            os.path.join(hvmtemplate.dir_path, '00file'),
+            195 * 1024 * 1024 - 4096 * 3)
+        self.fill_image(hvmtemplate.volumes['private'].path,
+                        195 * 1024 * 1024 - 4096 * 3)
+        self.fill_image(hvmtemplate.volumes['root'].path, 1024 * 1024 * 1024,
+                        sparse=True)
         vms.append(hvmtemplate)
         self.app.save()
 
@@ -93,7 +95,7 @@ class TC_00_Backup(qubes.tests.BackupTestsMixin, qubes.tests.QubesTestCase):
 
     def test_005_compressed_custom(self):
         vms = self.create_backup_vms()
-        self.make_backup(vms, compressed="bzip2")
+        self.make_backup(vms, compression_filter="bzip2")
         self.remove_vms(reversed(vms))
         self.restore_backup()
         for vm in vms:

--- a/qubes/tests/storage.py
+++ b/qubes/tests/storage.py
@@ -20,19 +20,16 @@ import qubes.log
 from qubes.exc import QubesException
 from qubes.storage import pool_drivers
 from qubes.storage.file import FilePool
-from qubes.tests import QubesTestCase, SystemTestsMixin
+from qubes.tests import QubesTestCase
 
 # :pylint: disable=invalid-name
-
-
-class TestApp(qubes.tests.TestEmitter):
-    pass
 
 
 class TestVM(object):
     def __init__(self, test, template=None):
         self.app = test.app
         self.name = test.make_vm_name('appvm')
+        self.dir_path = '/var/lib/qubes/appvms/' + self.name
         self.log = qubes.log.get_vm_logger(self.name)
 
         if template:
@@ -50,6 +47,10 @@ class TestVM(object):
 class TestTemplateVM(TestVM):
     dir_path_prefix = qubes.config.system_path['qubes_templates_dir']
 
+    def __init__(self, test, template=None):
+        super(TestTemplateVM, self).__init__(test, template)
+        self.dir_path = '/var/lib/qubes/vm-templates/' + self.name
+
     def is_template(self):
         return True
 
@@ -59,7 +60,7 @@ class TestDisposableVM(TestVM):
         return True
 
 class TestApp(qubes.Qubes):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):  # pylint: disable=unused-argument
         super(TestApp, self).__init__('/tmp/qubes-test.xml',
             load=False, offline_mode=True, **kwargs)
         self.load_initial_values()

--- a/qubes/tests/storage_file.py
+++ b/qubes/tests/storage_file.py
@@ -16,29 +16,27 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+''' Tests for the file storage backend '''
+
 import os
 import shutil
 
 import qubes.storage
 import qubes.tests.storage
-import unittest
 from qubes.config import defaults
-from qubes.storage import Storage
-from qubes.storage.file import (OriginFile, ReadOnlyFile, ReadWriteFile,
-                                SnapshotFile, VolatileFile)
-from qubes.tests import QubesTestCase, SystemTestsMixin
-from qubes.tests.storage import TestVM
 
 # :pylint: disable=invalid-name
 
+
 class TestApp(qubes.Qubes):
-    def __init__(self, *args, **kwargs):
-        super(TestApp, self).__init__('/tmp/qubes-test.xml',
-            load=False, offline_mode=True, **kwargs)
+    ''' A Mock App object '''
+    def __init__(self, *args, **kwargs):  # pylint: disable=unused-argument
+        super(TestApp, self).__init__('/tmp/qubes-test.xml', load=False,
+                                      offline_mode=True, **kwargs)
         self.load_initial_values()
         self.pools['linux-kernel'].dir_path = '/tmp/qubes-test-kernel'
-        dummy_kernel = os.path.join(
-            self.pools['linux-kernel'].dir_path, 'dummy')
+        dummy_kernel = os.path.join(self.pools['linux-kernel'].dir_path,
+                                    'dummy')
         os.makedirs(dummy_kernel)
         open(os.path.join(dummy_kernel, 'vmlinuz'), 'w').close()
         open(os.path.join(dummy_kernel, 'modules.img'), 'w').close()
@@ -46,16 +44,23 @@ class TestApp(qubes.Qubes):
         self.default_kernel = 'dummy'
 
     def cleanup(self):
+        ''' Remove temporary directories '''
         shutil.rmtree(self.pools['linux-kernel'].dir_path)
 
     def create_dummy_template(self):
-        self.add_new_vm(qubes.vm.templatevm.TemplateVM,
-            name='test-template', label='red',
-            memory=1024, maxmem=1024)
-        self.default_template = 'test-template'
+        ''' Initalizes a dummy TemplateVM as the `default_template` '''
+        template = self.add_new_vm(qubes.vm.templatevm.TemplateVM,
+                                   name='test-template', label='red',
+                                   memory=1024, maxmem=1024)
+        self.default_template = template
 
-class TC_00_FilePool(QubesTestCase):
-    """ This class tests some properties of the 'default' pool. """
+
+class TC_00_FilePool(qubes.tests.QubesTestCase):
+    """ This class tests some properties of the 'default' pool.
+
+        This test might become obsolete if we change the driver for the default
+        pool to something else as 'file'.
+    """
 
     def setUp(self):
         super(TC_00_FilePool, self).setUp()
@@ -76,21 +81,23 @@ class TC_00_FilePool(QubesTestCase):
         self.assertEquals(result, expected)
 
     def test001_default_storage_class(self):
-        """ Check when using default pool the Storage is ``Storage``. """
+        """ Check when using default pool the Storage is
+            ``qubes.storage.Storage``. """
         result = self._init_app_vm().storage
-        self.assertIsInstance(result, Storage)
+        self.assertIsInstance(result, qubes.storage.Storage)
 
     def _init_app_vm(self):
         """ Return initalised, but not created, AppVm. """
         vmname = self.make_vm_name('appvm')
         self.app.create_dummy_template()
-        return self.app.add_new_vm(qubes.vm.appvm.AppVM,
-                                   name=vmname,
+        return self.app.add_new_vm(qubes.vm.appvm.AppVM, name=vmname,
                                    template=self.app.default_template,
                                    label='red')
 
 
-class TC_01_FileVolumes(QubesTestCase):
+class TC_01_FileVolumes(qubes.tests.QubesTestCase):
+    ''' Test correct handling of different types of volumes '''
+
     POOL_DIR = '/tmp/test-pool'
     POOL_NAME = 'test-pool'
     POOL_CONF = {'driver': 'file', 'dir_path': POOL_DIR, 'name': POOL_NAME}
@@ -113,91 +120,99 @@ class TC_01_FileVolumes(QubesTestCase):
         config = {
             'name': 'root',
             'pool': self.POOL_NAME,
-            'volume_type': 'origin',
+            'save_on_stop': True,
+            'rw': True,
             'size': defaults['root_img_size'],
         }
-        vm = TestVM(self)
-        result = self.app.get_pool(self.POOL_NAME).init_volume(vm, config)
-        self.assertIsInstance(result, OriginFile)
-        self.assertEqual(result.name, 'root')
-        self.assertEqual(result.pool, self.POOL_NAME)
-        self.assertEqual(result.size, defaults['root_img_size'])
+        vm = qubes.tests.storage.TestVM(self)
+        volume = self.app.get_pool(self.POOL_NAME).init_volume(vm, config)
+        self.assertEqual(volume.name, 'root')
+        self.assertEqual(volume.pool, self.POOL_NAME)
+        self.assertEqual(volume.size, defaults['root_img_size'])
+        self.assertFalse(volume.snap_on_start)
+        self.assertTrue(volume.save_on_stop)
+        self.assertTrue(volume.rw)
 
     def test_001_snapshot_volume(self):
-        original_path = '/var/lib/qubes/vm-templates/fedora-23/root.img'
+        source = 'vm-templates/fedora-23/root'
         original_size = qubes.config.defaults['root_img_size']
         config = {
             'name': 'root',
             'pool': 'default',
-            'volume_type': 'snapshot',
-            'vid': original_path,
+            'snap_on_start': True,
+            'rw': False,
+            'source': source,
+            'size': original_size,
         }
-        vm = TestVM(self, template=self.app.default_template)
-        result = self.app.get_pool(self.POOL_NAME).init_volume(vm, config)
-        self.assertIsInstance(result, SnapshotFile)
-        self.assertEqual(result.name, 'root')
-        self.assertEqual(result.pool, 'default')
-        self.assertEqual(result.size, original_size)
+
+        template_vm = self.app.default_template
+        vm = qubes.tests.storage.TestVM(self, template=template_vm)
+        volume = self.app.get_pool(self.POOL_NAME).init_volume(vm, config)
+        self.assertEqual(volume.name, 'root')
+        self.assertEqual(volume.pool, 'default')
+        self.assertEqual(volume.size, original_size)
+        self.assertTrue(volume.snap_on_start)
+        self.assertTrue(volume.snap_on_start)
+        self.assertFalse(volume.save_on_stop)
+        self.assertFalse(volume.rw)
+        self.assertEqual(volume.usage, 0)
 
     def test_002_read_write_volume(self):
         config = {
             'name': 'root',
             'pool': self.POOL_NAME,
-            'volume_type': 'read-write',
+            'rw': True,
+            'save_on_stop': True,
             'size': defaults['root_img_size'],
         }
-        vm = TestVM(self)
-        result = self.app.get_pool(self.POOL_NAME).init_volume(vm, config)
-        self.assertIsInstance(result, ReadWriteFile)
-        self.assertEqual(result.name, 'root')
-        self.assertEqual(result.pool, self.POOL_NAME)
-        self.assertEqual(result.size, defaults['root_img_size'])
+        vm = qubes.tests.storage.TestVM(self)
+        volume = self.app.get_pool(self.POOL_NAME).init_volume(vm, config)
+        self.assertEqual(volume.name, 'root')
+        self.assertEqual(volume.pool, self.POOL_NAME)
+        self.assertEqual(volume.size, defaults['root_img_size'])
+        self.assertFalse(volume.snap_on_start)
+        self.assertTrue(volume.save_on_stop)
+        self.assertTrue(volume.rw)
 
-    @unittest.expectedFailure
-    def test_003_read_volume(self):
+    def test_003_read_only_volume(self):
         template = self.app.default_template
-        original_path = template.volumes['root'].vid
-        original_size = qubes.config.defaults['root_img_size']
-        config = {
-            'name': 'root',
-            'pool': 'default',
-            'volume_type': 'read-only',
-            'vid': original_path
-        }
-        vm = TestVM(self, template=template)
+        vid = template.volumes['root'].vid
+        config = {'name': 'root', 'pool': 'default', 'rw': False, 'vid': vid}
+        vm = qubes.tests.storage.TestVM(self, template=template)
 
-        result = self.app.get_pool(self.POOL_NAME).init_volume(vm, config)
-        self.assertIsInstance(result, ReadOnlyFile)
-        self.assertEqual(result.name, 'root')
-        self.assertEqual(result.pool, 'default')
-        self.assertEqual(result.size, original_size)
+        volume = self.app.get_pool(self.POOL_NAME).init_volume(vm, config)
+        self.assertEqual(volume.name, 'root')
+        self.assertEqual(volume.pool, 'default')
+
+        # original_size = qubes.config.defaults['root_img_size']
+        # FIXME: self.assertEqual(volume.size, original_size)
+        self.assertFalse(volume.snap_on_start)
+        self.assertFalse(volume.save_on_stop)
+        self.assertFalse(volume.rw)
 
     def test_004_volatile_volume(self):
         config = {
             'name': 'root',
             'pool': self.POOL_NAME,
-            'volume_type': 'volatile',
             'size': defaults['root_img_size'],
+            'rw': True,
         }
-        vm = TestVM(self)
-        result = self.app.get_pool(self.POOL_NAME).init_volume(vm, config)
-        self.assertIsInstance(result, VolatileFile)
-        self.assertEqual(result.name, 'root')
-        self.assertEqual(result.pool, self.POOL_NAME)
-        self.assertEqual(result.size, defaults['root_img_size'])
+        vm = qubes.tests.storage.TestVM(self)
+        volume = self.app.get_pool(self.POOL_NAME).init_volume(vm, config)
+        self.assertEqual(volume.name, 'root')
+        self.assertEqual(volume.pool, self.POOL_NAME)
+        self.assertEqual(volume.size, defaults['root_img_size'])
+        self.assertFalse(volume.snap_on_start)
+        self.assertFalse(volume.save_on_stop)
+        self.assertTrue(volume.rw)
 
     def test_005_appvm_volumes(self):
         ''' Check if AppVM volumes are propertly initialized '''
         vmname = self.make_vm_name('appvm')
-        vm = self.app.add_new_vm(qubes.vm.appvm.AppVM,
-                                 name=vmname,
+        vm = self.app.add_new_vm(qubes.vm.appvm.AppVM, name=vmname,
                                  template=self.app.default_template,
                                  label='red')
 
-        volumes = vm.volumes
-        self.assertIsInstance(volumes['root'], SnapshotFile)
-        self.assertIsInstance(volumes['private'], OriginFile)
-        self.assertIsInstance(volumes['volatile'], VolatileFile)
         expected = vm.template.dir_path + '/root.img:' + vm.template.dir_path \
             + '/root-cow.img'
         self.assertVolumePath(vm, 'root', expected, rw=False)
@@ -210,14 +225,9 @@ class TC_01_FileVolumes(QubesTestCase):
     def test_006_template_volumes(self):
         ''' Check if TemplateVM volumes are propertly initialized '''
         vmname = self.make_vm_name('appvm')
-        vm = self.app.add_new_vm(qubes.vm.templatevm.TemplateVM,
-                                 name=vmname,
+        vm = self.app.add_new_vm(qubes.vm.templatevm.TemplateVM, name=vmname,
                                  label='red')
 
-        volumes = vm.volumes
-        self.assertIsInstance(volumes['root'], OriginFile)
-        self.assertIsInstance(volumes['private'], ReadWriteFile)
-        self.assertIsInstance(volumes['volatile'], VolatileFile)
         expected = vm.dir_path + '/root.img:' + vm.dir_path + '/root-cow.img'
         self.assertVolumePath(vm, 'root', expected, rw=True)
         expected = vm.dir_path + '/private.img'
@@ -233,7 +243,7 @@ class TC_01_FileVolumes(QubesTestCase):
         self.assertEquals(b_dev.path, expected)
 
 
-class TC_03_FilePool(QubesTestCase):
+class TC_03_FilePool(qubes.tests.QubesTestCase):
     """ Test the paths for the default file based pool (``FilePool``).
     """
 
@@ -263,7 +273,6 @@ class TC_03_FilePool(QubesTestCase):
             shutil.rmtree('/tmp/qubes-test')
         qubes.config.system_path['qubes_base_dir'] = self._orig_qubes_base_dir
 
-
     def test_001_pool_exists(self):
         """ Check if the storage pool was added to the storage pool config """
         self.assertIn('test-pool', self.app.pools.keys())
@@ -290,8 +299,7 @@ class TC_03_FilePool(QubesTestCase):
         """ Check if all the needed image files are created for an AppVm"""
 
         vmname = self.make_vm_name('appvm')
-        vm = self.app.add_new_vm(qubes.vm.appvm.AppVM,
-                                 name=vmname,
+        vm = self.app.add_new_vm(qubes.vm.appvm.AppVM, name=vmname,
                                  template=self.app.default_template,
                                  volume_config={
                                      'private': {
@@ -300,25 +308,17 @@ class TC_03_FilePool(QubesTestCase):
                                      'volatile': {
                                          'pool': 'test-pool'
                                      }
-                                 },
-                                 label='red')
-        vm.storage.create()
+                                 }, label='red')
+        vm.create_on_disk()
 
         expected_vmdir = os.path.join(self.APPVMS_DIR, vm.name)
 
-        expected_private_origin_path = \
-            os.path.join(expected_vmdir, 'private.img')
-        expected_private_cow_path = \
-            os.path.join(expected_vmdir, 'private-cow.img')
-        expected_private_path = '%s:%s' % (expected_private_origin_path,
-                                        expected_private_cow_path)
+        expected_private_path = os.path.join(expected_vmdir, 'private.img')
         self.assertEquals(vm.volumes['private'].path, expected_private_path)
-        self.assertEqualsAndExists(vm.volumes['private'].path_origin,
-            expected_private_origin_path)
-        self.assertEqualsAndExists(vm.volumes['private'].path_cow,
-            expected_private_cow_path)
 
         expected_volatile_path = os.path.join(expected_vmdir, 'volatile.img')
+        vm.storage.get_pool(vm.volumes['volatile'])\
+            .reset(vm.volumes['volatile'])
         self.assertEqualsAndExists(vm.volumes['volatile'].path,
                                    expected_volatile_path)
 
@@ -327,8 +327,7 @@ class TC_03_FilePool(QubesTestCase):
             created propertly by the storage system
         """
         vmname = self.make_vm_name('tmvm')
-        vm = self.app.add_new_vm(qubes.vm.templatevm.TemplateVM,
-                                 name=vmname,
+        vm = self.app.add_new_vm(qubes.vm.templatevm.TemplateVM, name=vmname,
                                  volume_config={
                                      'root': {
                                          'pool': 'test-pool'
@@ -339,8 +338,7 @@ class TC_03_FilePool(QubesTestCase):
                                      'volatile': {
                                          'pool': 'test-pool'
                                      }
-                                 },
-                                 label='red')
+                                 }, label='red')
         vm.create_on_disk()
 
         expected_vmdir = os.path.join(self.TEMPLATES_DIR, vm.name)
@@ -349,18 +347,14 @@ class TC_03_FilePool(QubesTestCase):
         expected_root_cow_path = os.path.join(expected_vmdir, 'root-cow.img')
         expected_root_path = '%s:%s' % (expected_root_origin_path,
                                         expected_root_cow_path)
-        self.assertEquals(vm.volumes['root'].path, expected_root_path)
-        self.assertExist(vm.volumes['root'].path_origin)
+        self.assertEquals(vm.volumes['root'].block_device().path,
+                          expected_root_path)
+        self.assertExist(vm.volumes['root'].path)
 
         expected_private_path = os.path.join(expected_vmdir, 'private.img')
         self.assertEqualsAndExists(vm.volumes['private'].path,
                                    expected_private_path)
 
-        expected_volatile_path = os.path.join(expected_vmdir, 'volatile.img')
-        self.assertEqualsAndExists(vm.volumes['volatile'].path,
-                                   expected_volatile_path)
-
-        vm.storage.commit_template_changes()
         expected_rootcow_path = os.path.join(expected_vmdir, 'root-cow.img')
         self.assertEqualsAndExists(vm.volumes['root'].path_cow,
                                    expected_rootcow_path)
@@ -377,4 +371,5 @@ class TC_03_FilePool(QubesTestCase):
     def assertExist(self, path):
         """ Assert that the given path exists. """
         # :pylint: disable=invalid-name
-        self.assertTrue(os.path.exists(path), "Path %s does not exist" % path)
+        self.assertTrue(
+            os.path.exists(path), "Path {!s} does not exist".format(path))

--- a/qubes/tools/qvm_block.py
+++ b/qubes/tools/qvm_block.py
@@ -45,19 +45,20 @@ def prepare_table(vd_list, full=False):
     '''
     output = []
     if sys.stdout.isatty():
-        output += [('POOL_NAME:VOLUME_ID', 'VOLUME_TYPE', 'VMNAME')]
+        output += [('POOL:VOLUME', 'VMNAME', 'VOLUME_NAME')]  # NOQA
 
     for volume in vd_list:
         if volume.domains:
-            vmname = volume.domains.pop()
-            output += [(str(volume), volume.volume_type, vmname)]
-            for vmname in volume.domains:
+            vmname, volume_name = volume.domains.pop()
+            output += [(str(volume), vmname, volume_name)]
+            for tupple in volume.domains:
+                vmname, volume_name = tupple
                 if full or not sys.stdout.isatty():
-                    output += [(str(volume), volume.volume_type, vmname)]
+                    output += [(str(volume), vmname, volume_name)]
                 else:
-                    output += [('', '', vmname)]
+                    output += [('', vmname, volume_name)]
         else:
-            output += [(str(volume), volume.volume_type)]
+            output += [(str(volume), "")]
 
     return output
 
@@ -70,7 +71,6 @@ class VolumeData(object):
     def __init__(self, volume):
         self.name = volume.name
         self.pool = volume.pool
-        self.volume_type = volume.volume_type
         self.vid = volume.vid
         self.domains = []
 

--- a/qubes/tools/qvm_block.py
+++ b/qubes/tools/qvm_block.py
@@ -50,13 +50,14 @@ def prepare_table(vd_list, full=False):
     for volume in vd_list:
         if volume.domains:
             vmname, volume_name = volume.domains.pop()
-            output += [(str(volume), vmname, volume_name)]
+            output += [(str(volume), vmname, volume_name, volume.revisions)]
             for tupple in volume.domains:
                 vmname, volume_name = tupple
                 if full or not sys.stdout.isatty():
-                    output += [(str(volume), vmname, volume_name)]
+                    output += [(str(volume), vmname, volume_name,
+                            volume.revisions)]
                 else:
-                    output += [('', vmname, volume_name)]
+                    output += [('', vmname, volume_name, '', volume.revisions)]
         else:
             output += [(str(volume), "")]
 
@@ -72,6 +73,10 @@ class VolumeData(object):
         self.name = volume.name
         self.pool = volume.pool
         self.vid = volume.vid
+        if volume.revisions != {}:
+            self.revisions = 'Yes'
+        else:
+            self.revisions = 'No'
         self.domains = []
 
     def __str__(self):
@@ -110,7 +115,7 @@ def list_volumes(args):
             for volume in domain.attached_volumes:
                 try:
                     volume_data = vd_dict[volume.pool][volume.vid]
-                    volume_data.domains += [domain.name]
+                    volume_data.domains += [(domain.name, volume.name)]
                 except KeyError:
                     # Skipping volume
                     continue

--- a/qubes/tools/qvm_block.py
+++ b/qubes/tools/qvm_block.py
@@ -131,6 +131,15 @@ def list_volumes(args):
         result = [x for p in vd_dict.itervalues() for x in p.itervalues()]
     qubes.tools.print_table(prepare_table(result, full=args.full))
 
+def revert_volume(args):
+    volume = args.volume
+    app = args.app
+    try:
+        pool = app.pools[volume.pool]
+        pool.revert(volume)
+    except qubes.storage.StoragePoolException as e:
+        print(e.message, file=sys.stderr)
+        sys.exit(1)
 
 def attach_volumes(args):
     ''' Called by the parser to execute the :program:`qvm-block attach`
@@ -178,6 +187,14 @@ def init_list_parser(sub_parsers):
     list_parser._mutually_exclusive_groups.append(vm_name_group)
     list_parser.set_defaults(func=list_volumes)
 
+def init_revert_parser(sub_parsers):
+    revert_parser = sub_parsers.add_parser(
+        'revert', aliases=('rv', 'r'),
+        help='revert volume to previous revision')
+    revert_parser.add_argument(metavar='POOL_NAME:VOLUME_ID', dest='volume',
+                               action=qubes.tools.VolumeAction)
+    revert_parser.set_defaults(func=revert_volume)
+
 
 def get_parser():
     '''Create :py:class:`argparse.ArgumentParser` suitable for
@@ -190,6 +207,7 @@ def get_parser():
         description="For more information see qvm-block command -h",
         dest='command')
     init_list_parser(sub_parsers)
+    init_revert_parser(sub_parsers)
     attach_parser = sub_parsers.add_parser(
         'attach', help="Attach volume to domain", aliases=('at', 'a'))
     attach_parser.add_argument('--ro', help='attach device read-only',

--- a/qubes/tools/qvm_clone.py
+++ b/qubes/tools/qvm_clone.py
@@ -1,0 +1,73 @@
+#!/usr/bin/python2
+# -*- encoding: utf8 -*-
+#
+# The Qubes OS Project, http://www.qubes-os.org
+#
+# Copyright (C) 2016 Bahtiar `kalkin-` Gadimov <bahtiar@gadimov.de>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+''' Clone a domain '''
+
+import sys
+
+from qubes.tools import QubesArgumentParser, SinglePropertyAction
+
+parser = QubesArgumentParser(description=__doc__, vmname_nargs=1)
+parser.add_argument('new_name',
+                    metavar='NEWVM',
+                    action=SinglePropertyAction,
+                    help='name of the domain to create')
+
+group = parser.add_mutually_exclusive_group()
+group.add_argument('-P',
+                    metavar='POOL',
+                    dest='one_pool',
+                    default='',
+                    help='pool to use for the new domain')
+
+group.add_argument('-p',
+                    '--pool',
+                    action='append',
+                    metavar='POOL:VOLUME',
+                    help='specify the pool to use for the specific volume')
+
+
+def main(args=None):
+    ''' Clones an existing VM by copying all its disk files '''
+    args = parser.parse_args(args)
+    app = args.app
+    src_vm = args.domains[0]
+    new_name = args.properties['new_name']
+    dst_vm = app.add_new_vm(src_vm.__class__, name=new_name)
+    dst_vm.clone_properties(src_vm)
+
+    if args.one_pool:
+        dst_vm.clone_disk_files(src_vm, pool=args.one_pool)
+    elif hasattr(args, 'pools') and args.pools:
+        dst_vm.clone_disk_files(src_vm, pools=args.pools)
+    else:
+        dst_vm.clone_disk_files(src_vm)
+
+#   try:
+    app.save()  # HACK remove_from_disk on exception hangs for some reason
+#   except Exception as e:  # pylint: disable=broad-except
+#       dst_vm.remove_from_disk()
+#       parser.print_error(e)
+#   return 0
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/qubes/utils.py
+++ b/qubes/utils.py
@@ -29,11 +29,11 @@ import os
 import re
 import subprocess
 
+import pkg_resources
+
 import docutils
 import docutils.core
 import docutils.io
-import pkg_resources
-
 import qubes.exc
 
 
@@ -158,5 +158,3 @@ def get_entry_point_one(group, name):
                 ', '.join('{}.{}'.format(ep.module_name, '.'.join(ep.attrs))
                     for ep in epoints)))
     return epoints[0].load()
-
-

--- a/qubes/vm/dispvm.py
+++ b/qubes/vm/dispvm.py
@@ -46,24 +46,32 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
             'root': {
                 'name': 'root',
                 'pool': 'default',
-                'volume_type': 'snapshot',
+                'snap_on_start': True,
+                'save_on_stop': False,
+                'rw': False,
+                'internal': True
             },
             'private': {
                 'name': 'private',
                 'pool': 'default',
-                'volume_type': 'snapshot',
+                'snap_on_start': True,
+                'save_on_stop': False,
+                'internal': True,
+                'rw': True,
             },
             'volatile': {
                 'name': 'volatile',
                 'pool': 'default',
-                'volume_type': 'volatile',
+                'internal': True,
                 'size': qubes.config.defaults['root_img_size'] +
                         qubes.config.defaults['private_img_size'],
             },
             'kernel': {
                 'name': 'kernel',
                 'pool': 'linux-kernel',
-                'volume_type': 'read-only',
+                'snap_on_start': True,
+                'rw': False,
+                'internal': True
             }
         }
 

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -1099,7 +1099,11 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
         :param qubes.vm.qubesvm.QubesVM src: source VM
         '''
 
-        if not self.is_halted():
+        # If the current vm name is not a part of `self.app.domains.keys()`,
+        # then the current vm is in creation process. Calling
+        # `self.is_halted()` at this point, would instantiate libvirt, we want
+        # avoid that.
+        if self.name in self.app.domains.keys() and not self.is_halted():
             raise qubes.exc.QubesVMNotHaltedError(
                 self, 'Cannot clone a running domain {!r}'.format(self.name))
 

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -421,10 +421,15 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
                     name = node.get('name')
                     assert name
                     for key, value in node.items():
-                        self.volume_config[name][key] = value
+                        # pylint: disable=no-member
+                        if value == 'True':
+                            self.volume_config[name][key] = True
+                        else:
+                            self.volume_config[name][key] = value
 
             for name, conf in volume_config.items():
                 for key, value in conf.items():
+                    # pylint: disable=no-member
                     self.volume_config[name][key] = value
 
         elif volume_config:

--- a/qubes/vm/standalonevm.py
+++ b/qubes/vm/standalonevm.py
@@ -34,25 +34,34 @@ class StandaloneVM(qubes.vm.qubesvm.QubesVM):
             'root': {
                 'name': 'root',
                 'pool': 'default',
-                'volume_type': 'origin',
+                'snap_on_start': False,
+                'save_on_stop': True,
+                'rw': True,
+                'source': None,
+                'internal': True,
                 'size': qubes.config.defaults['root_img_size'],
             },
             'private': {
                 'name': 'private',
                 'pool': 'default',
-                'volume_type': 'origin',
+                'snap_on_start': False,
+                'save_on_stop': True,
+                'rw': True,
+                'source': None,
+                'internal': True,
                 'size': qubes.config.defaults['private_img_size'],
             },
             'volatile': {
                 'name': 'volatile',
                 'pool': 'default',
-                'volume_type': 'volatile',
+                'internal': True,
                 'size': qubes.config.defaults['root_img_size'],
             },
             'kernel': {
                 'name': 'kernel',
                 'pool': 'linux-kernel',
-                'volume_type': 'read-only',
+                'rw': False,
+                'internal': True
             }
         }
         super(StandaloneVM, self).__init__(*args, **kwargs)

--- a/qubes/vm/templatevm.py
+++ b/qubes/vm/templatevm.py
@@ -60,38 +60,40 @@ class TemplateVM(QubesVM):
             'root': {
                 'name': 'root',
                 'pool': 'default',
-                'volume_type': 'origin',
+                'snap_on_start': False,
+                'save_on_stop': True,
+                'rw': True,
+                'source': None,
                 'size': defaults['root_img_size'],
                 'internal': True
             },
             'private': {
                 'name': 'private',
                 'pool': 'default',
-                'volume_type': 'read-write',
+                'snap_on_start': False,
+                'save_on_stop': True,
+                'rw': True,
+                'source': None,
                 'size': defaults['private_img_size'],
+                'revisions_to_keep': 0,
                 'internal': True
             },
             'volatile': {
                 'name': 'volatile',
                 'pool': 'default',
                 'size': defaults['root_img_size'],
-                'volume_type': 'volatile',
-                'internal': True
+                'internal': True,
+                'rw': True,
             },
             'kernel': {
                 'name': 'kernel',
                 'pool': 'linux-kernel',
-                'volume_type': 'read-only',
-                'internal': True
+                'snap_on_start': True,
+                'internal': True,
+                'rw': False
             }
         }
         super(TemplateVM, self).__init__(*args, **kwargs)
-
-    def clone_disk_files(self, src):
-        super(TemplateVM, self).clone_disk_files(src)
-
-        # Create root-cow.img
-        self.commit_changes()
 
     def commit_changes(self):
         '''Commit changes to template'''

--- a/rpm_spec/core-dom0.spec
+++ b/rpm_spec/core-dom0.spec
@@ -247,6 +247,7 @@ fi
 %{python_sitelib}/qubes/tools/qvm_block.py*
 %{python_sitelib}/qubes/tools/qvm_create.py*
 %{python_sitelib}/qubes/tools/qvm_features.py*
+%{python_sitelib}/qubes/tools/qvm_clone.py*
 %{python_sitelib}/qubes/tools/qvm_kill.py*
 %{python_sitelib}/qubes/tools/qvm_ls.py*
 %{python_sitelib}/qubes/tools/qvm_pause.py*


### PR DESCRIPTION
This storage API removes the use of `volume_types` and adds the attributes
`snap_on_start` & `save_on_stop`. 

If `snap_on_start == True` the `Volume` has to have the attribute `source`
set, then a `Pool` does some implementation specific “magic” to create a
snapshot from the `source`. Bot volumes need to be part of the same pool.

If `save_on_stop == True` all writes to the `Volume` will be saved to
disk.
 
```python
	volatile        = not snap_on_start and not save_on_stop
	snapshot        =     snap_on_start and not save_on_stop
	origin          = not snap_on_start and     save_on_stop
	origin_snapshot =     snap_on_start and     save_on_stop
```

The old `volume_type` `volume` is just a normal volume with
`save_on_stop == True and revisions=0`.

`origin_snapshot` is an accidental feature. Such a volume has `source` set. On
startup the volume will start up as a fresh snapshot, but on the shutdown all
the changes would be written to disk. This opens interesting use cases for the
future.

Also:

- Volumes now have revisions
- Add revision support to `qvm-block(1)`
- Add `qvm-clone(1)`
- Add `qvm-block revert` command