### PR TITLE
Add raw_name field for qvm-ls

### DIFF
--- a/qvm-tools/qvm-ls
+++ b/qvm-tools/qvm-ls
@@ -41,6 +41,8 @@ fields = {
              + ('>' if vm.is_disposablevm() else '')\
              + ('}' if vm.is_netvm() else '')"},
 
+    "name-raw": {"func": "vm.name"},
+
     "type": {"func": "'HVM' if vm.type == 'HVM' else \
              ('Tpl' if vm.is_template() else \
              ('' if vm.type in ['AppVM', 'DisposableVM'] else \


### PR DESCRIPTION
Useful to avoid needing to `... | tr -d '<>{}[]='` just to get clean VM names in scripts.

Fixes https://github.com/QubesOS/qubes-issues/issues/2444

Example usage:
```
[user@dom0 ~]$ qvm-ls --raw-data raw_name state | grep fedora
fedora-23|Halted
fedora-23-dvm|Halted
fedora-24-minimal|Halted
fedora-24|Halted
```