### PR TITLE
qmemman: actually use the dom0-mem-boost config value

### DIFF
--- a/qmemman/qmemman_algo.py
+++ b/qmemman/qmemman_algo.py
@@ -97,7 +97,7 @@ def refresh_meminfo_for_domain(domain, untrusted_xenstore_key):
 def prefmem(domain):
 #dom0 is special, as it must have large cache, for vbds. Thus, give it a special boost
     if domain.id == '0':
-        return min(domain.mem_used*CACHE_FACTOR + 350*1024*1024, domain.memory_maximum)
+        return min(domain.mem_used*CACHE_FACTOR + DOM0_MEM_BOOST, domain.memory_maximum)
     return max(min(domain.mem_used*CACHE_FACTOR, domain.memory_maximum), MIN_PREFMEM)
 
 def memory_needed(domain):


### PR DESCRIPTION
Stumbled across this. The config value was simply ignored.