### PR TITLE
Add qubes.signals for forwarding events

### DIFF
--- a/qubes/__init__.py
+++ b/qubes/__init__.py
@@ -41,6 +41,7 @@ import lxml.etree
 import qubes.config
 import qubes.events
 import qubes.exc
+import qubes.signals
 
 __author__ = 'Invisible Things Lab'
 __license__ = 'GPLv2 or later'
@@ -372,8 +373,9 @@ class property(object): # pylint: disable=redefined-builtin,invalid-name
         return bool(value)
 
 
-class PropertyHolder(qubes.events.Emitter):
-    '''Abstract class for holding :py:class:`qubes.property`
+class PropertyHolder(qubes.events.Emitter, qubes.signals.SignalEmitter):
+    '''Abstract class for holding :py:class:`qubes.property`. This class also
+       forwards all the events to the the signal receivers.
 
     Events fired by instances of this class:
 
@@ -630,6 +632,13 @@ class PropertyHolder(qubes.events.Emitter):
             else:
                 # pylint: disable=no-member
                 self.log.fatal(msg)
+
+    def fire_event(self, event, *args, **kwargs):
+        ''' Fires the event as signal and calls the inherited fire_event method
+        '''
+        self.fire_signal(event, *args, **kwargs)
+        return super(PropertyHolder, self).fire_event(event, *args, **kwargs)
+
 
 # pylint: disable=wrong-import-position
 from qubes.vm import VMProperty

--- a/qubes/app.py
+++ b/qubes/app.py
@@ -725,12 +725,17 @@ class Qubes(qubes.PropertyHolder):
             vm.events_enabled = True
             vm.fire_event('domain-load')
 
+        self.start_forwarding_signals()
+
         # get a file timestamp (before closing it - still holding the lock!),
         #  to detect whether anyone else have modified it in the meantime
         self.__load_timestamp = os.path.getmtime(self._store)
         # intentionally do not call explicit unlock
         fh.close()
         del fh
+
+    def __str__(self):
+        return str(self._store)
 
     def __xml__(self):
         element = lxml.etree.Element('qubes')
@@ -810,6 +815,9 @@ class Qubes(qubes.PropertyHolder):
         # loading qubes.xml again
         self.__load_timestamp = os.path.getmtime(self._store)
         os.close(fd_old)
