### PR TITLE
Explicitly deny qubes.Filecopy to dom0 in RPC policy

### DIFF
--- a/qubes-rpc-policy/qubes.Filecopy.policy
+++ b/qubes-rpc-policy/qubes.Filecopy.policy
@@ -3,4 +3,5 @@
 
 ## Please use a single # to start your custom comments
 
+$anyvm	dom0	deny
 $anyvm	$anyvm	ask


### PR DESCRIPTION
It already wasn't possible to qubes.Filecopy to dom0 because dom0
had no actual qubes.Filecopy service.

The introduction of this policy only improves the error message when
someone tries.

Fixes https://github.com/QubesOS/qubes-issues/issues/2031