### PR TITLE
qvm-shutdown: Allow multiple VMs to be shut down with one invocation

### DIFF
--- a/doc/qvm-tools/qvm-shutdown.rst
+++ b/doc/qvm-tools/qvm-shutdown.rst
@@ -6,8 +6,6 @@ NAME
 ====
 qvm-shutdown
 
-:Date:   2012-04-11
-
 SYNOPSIS
 ========
 | qvm-shutdown [options] <vm-name> [vm-name ...]

--- a/doc/qvm-tools/qvm-shutdown.rst
+++ b/doc/qvm-tools/qvm-shutdown.rst
@@ -10,7 +10,7 @@ qvm-shutdown
 
 SYNOPSIS
 ========
-| qvm-shutdown [options] <vm-name>
+| qvm-shutdown [options] <vm-name> [vm-name ...]
 
 OPTIONS
 =======

--- a/qvm-tools/qvm-shutdown
+++ b/qvm-tools/qvm-shutdown
@@ -47,7 +47,7 @@ def main():
                             "repeated)")
 
     (options, args) = parser.parse_args ()
-    if not options.shutdown_all and (len (args) != 1):
+    if not options.shutdown_all and not args:
         parser.error ("You must specify VM name!")
 
     qvm_collection = QubesVmCollection()
@@ -66,12 +66,12 @@ def main():
             if vm.is_running():
                 vms_list.append (vm)
     else:
-        vmname = args[0]
-        vm = qvm_collection.get_vm_by_name(vmname)
-        if vm is None:
-            print >> sys.stderr, "A VM with the name '{0}' does not exist in the system!".format(vmname)
-            exit(1)
-        vms_list.append(vm)
+        for vmname in args:
+            vm = qvm_collection.get_vm_by_name(vmname)
+            if vm is None:
+                print >> sys.stderr, "A VM with the name '{0}' does not exist in the system!".format(vmname)
+                exit(1)
+            vms_list.append(vm)
 
     # Check VMs network dependencies
     if not options.force:

--- a/qvm-tools/qvm-shutdown
+++ b/qvm-tools/qvm-shutdown
@@ -28,7 +28,7 @@ import sys
 import time
 
 def main():
-    usage = "usage: %prog [options] <vm-name>"
+    usage = "usage: %prog [options] <vm-name> [vm-name ...]"
     parser = OptionParser (usage)
     
     parser.add_option ("-q", "--quiet", action="store_false", dest="verbose", default=True)


### PR DESCRIPTION
Prior to this commit, qvm-shutdown had a limitation where only one
VM name could be passed in via the command line for shutting down.

This commit removes the aforementioned limitation by adapting the
code for multiple command line arguments.

Signed-off-by: M. Vefa Bicakci <m.v.b@runbox.com>