### PR TITLE
Added dom0 check to qvm-prefs

### DIFF
--- a/qvm-tools/qvm-prefs
+++ b/qvm-tools/qvm-prefs
@@ -579,6 +579,10 @@ def main():
                              "the same time!"
         exit(1)
 
+    if vmname == 'dom0':
+        print >> sys.stderr, "dom0 cannot be edited by qvm-prefs"
+        exit(1)
+
     if options.offline_mode:
         vmm.offline_mode = True
 


### PR DESCRIPTION
Added a check to qvm-prefs to see if the specified VM is dom0 and,
if so, error out with a message that dom0 cannot be managed by
qvm-prefs. Fixes QubesOS/qubes-issues#2722