### PR TITLE
Rewrite root error message

### DIFF
--- a/qvm-tools/qvm-clone
+++ b/qvm-tools/qvm-clone
@@ -51,11 +51,10 @@ def main():
 
     if hasattr(os, "geteuid") and os.geteuid() == 0:
         if not options.force_root:
-            print >> sys.stderr, "*** Running this tool as root is" + \
-                " strongly discouraged, this will lead you in permissions" + \
-                "problems."
-            print >> sys.stderr, "Retry as unprivileged user."
-            print >> sys.stderr, "... or use --force-root to continue anyway."
+            print >> sys.stderr, "WARNING: Running this tool as root can lead to" + \
+                " permission problems and is strongly discouraged. Please" + \
+                " retry as an unprivileged user or use --force-root to" + \
+                " continue anyway."
             exit(1)
 
     qvm_collection = QubesVmCollection()


### PR DESCRIPTION
The language for this was very strange, so I rewrote it in a more standard format. Instead of printing things across three functions, I consolidated into one. I also opted for the more standard "WARNING:" instead of "***", which I've not seen before.