### PR TITLE
Added qubes-label entry to qubesdb on VM start

### DIFF
--- a/core-modules/000QubesVm.py
+++ b/core-modules/000QubesVm.py
@@ -1095,6 +1095,7 @@ class QubesVm(object):
             return
 
         self.qdb.write("/name", self.name)
+        self.qdb.write("/qubes-label", self.label.name)
         self.qdb.write("/qubes-vm-type", self.type)
         self.qdb.write("/qubes-vm-updateable", str(self.updateable))
         self.qdb.write("/qubes-vm-persistence",


### PR DESCRIPTION
There have been a handful of requests for access to the Qube label
color from within the Qube itself for theming purposes. Adding this
entry to QubesDB will facilitate that. I do not believe this causes
a breach of security, as I feel the label should be treated the same
as the Qube name, which is also set in 000QubesVm.py.