### PR TITLE
Remove obsolete options from .pylintrc

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -108,9 +108,6 @@ zope=no
 
 [BASIC]
 
-# Required attributes for module, separated by a comma
-required-attributes=
-
 # List of builtins function names that should not be used, separated by a comma
 bad-functions=map,filter,apply,input
 
@@ -199,10 +196,6 @@ ignore-docstrings=yes
 
 
 [CLASSES]
-
-# List of interface methods to ignore, separated by a comma. This is used for
-# instance to not check methods defines in Zope's Interface base class.
-ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
 
 # List of method names used to declare (i.e. assign) instance attributes.
 defining-attr-methods=__init__,__new__,setUp

--- a/qubes/__init__.py
+++ b/qubes/__init__.py
@@ -32,22 +32,12 @@ Qubes OS
 
 from __future__ import absolute_import
 
+import __builtin__
 import collections
-import errno
-import grp
-import logging
 import os
 import os.path
-import sys
-import tempfile
-import time
 
-import __builtin__
-
-import jinja2
 import lxml.etree
-import pkg_resources
-
 import qubes.config
 import qubes.events
 import qubes.exc
@@ -439,7 +429,7 @@ class PropertyHolder(qubes.events.Emitter):
         propvalues = {}
 
         all_names = set(prop.__name__ for prop in self.property_list())
-        for key in list(kwargs.keys()):
+        for key in list(kwargs):
             if not key in all_names:
                 continue
             propvalues[key] = kwargs.pop(key)

--- a/qubes/app.py
+++ b/qubes/app.py
@@ -36,13 +36,14 @@ import tempfile
 import time
 import uuid
 
-import jinja2
 import lxml.etree
+
+import jinja2
 import libvirt
 
 try:
-    import xen.lowlevel.xs
-    import xen.lowlevel.xc
+    import xen.lowlevel.xs  # pylint: disable=wrong-import-order
+    import xen.lowlevel.xc  # pylint: disable=wrong-import-order
 except ImportError:
     pass
 
@@ -58,12 +59,12 @@ else:
     raise RuntimeError("Qubes works only on POSIX or WinNT systems")
 
 
-import qubes
-import qubes.ext
-import qubes.utils
-import qubes.vm.adminvm
-import qubes.vm.qubesvm
-import qubes.vm.templatevm
+import qubes  # pylint: disable=wrong-import-position
+import qubes.ext  # pylint: disable=wrong-import-position
+import qubes.utils  # pylint: disable=wrong-import-position
+import qubes.vm.adminvm  # pylint: disable=wrong-import-position
+import qubes.vm.qubesvm  # pylint: disable=wrong-import-position
+import qubes.vm.templatevm  # pylint: disable=wrong-import-position
 
 
 class VirDomainWrapper(object):

--- a/qubes/ext/qubesmanager.py
+++ b/qubes/ext/qubesmanager.py
@@ -29,8 +29,8 @@
 .. warning:: API defined here is not declared stable.
 '''
 
-import qubes.ext
 import dbus
+import qubes.ext
 
 
 class QubesManager(qubes.ext.Extension):

--- a/qubes/utils.py
+++ b/qubes/utils.py
@@ -29,11 +29,11 @@ import os
 import re
 import subprocess
 
+import pkg_resources
+
 import docutils
 import docutils.core
 import docutils.io
-import pkg_resources
-
 import qubes.exc
 
 
@@ -158,5 +158,3 @@ def get_entry_point_one(group, name):
                 ', '.join('{}.{}'.format(ep.module_name, '.'.join(ep.attrs))
                     for ep in epoints)))
     return epoints[0].load()
-
-


### PR DESCRIPTION
This options are removed in current pylint versions. This prevents pylint from
barfing all over in vim/syntastic.