### PR TITLE
DRY Qubes[Disp]VmLabels

### DIFF
--- a/core/qubes.py
+++ b/core/qubes.py
@@ -935,14 +935,8 @@ QubesVmLabels = {
 }
 
 QubesDispVmLabels = {
-    "red":      QubesVmLabel(1, "0xcc0000", "red",      dispvm=True),
-    "orange":   QubesVmLabel(2, "0xf57900", "orange",   dispvm=True),
-    "yellow":   QubesVmLabel(3, "0xedd400", "yellow",   dispvm=True),
-    "green":    QubesVmLabel(4, "0x73d216", "green",    dispvm=True),
-    "gray":     QubesVmLabel(5, "0x555753", "gray",     dispvm=True),
-    "blue":     QubesVmLabel(6, "0x3465a4", "blue",     dispvm=True),
-    "purple":   QubesVmLabel(7, "0x75507b", "purple",   dispvm=True),
-    "black":    QubesVmLabel(8, "0x000000", "black",    dispvm=True),
+    k: QubesVmLabel(index=v.index, color=v.color, name=v.name, dispvm=True)
+        for k, v in QubesVmLabels.iteritems()
 }
 
 defaults["appvm_label"] = QubesVmLabels["red"]


### PR DESCRIPTION
## Before:
```
[user@dom0 ~]$ ag -C5 QubesDispVmLabels /usr/lib64
...
/usr/lib64/python2.7/site-packages/qubes/qubes.py
...
937:QubesDispVmLabels = {
938-    k: QubesVmLabel(index=v.index, color=v.color, name=v.name, dispvm=True)
939-        for k, v in QubesVmLabels.iteritems()
940-}
...
[user@dom0 ~]$ python
...
>>> import qubes.qubes
>>> qubes.qubes.QubesDispVmLabels
{'blue': QubesVmLabel(6, '0x3465a4', 'blue', dispvm=True), 'gray': QubesVmLabel(5, '0x555753', 'gray', dispvm=True), 'purple': QubesVmLabel(7, '0x75507b', 'purple', dispvm=True), 'yellow': QubesVmLabel(3, '0xedd400', 'yellow', dispvm=True), 'black': QubesVmLabel(8, '0x000000', 'black', dispvm=True), 'orange': QubesVmLabel(2, '0xf57900', 'orange', dispvm=True), 'green': QubesVmLabel(4, '0x73d216', 'green', dispvm=True), 'red': QubesVmLabel(1, '0xcc0000', 'red', dispvm=True)}
```

## After:
```
[user@dom0 ~]$ ag -C5 QubesDispVmLabels /usr/lib64
...
/usr/lib64/python2.7/site-packages/qubes/qubes.py
...
937:QubesDispVmLabels = {
938-    "red":      QubesVmLabel(1, "0xcc0000", "red",      dispvm=True),
939-    "orange":   QubesVmLabel(2, "0xf57900", "orange",   dispvm=True),
940-    "yellow":   QubesVmLabel(3, "0xedd400", "yellow",   dispvm=True),
941-    "green":    QubesVmLabel(4, "0x73d216", "green",    dispvm=True),
942-    "gray":     QubesVmLabel(5, "0x555753", "gray",     dispvm=True),
...
[user@dom0 ~]$ python
...
>>> import qubes.qubes
>>> qubes.qubes.QubesDispVmLabels
{'blue': QubesVmLabel(6, '0x3465a4', 'blue', dispvm=True), 'gray': QubesVmLabel(5, '0x555753', 'gray', dispvm=True), 'green': QubesVmLabel(4, '0x73d216', 'green', dispvm=True), 'yellow': QubesVmLabel(3, '0xedd400', 'yellow', dispvm=True), 'orange': QubesVmLabel(2, '0xf57900', 'orange', dispvm=True), 'black': QubesVmLabel(8, '0x000000', 'black', dispvm=True), 'purple': QubesVmLabel(7, '0x75507b', 'purple', dispvm=True), 'red': QubesVmLabel(1, '0xcc0000', 'red', dispvm=True)}
```

Only change is in order, from:
- `blue gray purple yellow black orange green red`
to:
- `blue gray green yellow orange black purple red`

If you are relying on order of an unordered dict... well... don't. (and we aren't)

Only uses of QubesDispVmLabels in qubes-src are:
```
core-admin/dispvm/qfile-daemon-dvm
32:from qubes.qubes import QubesDispVmLabels
69:                assert sys.argv[4] in QubesDispVmLabels.keys(), "Invalid label"
70:                label = QubesDispVmLabels[sys.argv[4]]

core-admin/core-modules/01QubesDisposableVm.py
31:from qubes.qubes import QubesDispVmLabels
115:            self._label = QubesDispVmLabels[self._label.name]
```