### PR TITLE
qubes-core.service: Do not shut down/reboot before all VMs have shut …

### DIFF
--- a/linux/systemd/qubes-core.service
+++ b/linux/systemd/qubes-core.service
@@ -7,6 +7,8 @@ After=qubes-db-dom0.service libvirtd.service xenconsoled.service
 Type=oneshot
 StandardOutput=syslog
 RemainAfterExit=yes
+# Needed to avoid rebooting before all VMs have shut down.
+TimeoutStopSec=180
 ExecStart=/usr/lib/qubes/startup-misc.sh
 ExecStop=/usr/bin/qvm-shutdown -q --all --wait
 # QubesDB daemons stop after 60s timeout in worst case; speed it up, since no


### PR DESCRIPTION
…down

Prior to this commit, the qubes-core.service inherited systemd's default
timeout value, which most of the time caused the dom0 shut down sequence
to proceed even if some VMs were still not fully shut down at the time of
dom0 shut down.

This commit corrects this issue by setting the service stop timeout to
infinity.

Signed-off-by: M. Vefa Bicakci <m.v.b@runbox.com>