### PR TITLE
qubesutils.py: pass readonly mode to libvirt

### DIFF
--- a/core/qubesutils.py
+++ b/core/qubesutils.py
@@ -424,6 +424,8 @@ def block_attach(qvmc, vm, device, frontend=None, mode="w", auto_detach=False, w
     SubElement(disk, 'target').set('dev', frontend)
     if backend_vm.qid != 0:
         SubElement(disk, 'backenddomain').set('name', device['vm'])
+    if mode == "r":
+        SubElement(disk, 'readonly')
     vm.libvirt_domain.attachDevice(etree.tostring(disk,  encoding='utf-8'))
     try:
         # trigger watches to update device status


### PR DESCRIPTION
Fixes QubesOS/qubes-issues#2255