+        for vm in self.domains:
+            vm.fire_event('domain-save')
+        self.fire_event('app-save')
 
     def load_initial_values(self):
         self.labels = {

--- a/qubes/core2migration.py
+++ b/qubes/core2migration.py
@@ -33,7 +33,7 @@ import qubes.vm.adminvm
 import qubes.ext.r3compatibility
 
 
-class AppVM(qubes.vm.appvm.AppVM):
+class AppVM(qubes.vm.appvm.AppVM):  # pylint: disable=too-many-ancestors
     """core2 compatibility AppVM class, with variable dir_path"""
     dir_path = qubes.property('dir_path',
         # pylint: disable=undefined-variable
@@ -46,7 +46,8 @@ class AppVM(qubes.vm.appvm.AppVM):
         return False
 
 class StandaloneVM(qubes.vm.standalonevm.StandaloneVM):
-    """core2 compatibility StandaloneVM class, with variable dir_path"""
+    """core2 compatibility StandaloneVM class, with variable dir_path
+    """  # pylint: disable=too-many-ancestors
     dir_path = qubes.property('dir_path',
         # pylint: disable=undefined-variable
         default=(lambda self: super(StandaloneVM, self).dir_path),

--- a/qubes/signals.py
+++ b/qubes/signals.py
@@ -99,13 +99,14 @@ class SignalEmitter(object):
         ''' Sends out a signal to each signal receiver '''
         for receiver in self.signal_receivers:
             try:
-                receiver.fire_signal(self, name, *args, **kwargs)
-            except Exception:  # pylint: disable=broad-except
+                receiver.fire_signal(self, name, args, kwargs)
+            except Exception as exc:  # pylint: disable=broad-except
                 msg = "Can not send event {!r} to the receiver {!r}".format(
                     name, receiver)
                 try:
                     # pylint: disable=no-member
                     self.log.warn(msg)
+                    self.log.exception(exc)
                 except:  # pylint: disable=bare-except
                     print(msg, file=sys.stderr)
 

--- a/qubes/signals.py
+++ b/qubes/signals.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python2
+# -*- encoding: utf8 -*-
+#
+# The Qubes OS Project, https://www.qubes-os.org/
+#
+# Copyright (C) 2016 Bahtiar `kalkin-` Gadimov <bahtiar@gadimov.de>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+''' Signals are events which need to propagate to the "outer system" like D-Bus,
+    GuiDomain & Co.
+
+    When forwarding qubes.events to the "outer system" we have to differentiate
+    between different kinds of events:
+
+    - All the events send before/after/including domain-init and domain-load,
+      are only useful for core-admin.
+    - All the 'property-*' after the domain is loaded need to be buffered as an
+      array of events until app.save() is called and only then be send to the
+      event_receiver.
+    - Events which should be propagated to the event_receiver as soon as
+       possible, like domain-add/delete/is-fully-usable
+'''
+
+from __future__ import print_function
+
+import sys
+
+import pkg_resources
+
+RECEIVERS_ENTRY_POINT = 'qubes.signals.receivers'
+
+
+class SignalEmitter(object):
+    ''' SignalEmitter implements helper functions to buffer some signals,
+        which will be send out once the `_flush_signals()` function is called.
+
+        This is used to buffer property change signals until app.save() is
+        called.
+    '''
+
+    def __init__(self, *args, **kwargs):
+        super(SignalEmitter, self).__init__(*args, **kwargs)
+        self.signal_receivers = []
+        for entry in pkg_resources.iter_entry_points(RECEIVERS_ENTRY_POINT):
+            receiver = entry.load()
+            self.signal_receivers.append(receiver())
+        self.changes = []
+        self._is_loaded = None
+
+    def _buffer(self, name, args, kwargs):
+        ''' Adds a signal to the signal buffer, to be flushed out later '''
+        if self._is_loaded:
+            self.changes.append((name, args, kwargs))
+
+    def _flush_signals(self):
+        ''' Send out all the buffered signals '''
+        for event_tupple in self.changes:
+            self._fire_signal(*event_tupple)
+        self.changes = []
+
+    def fire_signal(self, event, *args, **kwargs):
+        ''' This function has a hardcoded logic, which decides if an event
+            should be send out as a signal immediately or buffered and send out
+            when an '*-save' event is fired.
+
+            Keep in mind that the '*-save' event it self is dropped, because it
+            doesn't carry any new information for the signal receiver.
+        '''
+        if not self._is_loaded:
+            return
+        if event.startswith('property-') \
+        or event.startswith('device-attach') \
+        or event.startswith('domain-feature-') \
+        or event in ['domain-add', 'domain-delete']:
+            self._buffer(event, args, kwargs)
+        else:
+            if len(event.split('-', 1)) == 2:
+                _, name = event.split('-', 1)
+
+            if name.startswith('save'):
+                self._flush_signals()
+            else:
+                self._fire_signal(event, *args, **kwargs)
+
+    def _fire_signal(self, name, *args, **kwargs):
+        ''' Sends out a signal to each signal receiver '''
+        for receiver in self.signal_receivers:
+            try:
+                receiver.fire_signal(self, name, *args, **kwargs)
+            except Exception:  # pylint: disable=broad-except
+                msg = "Can not send event {!r} to the receiver {!r}".format(
+                    name, receiver)
+                try:
+                    # pylint: disable=no-member
+                    self.log.warn(msg)
+                except:  # pylint: disable=bare-except
+                    print(msg, file=sys.stderr)
+
+    def start_forwarding_signals(self):
+        ''' This method needs to be called to start forwarding signals. It
+            should be called by the implementing object once it stops
+            receiving meaningless preload events like 'domain-load' &
+            'domain-init'
+        '''
+        self._is_loaded = True

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -1301,7 +1301,7 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
             return False
 
         # TODO context manager #1693
-        return self.libvirt_domain and self.libvirt_domain.isActive()
+        return bool(self.libvirt_domain and self.libvirt_domain.isActive())
 
     def is_paused(self):
         '''Check whether this domain is paused.

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -501,6 +501,8 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
         self.storage = qubes.storage.Storage(self)
         vm_pool = qubes.storage.domain.DomainPool(self)
         self.app.pools[vm_pool.name] = vm_pool
+        if event == 'domain-load':
+            self.start_forwarding_signals()
 
     @qubes.events.handler('property-set:label')
     def on_property_set_label(self, event, name, new_label, old_label=None):

--- a/rpm_spec/core-dom0.spec
+++ b/rpm_spec/core-dom0.spec
@@ -219,6 +219,7 @@ fi
 %{python_sitelib}/qubes/exc.py*
 %{python_sitelib}/qubes/log.py*
 %{python_sitelib}/qubes/rngdoc.py*
+%{python_sitelib}/qubes/signals.py*
 %{python_sitelib}/qubes/utils.py*
 
 %dir %{python_sitelib}/qubes/vm


### PR DESCRIPTION
Signals are events which need to propagate to the "outer system" like D-Bus,
GuiDomain & Co. The path which an event takes from internals to the GUI looks
currently like this.

```
core-admin -> entry_point.event_receiver -> DbusReceiver -> DBUS-SYSTEM -> GUI
```

When forwarding qubes.events to the "outer system" we have to differentiate
between different kinds of events:

* All the events send before/after/including domain-init and domain-load,
    are only useful for core-admin and should be dropped.
* Events which should be propagated to the `event_receiver` as soon as
    possible, like domain-add/delete/is-fully-usable
* All the 'property-*' after domains and `Qubes()` is loaded need to be
    buffered as an array of events until `Qubes.save()` is called and only then be
    send to the event_receiver.

They word signal is just used to reduce the confusion between to internal core-admin
events and events handled like described above.