### PR TITLE
Do the right thing on removal of proxyVM used as dispvm_netvm

### DIFF
--- a/core-modules/000QubesVm.py
+++ b/core-modules/000QubesVm.py
@@ -655,7 +655,10 @@ class QubesVm(object):
             return self.netvm
         else:
             if isinstance(self._dispvm_netvm, int):
-                return self._collection[self._dispvm_netvm]
+                if  self._dispvm_netvm in self._collection:
+                    return self._collection[self._dispvm_netvm]
+                else:
+                    return None
             else:
                 return self._dispvm_netvm
 


### PR DESCRIPTION
QubesOS/qubes-issues#2382 suggests better error handling on removal of qubes used as dispvm_netvm.
The error arises _after_ the  dispvm_netvm has been removed from disk and the qubes collection, when saving the db. This fix follows the treatment of removal of netvm, by resetting dispvm_netvm to none.