### PR TITLE
add --help and -h on qvm-create-default-qvm

### DIFF
--- a/qvm-tools/qvm-create-default-dvm
+++ b/qvm-tools/qvm-create-default-dvm
@@ -1,5 +1,5 @@
 #!/bin/sh
-if [ $# != 1 -a $# != 2 ] ; then
+if [ $# != 1 -a $# != 2 -o $1 == "--help" -o $1 == "-h" ] ; then
 	echo 'Usage: qvm-create-default-dvm templatename|--default-template|--used-template [script-name|--default-script]'
 	exit 1
 fi


### PR DESCRIPTION
My 2 cents, this is for prevent such error :
```
qvm-create-default-dvm -h 
/var/lib/qubes/vm-templates/-h is not a directory
```
In qubes-manager, we can't prefix a vm with '-', it is a forbidden caracteres.