### PR TITLE
"Paranoid mode" in backup restore 

### DIFF
--- a/core-modules/000QubesVm.py
+++ b/core-modules/000QubesVm.py
@@ -22,6 +22,7 @@
 #
 #
 
+import ast
 import datetime
 import base64
 import hashlib
@@ -132,14 +133,14 @@ class QubesVm(object):
             "pcidevs": {
                 "default": '[]',
                 "order": 25,
-                "func": lambda value: [] if value in ["none", None]  else
-                    eval(value) if value.find("[") >= 0 else
-                    eval("[" + value + "]") },
+                "func": lambda value: list([] if value in ["none", None] else
+                    ast.literal_eval(value) if value.find("[") >= 0 else
+                    ast.literal_eval("[" + value + "]")) },
             "pci_strictreset": {"default": True},
             "pci_e820_host": {"default": True},
             # Internal VM (not shown in qubes-manager, doesn't create appmenus entries
             "internal": { "default": False, 'attr': '_internal' },
-            "vcpus": { "default": 2 },
+            "vcpus": { "default": 2, "func": int },
             "uses_default_kernel": { "default": True, 'order': 30 },
             "uses_default_kernelopts": { "default": True, 'order': 30 },
             "kernel": {
@@ -161,7 +162,7 @@ class QubesVm(object):
                 else not self.installed_by_rpm },
             "services": {
                 "default": {},
-                "func": lambda value: eval(str(value)) },
+                "func": lambda value: dict(ast.literal_eval(str(value))) },
             "debug": { "default": False },
             "default_user": { "default": "user", "attr": "_default_user" },
             "qrexec_timeout": { "default": 60 },

--- a/core-modules/000QubesVm.py
+++ b/core-modules/000QubesVm.py
@@ -1324,7 +1324,8 @@ class QubesVm(object):
         attrs = ['kernel', 'uses_default_kernel', 'netvm', 'uses_default_netvm',
                  'memory', 'maxmem', 'kernelopts', 'uses_default_kernelopts',
                  'services', 'vcpus', '_mac', 'pcidevs', 'include_in_backups',
-                 '_label', 'default_user', 'qrexec_timeout']
+                 '_label', 'default_user', 'qrexec_timeout',
+                 'dispvm_netvm', 'uses_default_dispvm_netvm']
 
         # fire hooks
         for hook in self.hooks_get_clone_attrs:

--- a/core-modules/000QubesVm.py
+++ b/core-modules/000QubesVm.py
@@ -249,7 +249,8 @@ class QubesVm(object):
         for hook in self.hooks_set_attr:
             hook(self, attr, newvalue, oldvalue)
 
-    def __basic_parse_xml_attr(self, value):
+    @staticmethod
+    def __basic_parse_xml_attr(value):
         if value is None:
             return None
         if value.lower() == "none":
@@ -561,8 +562,9 @@ class QubesVm(object):
         else:
             return False
 
-    def verify_name(self, name):
-        if not isinstance(self.__basic_parse_xml_attr(name), str):
+    @classmethod
+    def verify_name(cls, name):
+        if not isinstance(cls.__basic_parse_xml_attr(name), str):
             return False
         if len(name) > 31:
             return False

--- a/core/Makefile
+++ b/core/Makefile
@@ -23,6 +23,8 @@ endif
 	cp notify.py[co] $(DESTDIR)$(PYTHON_QUBESPATH)
 	cp backup.py $(DESTDIR)$(PYTHON_QUBESPATH)
 	cp backup.py[co] $(DESTDIR)$(PYTHON_QUBESPATH)
+	cp backupparser.py $(DESTDIR)$(PYTHON_QUBESPATH)
+	cp backupparser.py[co] $(DESTDIR)$(PYTHON_QUBESPATH)
 ifneq ($(BACKEND_VMM),)
 	if [ -r settings-$(SETTINGS_SUFFIX).py ]; then \
 		cp settings-$(SETTINGS_SUFFIX).py $(DESTDIR)$(PYTHON_QUBESPATH)/settings.py && \

--- a/core/backupparser.py
+++ b/core/backupparser.py
@@ -1,0 +1,275 @@
+# -*- encoding: utf8 -*-
+#
+# The Qubes OS Project, http://www.qubes-os.org
+#
+# Copyright (C) 2017 Marek Marczykowski-Górecki
+#                               <marmarek@invisiblethingslab.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+'''Standalone qubes.xml parser for safer parsing - without interfering with
+all QubesVM code'''
+import ast
+import string
+
+import lxml.etree
+import xml.parsers.expat
+import os
+import sys
+
+import re
+from qubes import QubesVmCollection, QubesException, QubesVmClasses, \
+    QubesVm, system_path, QubesVmLabels
+
+
+class SafeQubesVmCollection(QubesVmCollection):
+
+    def save(self):
+        raise NotImplementedError('This class is only for reading qubes.xml')
+
+    def add_new_vm(self, vm_type, **kwargs):
+        raise NotImplementedError('This class is only for reading qubes.xml')
+
+    def load_vm(self, vm_type, element):
+        kwargs = {}
+
+        untrusted_name = element.get('name')
+        if untrusted_name is None:
+            raise ValueError('missing VM name')
+        if '..' in untrusted_name or '/' in untrusted_name or \
+                not QubesVm.verify_name(untrusted_name):
+            raise ValueError('rejecting VM name {!r}'.format(untrusted_name))
+        if any((vm.name == untrusted_name) for vm in self.values()):
+            raise ValueError('Duplicated name: {}'.format(untrusted_name))
+        name = untrusted_name
+        kwargs['name'] = name
+
+        qid = int(element.get('qid'))
+        if qid in self:
+            raise ValueError('Duplicated qid: {}, name: {}'.format(qid, name))
+        kwargs['qid'] = qid
+
+        # load() enforce load order so templates are loader before
+        # template-based VMs
+
+        untrusted_template_qid = element.get('template_qid')
+        if untrusted_template_qid is not None:
+            if untrusted_template_qid == 'none':
+                template = None
+            else:
+                template_qid = int(untrusted_template_qid)
+                template = self[template_qid]
+            kwargs['template'] = template
+
+        backup_content = (element.get('backup_content') == 'True')
+        kwargs['backup_content'] = backup_content
+
+        if backup_content:
+            untrusted_backup_path = element.get('backup_path')
+            if untrusted_backup_path not in [
+                        'appvms/' + name, 'vm-templates/' + name,
+                        'servicevms/' + name, 'vm' + str(qid)]:
+                raise ValueError('rejecting backup path')
+            backup_path = untrusted_backup_path
+            kwargs['backup_path'] = backup_path
+
+            untrusted_backup_size = element.get('backup_size')
+            if untrusted_backup_size:
+                backup_size = int(element.get('backup_size'))
+                kwargs['backup_size'] = backup_size
+
+        uses_default_kernel = (element.get('uses_default_kernel') == 'True')
+        kwargs['uses_default_kernel'] = uses_default_kernel
+
+        if not uses_default_kernel:
+            untrusted_kernel = element.get('kernel')
+            if untrusted_kernel is not None:
+                if '..' or '/' in untrusted_kernel:
+                    raise ValueError(
+                        'invalid kernel: {!r}'.format(untrusted_kernel))
+                # missing kernel is handled by restore logic, depending on
+                # restore options
+                kernel = untrusted_kernel
+                kwargs['kernel'] = kernel
+
+        memory = int(element.get('memory'))
+        kwargs['memory'] = memory
+
+        untrusted_maxmem = element.get('maxmem')
+        if untrusted_maxmem is not None:
+            maxmem = int(untrusted_maxmem)
+            kwargs['maxmem'] = maxmem
+
+        untrusted_uses_default_kernelopts = \
+            element.get('uses_default_kernelopts')
+        if untrusted_uses_default_kernelopts is not None:
+            uses_default_kernelopts = (untrusted_uses_default_kernelopts ==
+                                       'True')
+            kwargs['uses_default_kernelopts'] = uses_default_kernelopts
+        else:
+            uses_default_kernelopts = True
+
+        untrusted_kernelopts = element.get('kernelopts')
+        if not uses_default_kernelopts and untrusted_kernelopts is not None:
+            if any((c in untrusted_kernelopts) for c in '<>\'"&'):
+                raise ValueError('Invalid characters in kernelopts')
+            kernelopts = untrusted_kernelopts
+            kwargs['kernelopts'] = kernelopts
+
+        untrusted_services = element.get('services')
+        if untrusted_services is not None:
+            services = {}
+            for untrusted_key, untrusted_value in ast.literal_eval(
+                    untrusted_services).items():
+                if all((c in string.ascii_letters + '-_') for c in
+                        untrusted_key) and isinstance(untrusted_value, bool):
+                    services[untrusted_key] = untrusted_value
+            kwargs['services'] = services
+
+        vcpus = int(element.get('vcpus'))
+        kwargs['vcpus'] = vcpus
+
+        internal = (element.get('internal') == 'True')
+        kwargs['internal'] = internal
+
+        untrusted_mac = element.get('mac')
+        if untrusted_mac is not None:
+            if re.match(r'^([0-9a-f][0-9a-f]:){5}[0-9a-f][0-9a-f]$', untrusted_mac,
+                    re.IGNORECASE) is None:
+                raise ValueError('invalid mac value')
+            mac = untrusted_mac
+            kwargs['mac'] = mac
+
+        include_in_backups = (element.get('include_in_backups') == 'True')
+        kwargs['include_in_backups'] = include_in_backups
+
+        untrusted_label = element.get('label')
+        if untrusted_label is None:
+            raise ValueError('missing label')
+
+        label = QubesVmLabels[untrusted_label]
+        kwargs['label'] = label
+
+        untrusted_timezone = element.get('timezone')
+        if untrusted_timezone is not None:
+            if untrusted_timezone != 'localtime' and not \
+                    untrusted_timezone.isdigit():
+                raise ValueError('invalid timezone value')
+            timezone = untrusted_timezone
+            kwargs['timezone'] = timezone
+
+        untrusted_qrexec_timeout = element.get('qrexec_timeout')
+        if untrusted_qrexec_timeout is not None:
+            qrexec_timeout = int(untrusted_qrexec_timeout)
+            kwargs['qrexec_timeout'] = qrexec_timeout
+
+        untrusted_qrexec_installed = element.get('qrexec_installed')
+        if untrusted_qrexec_installed is not None:
+            qrexec_installed = (untrusted_qrexec_installed == 'True')
+            kwargs['qrexec_installed'] = qrexec_installed
+
+        untrusted_guiagent_installed = element.get('guiagent_installed')
+        if untrusted_guiagent_installed is not None:
+            guiagent_installed = (untrusted_guiagent_installed == 'True')
+            kwargs['guiagent_installed'] = guiagent_installed
+
+        # ignore default_user
+        # ignore pcidevs
+        # ignore drive
+
+        vm_cls = QubesVmClasses[vm_type]
+        vm = vm_cls(collection=self, **kwargs)
+        if not self.verify_new_vm(vm):
+            raise QubesException("Wrong VM description!")
+
+        self[vm.qid] = vm
+
+        return vm
+
+    def load_vm_deps(self, vm, element):
+        uses_default_netvm = element.get('uses_default_netvm') == 'True'
+        vm.uses_default_netvm = uses_default_netvm
+
+        if not uses_default_netvm:
+            untrusted_netvm_qid = element.get('netvm_qid')
+            if untrusted_netvm_qid is not None and untrusted_netvm_qid != \
+                    'none':
+                netvm = self[int(untrusted_netvm_qid)]
+            else:
+                netvm = None
+        else:
+            if vm.is_proxyvm():
+                netvm = self.get_default_fw_netvm()
+            else:
+                netvm = self.get_default_netvm()
+
+        # directly set internal attr to not call setters...
+        vm._netvm = netvm
+        if netvm:
+            netvm.connected_vms[vm.qid] = vm
+
+        uses_default_dispvm_netvm = \
+            element.get('uses_default_dispvm_netvm') == 'True'
+        vm.uses_default_dispvm_netvm = uses_default_dispvm_netvm
+
+        if not uses_default_dispvm_netvm:
+            untrusted_dispvm_netvm_qid = element.get('dispvm_netvm')
+            if untrusted_dispvm_netvm_qid is not None:
+                dispvm_netvm = self[int(untrusted_dispvm_netvm_qid)]
+                vm.dispvm_netvm = dispvm_netvm
+
+    def load(self):
+        self.log.debug('load()')
+        self.clear()
+
+        try:
+            self.qubes_store_file.seek(0)
+            tree = lxml.etree.parse(self.qubes_store_file)
+        except (EnvironmentError,
+        xml.parsers.expat.ExpatError) as err:
+            raise QubesException("error loading qubes.xml: {}".format(
+                os.path.basename(sys.argv[0]), err))
+
+        self.load_globals(tree.getroot())
+
+        loaded_vms = []
+        for (vm_class_name, vm_class) in sorted(QubesVmClasses.items(),
+                key=lambda _x: _x[1].load_order):
+            if vm_class_name == 'QubesAdminVm':
+                # skip dom0
+                continue
+            vms_of_class = tree.findall(vm_class_name)
+            # first non-template based, then template based
+            sorted_vms_of_class = sorted(vms_of_class,
+                key=lambda x: str(x.get('template_qid')).lower() != "none")
+            for element in sorted_vms_of_class:
+                try:
+                    vm = self.load_vm(vm_class_name, element)
+                    loaded_vms.append((vm, element))
+                except (ValueError, LookupError) as err:
+                    raise QubesException(
+                        "paranoid-mode: error loading VM from qubes.xml "
+                        "({}): {}".format(
+                            vm_class_name, err))
+
+        self.check_globals()
+
+        # then set dependencies
+        for vm, element in loaded_vms:
+            try:
+                self.load_vm_deps(vm, element)
+            except (ValueError, LookupError) as err:
+                raise QubesException(
+                    "error setting dependencies for VM {}: {}".format(
+                        vm.name, err))

--- a/core/qubes.py
+++ b/core/qubes.py
@@ -802,9 +802,8 @@ class QubesVmCollection(dict):
             tree = lxml.etree.parse(self.qubes_store_file)
         except (EnvironmentError,
                 xml.parsers.expat.ExpatError) as err:
-            print("{0}: import error: {1}".format(
+            raise QubesException("error loading qubes.xml: {}".format(
                 os.path.basename(sys.argv[0]), err))
-            return False
 
         self.load_globals(tree.getroot())
 
@@ -819,10 +818,9 @@ class QubesVmCollection(dict):
                     vm = vm_class(xml_element=element, collection=self)
                     self[vm.qid] = vm
                 except (ValueError, LookupError) as err:
-                    print("{0}: import error ({1}): {2}".format(
-                        os.path.basename(sys.argv[0]), vm_class_name, err))
-                    raise
-                    return False
+                    raise QubesException(
+                        "error loading VM from qubes.xml({}): {}".format(
+                            vm_class_name, err))
 
         # After importing all VMs, set netvm references, in the same order
         for (vm_class_name, vm_class) in sorted(QubesVmClasses.items(),

--- a/doc/qvm-tools/qvm-backup-restore.rst
+++ b/doc/qvm-tools/qvm-backup-restore.rst
@@ -40,6 +40,17 @@ OPTIONS
     Read passphrase from file, or use '-' to read from stdin
 -z, --compressed
     The backup is compressed
+--paranoid-mode, --plan-b
+    Treat the backup as untrusted, disable restoring things potentially
+    compromising security of dom0/other VMs, even when such data is properly
+    authenticated. This may be used to restore a backup made on compromissed
+    system. Things currently affected by this option:
+      - disable dom0 home restore
+      - reject compressed backups
+      - reject old backup formats (Qubes R2 and older)
+      - more strict validation of VM names (for example don't allow '..' in it)
+      - do not restore firewall rules, attached PCI devices, attached block
+        devices, menu entries
 --debug
     Enable (a lot of) debug output
 

--- a/qvm-tools/qvm-backup-restore
+++ b/qvm-tools/qvm-backup-restore
@@ -94,6 +94,13 @@ def main():
     parser.add_option ("-z", "--compressed", action="store_true", dest="compressed", default=False,
                        help="The backup is compressed")
 
+    parser.add_option("--paranoid-mode", "--plan-b", action="store_true",
+                      dest="paranoid_mode", default=False,
+                      help="Treat the backup as untrusted, don't restore "
+                           "things potentially compromising security, "
+                           "even when properly authenticated. See man page "
+                           "for details.")
+
     parser.add_option ("--debug", action="store_true", dest="debug",
                        default=False, help="Enable (a lot of) debug output")
 
@@ -131,6 +138,8 @@ def main():
         restore_options['exclude'] = options.exclude
     if options.verify_only:
         restore_options['verify-only'] = True
+    if options.paranoid_mode:
+        restore_options['paranoid-mode'] = True
     if options.debug:
         qubes.backup.BACKUP_DEBUG = True
 

--- a/qvm-tools/qvm-backup-restore
+++ b/qvm-tools/qvm-backup-restore
@@ -196,6 +196,8 @@ def main():
             there_are_missing_templates = True
         if 'missing-netvm' in vm_info.keys():
             there_are_missing_netvms = True
+        if 'missing-dispvm_netvm' in vm_info.keys():
+            there_are_missing_netvms = True
         if 'already-exists' in vm_info.keys():
             there_are_conflicting_vms = True
         if 'username-mismatch' in vm_info.keys():

--- a/rpm_spec/core-dom0.spec
+++ b/rpm_spec/core-dom0.spec
@@ -199,6 +199,9 @@ fi
 %{python_sitearch}/qubes/backup.py
 %{python_sitearch}/qubes/backup.pyc
 %{python_sitearch}/qubes/backup.pyo
+%{python_sitearch}/qubes/backupparser.py
+%{python_sitearch}/qubes/backupparser.pyc
+%{python_sitearch}/qubes/backupparser.pyo
 %{python_sitearch}/qubes/storage/*.py
 %{python_sitearch}/qubes/storage/*.pyc
 %{python_sitearch}/qubes/storage/*.pyo

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -150,12 +150,10 @@ class _AssertNotRaisesContext(object):
 
         if issubclass(exc_type, self.expected):
             raise self.failureException(
-                "{0} raised".format(exc_name))
+                "{} raised: {}".format(exc_name, str(exc_value)))
         else:
             # pass through
             return False
-
-        self.exception = exc_value # store for later retrieval
 
 
 class BeforeCleanExit(BaseException):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -609,7 +609,7 @@ class BackupTestsMixin(SystemTestsMixin):
             print msg
 
     def fill_image(self, path, size=None, sparse=False):
-        block_size = 4096
+        block_size = 4096 * 1024
 
         if self.verbose:
             print >>sys.stderr, "-> Filling %s" % path

--- a/tests/backup.py
+++ b/tests/backup.py
@@ -158,6 +158,28 @@ class TC_00_Backup(qubes.tests.BackupTestsMixin, qubes.tests.QubesTestCase):
 
         self.remove_vms(vms)
 
+    def test_300_paranoid(self):
+        vms = self.create_backup_vms()
+        self.make_backup(vms)
+        self.remove_vms(vms)
+        self.restore_backup(options={'paranoid-mode': True})
+        self.remove_vms(vms)
+
+    def test_301_paranoid_reject_compression(self):
+        vms = self.create_backup_vms()
+        self.make_backup(vms, do_kwargs={'compressed': True})
+        self.remove_vms(vms)
+        backupfile = os.path.join(self.backupdir,
+                                  sorted(os.listdir(self.backupdir))[-1])
+
+        with self.assertRaises(qubes.qubes.QubesException):
+            qubes.backup.backup_restore_prepare(
+                backupfile, "qubes",
+                host_collection=self.qc,
+                print_callback=self.print_callback,
+                options={'paranoid-mode': True})
+
+
 class TC_10_BackupVMMixin(qubes.tests.BackupTestsMixin):
     def setUp(self):
         super(TC_10_BackupVMMixin, self).setUp()

--- a/tests/backupcompatibility.py
+++ b/tests/backupcompatibility.py
@@ -34,6 +34,35 @@ from qubes import backup
 
 import qubes.tests
 
+QUBESXML_R32 = '''
+<QubesVmCollection clockvm="5" default_fw_netvm="5" default_kernel="4.4.14-11" default_netvm="6" default_template="1" updatevm="6">
+  <QubesAdminVm autostart="False" backup_content="True" backup_path="dom0-home/user" backup_size="9770090496" conf_file="dom0.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/servicevms/dom0" dispvm_netvm="none" firewall_conf="firewall.xml" include_in_backups="True" installed_by_rpm="False" internal="False" label="black" maxmem="0" memory="300" name="dom0" netid="0" pci_e820_host="True" pci_strictreset="True" pcidevs="[]" pool_name="default" qid="0" qrexec_timeout="60" services="{'meminfo-writer': True}" template_qid="none" uses_default_dispvm_netvm="True" vcpus="0"/>
+  <QubesTemplateVm autostart="False" backup_content="False" backup_path="" backup_size="0" conf_file="fedora-23.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/vm-templates/fedora-23" dispvm_netvm="6" firewall_conf="firewall.xml" include_in_backups="False" installed_by_rpm="True" internal="False" kernel="4.4.14-11" kernelopts="nopat" label="black" maxmem="2006" memory="400" name="fedora-23" netvm_qid="6" pci_e820_host="True" pci_strictreset="True" pcidevs="[]" pool_name="default" qid="1" qrexec_timeout="60" services="{'meminfo-writer': True}" template_qid="none" uses_default_dispvm_netvm="True" uses_default_kernel="True" uses_default_kernelopts="True" uses_default_netvm="True" uuid="778f8b4a-6847-476b-8892-14d5b61b69da" vcpus="2"/>
+  <QubesTemplateVm autostart="False" backup_content="False" backup_path="" backup_size="0" conf_file="debian-8.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/vm-templates/debian-8" dispvm_netvm="6" firewall_conf="firewall.xml" include_in_backups="False" installed_by_rpm="True" internal="False" kernel="4.4.14-11" kernelopts="nopat" label="black" maxmem="2006" memory="400" name="debian-8" netvm_qid="6" pci_e820_host="True" pci_strictreset="True" pcidevs="[]" pool_name="default" qid="2" qrexec_timeout="60" services="{'meminfo-writer': True}" template_qid="none" uses_default_dispvm_netvm="True" uses_default_kernel="True" uses_default_kernelopts="True" uses_default_netvm="True" vcpus="2"/>
+  <QubesTemplateVm autostart="False" backup_content="False" backup_path="" backup_size="0" conf_file="whonix-ws.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/vm-templates/whonix-ws" dispvm_netvm="8" firewall_conf="firewall.xml" include_in_backups="False" installed_by_rpm="True" internal="False" kernel="4.4.14-11" kernelopts="nopat" label="black" maxmem="2006" memory="400" name="whonix-ws" netvm_qid="8" pci_e820_host="True" pci_strictreset="True" pcidevs="[]" pool_name="default" qid="3" qrexec_timeout="60" services="{'meminfo-writer': True}" template_qid="none" uses_default_dispvm_netvm="True" uses_default_kernel="True" uses_default_kernelopts="True" uses_default_netvm="False" uuid="020b6cc9-4e2e-436a-a67f-7dbb8d6c1ec7" vcpus="2"/>
+  <QubesTemplateVm autostart="False" backup_content="False" backup_path="" backup_size="0" conf_file="whonix-gw.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/vm-templates/whonix-gw" dispvm_netvm="8" firewall_conf="firewall.xml" include_in_backups="False" installed_by_rpm="True" internal="False" kernel="4.4.14-11" kernelopts="nopat" label="black" maxmem="2006" memory="400" name="whonix-gw" netvm_qid="8" pci_e820_host="True" pci_strictreset="True" pcidevs="[]" pool_name="default" qid="4" qrexec_timeout="60" services="{'meminfo-writer': True}" template_qid="none" uses_default_dispvm_netvm="True" uses_default_kernel="True" uses_default_kernelopts="True" uses_default_netvm="False" uuid="56c39ac4-7090-4fba-83b7-291bb43fe3ab" vcpus="2"/>
+  <QubesNetVm autostart="True" backup_content="False" backup_path="" backup_size="0" conf_file="sys-net.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/servicevms/sys-net" dispvm_netvm="none" firewall_conf="firewall.xml" include_in_backups="True" installed_by_rpm="False" internal="False" kernel="4.4.14-11" kernelopts="nopat iommu=soft swiotlb=8192" label="red" maxmem="2006" memory="300" name="sys-net" netid="1" pci_e820_host="True" pci_strictreset="True" pcidevs="['02:00.0']" pool_name="default" qid="5" qrexec_timeout="60" services="{'ntpd': False, 'meminfo-writer': False}" template_qid="1" uses_default_dispvm_netvm="True" uses_default_kernel="True" uses_default_kernelopts="True" uuid="d629b4c8-39fc-4e76-ad02-ec42bc2b4166" vcpus="2"/>
+  <QubesProxyVm autostart="True" backup_content="False" backup_path="" backup_size="0" conf_file="sys-firewall.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/servicevms/sys-firewall" dispvm_netvm="5" firewall_conf="firewall.xml" include_in_backups="True" installed_by_rpm="False" internal="False" kernel="4.4.14-11" kernelopts="nopat" label="green" maxmem="2006" memory="500" name="sys-firewall" netid="2" netvm_qid="5" pci_e820_host="True" pci_strictreset="True" pcidevs="[]" pool_name="default" qid="6" qrexec_timeout="60" services="{'meminfo-writer': True}" template_qid="1" uses_default_dispvm_netvm="True" uses_default_kernel="True" uses_default_kernelopts="True" uuid="8f3d442f-b37b-449e-8209-1dd413d942c2" vcpus="2"/>
+  <QubesAppVm autostart="False" backup_content="False" backup_path="" backup_size="0" conf_file="untrusted.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/appvms/untrusted" dispvm_netvm="6" firewall_conf="firewall.xml" include_in_backups="True" installed_by_rpm="False" internal="False" kernel="4.4.14-11" kernelopts="nopat" label="red" maxmem="2006" memory="400" name="untrusted" netvm_qid="6" pci_e820_host="True" pci_strictreset="True" pcidevs="[]" pool_name="default" qid="7" qrexec_timeout="60" services="{'meminfo-writer': True}" template_qid="1" uses_default_dispvm_netvm="True" uses_default_kernel="True" uses_default_kernelopts="True" uses_default_netvm="True" uuid="43fb3f4d-f139-4ab4-b262-a3573ae9b0c8" vcpus="2"/>
+  <QubesProxyVm autostart="True" backup_content="False" backup_path="" backup_size="0" conf_file="sys-whonix.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/servicevms/sys-whonix" dispvm_netvm="6" firewall_conf="firewall.xml" include_in_backups="True" installed_by_rpm="False" internal="False" kernel="4.4.14-11" kernelopts="nopat" label="black" maxmem="2006" memory="500" name="sys-whonix" netid="3" netvm_qid="6" pci_e820_host="True" pci_strictreset="True" pcidevs="[]" pool_name="default" qid="8" qrexec_timeout="60" services="{'meminfo-writer': True}" template_qid="4" uses_default_dispvm_netvm="True" uses_default_kernel="True" uses_default_kernelopts="True" uuid="f7b7b41f-840c-4761-a988-3993d3ea73db" vcpus="2"/>
+  <QubesAppVm autostart="False" backup_content="False" backup_path="" backup_size="0" conf_file="anon-whonix.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/appvms/anon-whonix" dispvm_netvm="8" firewall_conf="firewall.xml" include_in_backups="True" installed_by_rpm="False" internal="False" kernel="4.4.14-11" kernelopts="nopat" label="red" maxmem="2006" memory="400" name="anon-whonix" netvm_qid="8" pci_e820_host="True" pci_strictreset="True" pcidevs="[]" pool_name="default" qid="9" qrexec_timeout="60" services="{'meminfo-writer': True}" template_qid="3" uses_default_dispvm_netvm="True" uses_default_kernel="True" uses_default_kernelopts="True" uses_default_netvm="False" uuid="d095f34f-26dc-48c1-89f7-c8ffba852452" vcpus="2"/>
+  <QubesAppVm autostart="False" backup_content="False" backup_path="" backup_size="0" conf_file="vault.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/appvms/vault" dispvm_netvm="none" firewall_conf="firewall.xml" include_in_backups="True" installed_by_rpm="False" internal="False" kernel="4.4.14-11" kernelopts="nopat" label="black" maxmem="2006" memory="400" name="vault" netvm_qid="none" pci_e820_host="True" pci_strictreset="True" pcidevs="[]" pool_name="default" qid="10" qrexec_timeout="60" services="{'meminfo-writer': True}" template_qid="1" uses_default_dispvm_netvm="True" uses_default_kernel="True" uses_default_kernelopts="True" uses_default_netvm="False" uuid="4627217c-f6c9-4365-a264-3d118fab91a1" vcpus="2"/>
+  <QubesAppVm autostart="False" backup_content="False" backup_path="" backup_size="0" conf_file="personal.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/appvms/personal" dispvm_netvm="6" firewall_conf="firewall.xml" include_in_backups="True" installed_by_rpm="False" internal="False" kernel="4.4.14-11" kernelopts="nopat" label="yellow" maxmem="2006" memory="400" name="personal" netvm_qid="6" pci_e820_host="True" pci_strictreset="True" pcidevs="[]" pool_name="default" qid="11" qrexec_timeout="60" services="{'meminfo-writer': True}" template_qid="1" uses_default_dispvm_netvm="True" uses_default_kernel="True" uses_default_kernelopts="True" uses_default_netvm="True" uuid="b076f81f-32dc-448c-a755-07cdaf9af009" vcpus="2"/>
+  <QubesAppVm autostart="False" backup_content="False" backup_path="" backup_size="0" conf_file="work.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/appvms/work" dispvm_netvm="6" firewall_conf="firewall.xml" include_in_backups="True" installed_by_rpm="False" internal="False" kernel="4.4.14-11" kernelopts="nopat" label="blue" maxmem="2006" memory="400" name="work" netvm_qid="6" pci_e820_host="True" pci_strictreset="True" pcidevs="[]" pool_name="default" qid="12" qrexec_timeout="60" services="{'meminfo-writer': True}" template_qid="1" uses_default_dispvm_netvm="True" uses_default_kernel="True" uses_default_kernelopts="True" uses_default_netvm="True" uuid="71cf8f3d-51bc-45ef-808c-b7d4e3320e37" vcpus="2"/>
+  <QubesAppVm autostart="False" backup_content="False" backup_path="" backup_size="0" conf_file="fedora-23-dvm.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/appvms/fedora-23-dvm" dispvm_netvm="6" firewall_conf="firewall.xml" include_in_backups="True" installed_by_rpm="False" internal="True" kernel="4.4.14-11" kernelopts="nopat" label="gray" maxmem="2006" memory="400" name="fedora-23-dvm" netvm_qid="6" pci_e820_host="True" pci_strictreset="True" pcidevs="[]" pool_name="default" qid="13" qrexec_timeout="60" services="{'meminfo-writer': True}" template_qid="1" uses_default_dispvm_netvm="True" uses_default_kernel="True" uses_default_kernelopts="True" uses_default_netvm="True" uuid="54b498c6-1112-4c5e-861d-bfffa86db4ec" vcpus="1"/>
+  <QubesHVm autostart="False" backup_content="False" backup_path="" backup_size="0" conf_file="stubdomtest.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/appvms/stubdomtest" dispvm_netvm="6" drive="None" firewall_conf="firewall.xml" guiagent_installed="False" include_in_backups="True" installed_by_rpm="False" internal="False" label="red" memory="1536" name="stubdomtest" netvm_qid="6" pci_e820_host="True" pci_strictreset="False" pcidevs="[]" pool_name="default" qid="14" qrexec_installed="False" qrexec_timeout="60" seamless_gui_mode="False" services="{'meminfo-writer': False}" template_qid="none" timezone="localtime" uses_default_dispvm_netvm="True" uses_default_netvm="True" uuid="490f5562-660d-401d-bb7f-33c6d7bf2128" vcpus="1"/>
+  <QubesAppVm autostart="False" backup_content="True" backup_path="appvms/test-work" backup_size="68145152" conf_file="test-work.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/appvms/test-work" dispvm_netvm="19" firewall_conf="firewall.xml" include_in_backups="True" installed_by_rpm="False" internal="False" kernel="4.4.14-11" kernelopts="nopat" label="green" maxmem="2006" memory="400" name="test-work" netvm_qid="23" pci_e820_host="True" pci_strictreset="True" pcidevs="[]" pool_name="default" qid="15" qrexec_timeout="60" services="{'meminfo-writer': True}" template_qid="1" uses_default_dispvm_netvm="False" uses_default_kernel="True" uses_default_kernelopts="True" uses_default_netvm="False" uuid="9717539c-a3ce-4c3e-b95a-1238d195f78f" vcpus="2"/>
+  <QubesAppVm autostart="False" backup_content="True" backup_path="appvms/test-standalonevm" backup_size="4446990336" conf_file="test-standalonevm.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/appvms/test-standalonevm" dispvm_netvm="6" firewall_conf="firewall.xml" include_in_backups="True" installed_by_rpm="False" internal="False" kernel="4.4.14-11" kernelopts="nopat" label="blue" maxmem="2006" memory="400" name="test-standalonevm" netvm_qid="6" pci_e820_host="True" pci_strictreset="True" pcidevs="[]" pool_name="default" qid="16" qrexec_timeout="60" services="{'meminfo-writer': True}" template_qid="none" uses_default_dispvm_netvm="True" uses_default_kernel="True" uses_default_kernelopts="True" uses_default_netvm="True" uuid="b8a56982-200a-4349-9cfa-3407a919c861" vcpus="2"/>
+  <QubesTemplateVm autostart="False" backup_content="True" backup_path="vm-templates/test-template-clone" backup_size="4016513024" conf_file="test-template-clone.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/vm-templates/test-template-clone" dispvm_netvm="6" firewall_conf="firewall.xml" include_in_backups="False" installed_by_rpm="False" internal="False" kernel="4.4.14-11" kernelopts="nopat" label="black" maxmem="2006" memory="400" name="test-template-clone" netvm_qid="6" pci_e820_host="True" pci_strictreset="True" pcidevs="[]" pool_name="default" qid="17" qrexec_timeout="60" services="{'meminfo-writer': True}" template_qid="none" uses_default_dispvm_netvm="True" uses_default_kernel="True" uses_default_kernelopts="True" uses_default_netvm="True" uuid="068a34f5-23eb-462c-b8c3-5b4e3a2d2bfe" vcpus="2"/>
+  <QubesAppVm autostart="False" backup_content="True" backup_path="appvms/test-custom-template-appvm" backup_size="68145152" conf_file="test-custom-template-appvm.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/appvms/test-custom-template-appvm" dispvm_netvm="6" firewall_conf="firewall.xml" include_in_backups="True" installed_by_rpm="False" internal="False" kernel="4.4.14-11" kernelopts="nopat" label="green" maxmem="2006" memory="400" name="test-custom-template-appvm" netvm_qid="6" pci_e820_host="True" pci_strictreset="True" pcidevs="[]" pool_name="default" qid="18" qrexec_timeout="60" services="{'meminfo-writer': True}" template_qid="17" uses_default_dispvm_netvm="True" uses_default_kernel="True" uses_default_kernelopts="True" uses_default_netvm="True" uuid="eea549b7-cc81-4191-a229-4866489f3d8e" vcpus="2"/>
+  <QubesProxyVm autostart="False" backup_content="True" backup_path="servicevms/test-testproxy" backup_size="68063232" conf_file="test-testproxy.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/servicevms/test-testproxy" dispvm_netvm="none" firewall_conf="firewall.xml" include_in_backups="True" installed_by_rpm="False" internal="False" kernel="4.4.14-11" kernelopts="nopat" label="yellow" maxmem="2006" memory="300" name="test-testproxy" netid="4" netvm_qid="none" pci_e820_host="True" pci_strictreset="True" pcidevs="[]" pool_name="default" qid="19" qrexec_timeout="60" services="{'meminfo-writer': True}" template_qid="1" uses_default_dispvm_netvm="True" uses_default_kernel="True" uses_default_kernelopts="True" uuid="c9951f79-ae68-45d4-864d-b60381169cd3" vcpus="2"/>
+  <QubesHVm autostart="False" backup_content="True" backup_path="appvms/test-testhvm" backup_size="32768" conf_file="test-testhvm.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/appvms/test-testhvm" dispvm_netvm="6" drive="None" firewall_conf="firewall.xml" guiagent_installed="False" include_in_backups="True" installed_by_rpm="False" internal="False" label="orange" memory="512" name="test-testhvm" netvm_qid="6" pci_e820_host="True" pci_strictreset="True" pcidevs="[]" pool_name="default" qid="20" qrexec_installed="False" qrexec_timeout="60" seamless_gui_mode="False" services="{'meminfo-writer': False}" template_qid="none" timezone="localtime" uses_default_dispvm_netvm="True" uses_default_netvm="True" uuid="14055677-44bd-4a11-99e2-595d5e17d2ee" vcpus="2"/>
+  <QubesTemplateHVm autostart="False" backup_content="True" backup_path="vm-templates/test-hvmtemplate" backup_size="32768" conf_file="test-hvmtemplate.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/vm-templates/test-hvmtemplate" dispvm_netvm="6" drive="None" firewall_conf="firewall.xml" guiagent_installed="False" include_in_backups="True" installed_by_rpm="False" internal="False" label="green" memory="512" name="test-hvmtemplate" netvm_qid="6" pci_e820_host="True" pci_strictreset="True" pcidevs="[]" pool_name="default" qid="21" qrexec_installed="False" qrexec_timeout="60" seamless_gui_mode="False" services="{'meminfo-writer': False}" template_qid="none" timezone="localtime" uses_default_dispvm_netvm="True" uses_default_netvm="True" uuid="bcba2650-1854-4c84-b1b3-082a48d93366" vcpus="2"/>
+  <QubesHVm autostart="False" backup_content="True" backup_path="appvms/test-template-based-hvm" backup_size="24576" conf_file="test-template-based-hvm.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/appvms/test-template-based-hvm" dispvm_netvm="6" drive="None" firewall_conf="firewall.xml" guiagent_installed="False" include_in_backups="True" installed_by_rpm="False" internal="False" label="red" memory="512" name="test-template-based-hvm" netvm_qid="6" pci_e820_host="True" pci_strictreset="True" pcidevs="[]" pool_name="default" qid="22" qrexec_installed="False" qrexec_timeout="60" seamless_gui_mode="False" services="{'meminfo-writer': False}" template_qid="21" timezone="localtime" uses_default_dispvm_netvm="True" uses_default_netvm="True" uuid="39c5f6bf-ab27-4d75-8b3f-d436833cff26" vcpus="2"/>
+  <QubesNetVm autostart="False" backup_content="True" backup_path="servicevms/test-net" backup_size="68059136" conf_file="test-net.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/servicevms/test-net" dispvm_netvm="none" firewall_conf="firewall.xml" include_in_backups="True" installed_by_rpm="False" internal="False" kernel="4.4.14-11" kernelopts="nopat" label="red" maxmem="2006" memory="300" name="test-net" netid="5" pci_e820_host="True" pci_strictreset="False" pcidevs="[]" pool_name="default" qid="23" qrexec_timeout="60" services="{'meminfo-writer': True}" template_qid="1" uses_default_dispvm_netvm="True" uses_default_kernel="True" uses_default_kernelopts="True" uuid="30865f52-5574-42c6-b3e1-500dc1d320ac" vcpus="2"/>
+</QubesVmCollection>
+'''
+
 QUBESXML_R2B2 = '''
 <QubesVmCollection updatevm="3" default_kernel="3.7.6-2" default_netvm="3" default_fw_netvm="2" default_template="1" clockvm="2">
   <QubesTemplateVm installed_by_rpm="True" kernel="3.7.6-2" uses_default_kernelopts="True" qid="1" include_in_backups="True" uses_default_kernel="True" qrexec_timeout="60" internal="False" conf_file="fedora-18-x64.conf" label="black" template_qid="none" kernelopts="" memory="400" default_user="user" netvm_qid="3" uses_default_netvm="True" volatile_img="volatile.img" services="{'meminfo-writer': True}" maxmem="1535" pcidevs="[]" name="fedora-18-x64" private_img="private.img" vcpus="2" root_img="root.img" debug="False" dir_path="/var/lib/qubes/vm-templates/fedora-18-x64"/>
@@ -81,6 +110,18 @@ MANGLED_SUBDIRS_R2 = {
     "test-standalonevm": "vm11",
     "test-testproxy": "vm12",
     "test-testhvm": "vm14",
+}
+
+MANGLED_SUBDIRS_R32 = {
+    "test-work": "vm15",
+    "test-template-clone": "vm17",
+    "test-custom-template-appvm": "vm18",
+    "test-standalonevm": "vm16",
+    "test-testproxy": "vm19",
+    "test-testhvm": "vm20",
+    "test-hvmtemplate": "vm21",
+    "test-template-based-hvm": "vm22",
+    "test-net": "vm23",
 }
 
 APPTEMPLATE_R2B2 = '''
@@ -133,6 +174,37 @@ X-Qubes-VmName=%VMNAME%
 Icon=%VMDIR%/icon.png
 '''
 
+APPTEMPLATE_HVM_START_R32 = '''[Desktop Entry]
+Version=1.0
+Type=Application
+Exec=qvm-start --quiet --tray %VMNAME%
+Icon=%XDGICON%
+Terminal=false
+Name=%VMNAME%: Start
+GenericName=%VMNAME%: Start
+StartupNotify=false
+Categories=System;X-Qubes-VM;
+'''
+
+APPTEMPLATE_APPMENU_SELECT_R32 = '''[Desktop Entry]
+Version=1.0
+Type=Application
+Exec=qubes-vm-settings %VMNAME% applications
+Icon=qubes-appmenu-select
+Terminal=false
+Name=%VMNAME%: Add more shortcuts...
+GenericName=%VMNAME%: Add more shortcuts...
+StartupNotify=false
+Categories=System;X-Qubes-VM;
+'''
+
+APPTEMPLATE_DIR_R32 = '''[Desktop Entry]
+Encoding=UTF-8
+Type=Directory
+Icon=%XDGICON%
+Name=%VMTYPE%: %VMNAME%
+'''
+
 QUBESXML_R1 = '''<?xml version='1.0' encoding='UTF-8'?>
 <QubesVmCollection clockvm="2" default_fw_netvm="2" default_kernel="3.2.7-10" default_netvm="3" default_template="1" updatevm="3"><QubesTemplateVm conf_file="fedora-17-x64.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/vm-templates/fedora-17-x64" include_in_backups="True" installed_by_rpm="True" internal="False" kernel="3.2.7-10" kernelopts="" label="gray" maxmem="4063" memory="400" name="fedora-17-x64" netvm_qid="3" pcidevs="[]" private_img="private.img" qid="1" root_img="root.img" services="{&apos;meminfo-writer&apos;: True}" template_qid="none" uses_default_kernel="True" uses_default_kernelopts="True" uses_default_netvm="True" vcpus="2" volatile_img="volatile.img" /><QubesNetVm conf_file="netvm.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/servicevms/netvm" include_in_backups="True" installed_by_rpm="False" internal="False" kernel="3.2.7-10" kernelopts="iommu=soft swiotlb=2048" label="red" maxmem="4063" memory="200" name="netvm" netid="1" pcidevs="[&apos;00:19.0&apos;, &apos;03:00.0&apos;]" private_img="private.img" qid="2" root_img="root.img" services="{&apos;ntpd&apos;: False, &apos;meminfo-writer&apos;: False}" template_qid="1" uses_default_kernel="True" uses_default_kernelopts="True" vcpus="2" volatile_img="volatile.img" /><QubesProxyVm conf_file="firewallvm.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/servicevms/firewallvm" include_in_backups="True" installed_by_rpm="False" internal="False" kernel="3.2.7-10" kernelopts="" label="green" maxmem="4063" memory="200" name="firewallvm" netid="2" netvm_qid="2" pcidevs="[]" private_img="private.img" qid="3" root_img="root.img" services="{&apos;meminfo-writer&apos;: True}" template_qid="1" uses_default_kernel="True" uses_default_kernelopts="True" vcpus="2" volatile_img="volatile.img" /><QubesAppVm conf_file="fedora-17-x64-dvm.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/appvms/fedora-17-x64-dvm" include_in_backups="True" installed_by_rpm="False" internal="True" kernel="3.2.7-10" kernelopts="" label="gray" maxmem="4063" memory="400" name="fedora-17-x64-dvm" netvm_qid="3" pcidevs="[]" private_img="private.img" qid="4" root_img="root.img" services="{&apos;meminfo-writer&apos;: True}" template_qid="1" uses_default_kernel="True" uses_default_kernelopts="True" uses_default_netvm="True" vcpus="1" volatile_img="volatile.img" /><QubesAppVm conf_file="test-work.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/appvms/test-work" include_in_backups="True" installed_by_rpm="False" internal="False" kernel="3.2.7-10" kernelopts="" label="green" maxmem="4063" memory="400" name="test-work" netvm_qid="3" pcidevs="[]" private_img="private.img" qid="5" root_img="root.img" services="{&apos;meminfo-writer&apos;: True}" template_qid="1" uses_default_kernel="True" uses_default_kernelopts="True" uses_default_netvm="True" vcpus="2" volatile_img="volatile.img" /><QubesAppVm conf_file="personal.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/appvms/personal" include_in_backups="True" installed_by_rpm="False" internal="False" kernel="3.2.7-10" kernelopts="" label="yellow" maxmem="4063" memory="400" name="personal" netvm_qid="3" pcidevs="[]" private_img="private.img" qid="6" root_img="root.img" services="{&apos;meminfo-writer&apos;: True}" template_qid="1" uses_default_kernel="True" uses_default_kernelopts="True" uses_default_netvm="True" vcpus="2" volatile_img="volatile.img" /><QubesAppVm conf_file="banking.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/appvms/banking" include_in_backups="True" installed_by_rpm="False" internal="False" kernel="3.2.7-10" kernelopts="" label="green" maxmem="4063" memory="400" name="banking" netvm_qid="3" pcidevs="[]" private_img="private.img" qid="7" root_img="root.img" services="{&apos;meminfo-writer&apos;: True}" template_qid="1" uses_default_kernel="True" uses_default_kernelopts="True" uses_default_netvm="True" vcpus="2" volatile_img="volatile.img" /><QubesAppVm conf_file="untrusted.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/appvms/untrusted" include_in_backups="True" installed_by_rpm="False" internal="False" kernel="3.2.7-10" kernelopts="" label="red" maxmem="4063" memory="400" name="untrusted" netvm_qid="3" pcidevs="[]" private_img="private.img" qid="8" root_img="root.img" services="{&apos;meminfo-writer&apos;: True}" template_qid="1" uses_default_kernel="True" uses_default_kernelopts="True" uses_default_netvm="True" vcpus="2" volatile_img="volatile.img" /><QubesAppVm conf_file="test-standalonevm.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/appvms/test-standalonevm" include_in_backups="True" installed_by_rpm="False" internal="False" kernel="None" kernelopts="" label="red" maxmem="4063" memory="400" name="test-standalonevm" netvm_qid="3" pcidevs="[]" private_img="private.img" qid="9" root_img="root.img" services="{&apos;meminfo-writer&apos;: True}" template_qid="none" uses_default_kernel="False" uses_default_kernelopts="True" uses_default_netvm="True" vcpus="2" volatile_img="volatile.img" /><QubesAppVm conf_file="test-testvm.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/appvms/test-testvm" include_in_backups="True" installed_by_rpm="False" internal="False" kernel="3.2.7-10" kernelopts="" label="red" mac="00:16:3E:5E:6C:55" maxmem="4063" memory="400" name="test-testvm" netvm_qid="3" pcidevs="[]" private_img="private.img" qid="10" root_img="root.img" services="{&apos;meminfo-writer&apos;: True}" template_qid="1" uses_default_kernel="True" uses_default_kernelopts="True" uses_default_netvm="True" vcpus="2" volatile_img="volatile.img" /><QubesTemplateVm conf_file="test-template-clone.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/vm-templates/test-template-clone" include_in_backups="True" installed_by_rpm="False" internal="False" kernel="3.2.7-10" kernelopts="" label="gray" maxmem="4063" memory="400" name="test-template-clone" netvm_qid="3" pcidevs="[]" private_img="private.img" qid="11" root_img="root.img" services="{&apos;meminfo-writer&apos;: True}" template_qid="none" uses_default_kernel="True" uses_default_kernelopts="True" uses_default_netvm="True" vcpus="2" volatile_img="volatile.img" /><QubesAppVm conf_file="test-custom-template-appvm.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/appvms/test-custom-template-appvm" include_in_backups="True" installed_by_rpm="False" internal="False" kernel="3.2.7-10" kernelopts="" label="yellow" maxmem="4063" memory="400" name="test-custom-template-appvm" netvm_qid="3" pcidevs="[]" private_img="private.img" qid="12" root_img="root.img" services="{&apos;meminfo-writer&apos;: True}" template_qid="11" uses_default_kernel="True" uses_default_kernelopts="True" uses_default_netvm="True" vcpus="2" volatile_img="volatile.img" /><QubesProxyVm conf_file="test-testproxy.conf" debug="False" default_user="user" dir_path="/var/lib/qubes/servicevms/test-testproxy" include_in_backups="True" installed_by_rpm="False" internal="False" kernel="3.2.7-10" kernelopts="" label="yellow" maxmem="4063" memory="200" name="test-testproxy" netid="3" netvm_qid="2" pcidevs="[]" private_img="private.img" qid="13" root_img="root.img" services="{&apos;meminfo-writer&apos;: True}" template_qid="1" uses_default_kernel="True" uses_default_kernelopts="True" vcpus="2" volatile_img="volatile.img" /></QubesVmCollection>
 '''
@@ -144,6 +216,14 @@ encrypted={encrypted}
 compressed={compressed}
 compression-filter=gzip
 '''
+
+BACKUP_HEADER_R32 = '''version=3
+hmac-algorithm=SHA512
+crypto-algorithm=aes-256-cbc
+encrypted={encrypted}
+compressed={compressed}
+{compression_filter}'''
+
 
 class TC_00_BackupCompatibility(qubes.tests.BackupTestsMixin, qubes.tests.QubesTestCase):
     def tearDown(self):
@@ -198,12 +278,36 @@ class TC_00_BackupCompatibility(qubes.tests.BackupTestsMixin, qubes.tests.QubesT
     def fullpath(self, name):
         return os.path.join(self.backupdir, name)
 
-    def create_v1_files(self, r2b2=False):
+    def create_files(self, version=1):
+        '''Create files for a backup. Versions:
+         - 1: Qubes R1 (backup format v1)
+         - 2: Qubes R2 (backup format v3)
+         - 3: Qubes R3.2 (backup format v3)
+         '''
+
         appmenus_list = [
             "firefox", "gnome-terminal", "evince", "evolution",
             "mozilla-thunderbird", "libreoffice-startcenter", "nautilus",
             "gedit", "gpk-update-viewer", "gpk-application"
         ]
+        appmenus_whitelist_template = appmenus_list
+        if version >= 3:
+            appmenus_list.remove('libreoffice-startcenter')
+            appmenus_list.remove('gnome-terminal')
+            appmenus_list.remove('nautilus')
+            appmenus_list.remove('gedit')
+            appmenus_list.remove('gpk-application')
+            appmenus_list.extend([
+                'org.gnome.Terminal',
+                'org.gnome.Nautilus',
+                'org.gnome.gedit',
+                'org.gnome.Software',
+                'gnome-control-center'])
+            appmenus_whitelist_template = [
+                'org.gnome.Software',
+                'org.gnome.Terminal',
+                'gnome-control-center',
+                'gpk-update-viewer']
 
         os.mkdir(self.fullpath("appvms"))
         os.mkdir(self.fullpath("servicevms"))
@@ -213,16 +317,24 @@ class TC_00_BackupCompatibility(qubes.tests.BackupTestsMixin, qubes.tests.QubesT
         os.mkdir(self.fullpath("appvms/test-work"))
         self.create_whitelisted_appmenus(self.fullpath(
             "appvms/test-work/whitelisted-appmenus.list"))
-        os.symlink("/usr/share/qubes/icons/green.png",
+        if version >= 3:
+            shutil.copy("/usr/share/qubes/icons/green.png",
                    self.fullpath("appvms/test-work/icon.png"))
+        else:
+            os.symlink("/usr/share/qubes/icons/green.png",
+                       self.fullpath("appvms/test-work/icon.png"))
         self.create_private_img(self.fullpath("appvms/test-work/private.img"))
 
         # StandaloneVM
         os.mkdir(self.fullpath("appvms/test-standalonevm"))
         self.create_whitelisted_appmenus(self.fullpath(
             "appvms/test-standalonevm/whitelisted-appmenus.list"))
-        os.symlink("/usr/share/qubes/icons/blue.png",
-                   self.fullpath("appvms/test-standalonevm/icon.png"))
+        if version >= 3:
+            shutil.copy("/usr/share/qubes/icons/blue.png",
+                       self.fullpath("appvms/test-standalonevm/icon.png"))
+        else:
+            os.symlink("/usr/share/qubes/icons/blue.png",
+                       self.fullpath("appvms/test-standalonevm/icon.png"))
         self.create_private_img(self.fullpath(
             "appvms/test-standalonevm/private.img"))
         self.create_sparse(
@@ -245,10 +357,22 @@ class TC_00_BackupCompatibility(qubes.tests.BackupTestsMixin, qubes.tests.QubesT
                         self.fullpath("appvms/test-custom-template-appvm")])
 
         # HVM
-        if r2b2:
-            subprocess.check_call(
-                ["/bin/cp", "-a", self.fullpath("appvms/test-standalonevm"),
-                            self.fullpath("appvms/test-testhvm")])
+        if version >= 2:
+            os.mkdir(self.fullpath("appvms/test-testhvm"))
+            for filedir in ['icon.png', 'apps.templates', 'private.img',
+                    'root.img']:
+                subprocess.check_call(
+                    ["/bin/cp", "-a",
+                        self.fullpath("appvms/test-standalonevm/" + filedir),
+                        self.fullpath("appvms/test-testhvm/" + filedir)])
+
+        # HVM based on a template
+        if version >= 3:
+            os.mkdir(self.fullpath("appvms/test-template-based-hvm"))
+            self.create_private_img(
+                self.fullpath("appvms/test-template-based-hvm/private.img"))
+            shutil.copy("/usr/share/qubes/icons/red.png",
+                self.fullpath("appvms/test-template-based-hvm/icon.png"))
 
         # ProxyVM
         os.mkdir(self.fullpath("servicevms/test-testproxy"))
@@ -256,6 +380,11 @@ class TC_00_BackupCompatibility(qubes.tests.BackupTestsMixin, qubes.tests.QubesT
             "servicevms/test-testproxy/whitelisted-appmenus.list"))
         self.create_private_img(
             self.fullpath("servicevms/test-testproxy/private.img"))
+
+        if version >= 3:
+            subprocess.check_call(
+                ["/bin/cp", "-a", self.fullpath("servicevms/test-testproxy"),
+                    self.fullpath("servicevms/test-net")])
 
         # Custom template
         os.mkdir(self.fullpath("vm-templates/test-template-clone"))
@@ -276,15 +405,20 @@ class TC_00_BackupCompatibility(qubes.tests.BackupTestsMixin, qubes.tests.QubesT
             "-C", self.fullpath("vm-templates/test-template-clone"),
             "volatile.img"])
         self.create_whitelisted_appmenus(self.fullpath(
-            "vm-templates/test-template-clone/whitelisted-appmenus.list"))
+            "vm-templates/test-template-clone/whitelisted-appmenus.list"),
+            appmenus_whitelist_template)
         self.create_whitelisted_appmenus(self.fullpath(
             "vm-templates/test-template-clone/vm-whitelisted-appmenus.list"))
-        if r2b2:
+        if version >= 2:
             self.create_whitelisted_appmenus(self.fullpath(
                 "vm-templates/test-template-clone/netvm-whitelisted-appmenus"
                 ".list"))
-        os.symlink("/usr/share/qubes/icons/green.png",
-                   self.fullpath("vm-templates/test-template-clone/icon.png"))
+        if version >= 3:
+            shutil.copy("/usr/share/qubes/icons/green.png",
+                       self.fullpath("vm-templates/test-template-clone/icon.png"))
+        else:
+            os.symlink("/usr/share/qubes/icons/green.png",
+                       self.fullpath("vm-templates/test-template-clone/icon.png"))
         os.mkdir(
             self.fullpath("vm-templates/test-template-clone/apps.templates"))
         self.create_appmenus(
@@ -297,7 +431,106 @@ class TC_00_BackupCompatibility(qubes.tests.BackupTestsMixin, qubes.tests.QubesT
             APPTEMPLATE_R2B2.replace("%VMNAME%", "test-template-clone")
             .replace("%VMDIR%", self.fullpath(
                 "vm-templates/test-template-clone")),
-            appmenus_list)
+            appmenus_whitelist_template,
+            'test-template-clone-')
+        with open(self.fullpath(
+                "vm-templates/test-template-clone/apps/test-template-clone"
+                "-vm.directory"), 'w') as f:
+            f.write(APPTEMPLATE_DIR_R32.
+                replace('%VMNAME', 'test-template-clone').
+                replace('%XDGICON%', 'appvm-black').
+                replace('%VMTYPE%', 'Template'))
+        with open(self.fullpath(
+                "vm-templates/test-template-clone/apps/test-template-clone"
+                "-qubes-appmenu-select.destop"), 'w') as f:
+            f.write(APPTEMPLATE_APPMENU_SELECT_R32.
+                replace('%VMNAME', 'test-template-clone').
+                replace('%XDGICON%', 'appvm-black').
+                replace('%VMTYPE%', 'Template'))
+        open(self.fullpath(
+                "vm-templates/test-template-clone/test-template-clone.conf"),
+            'w').close()
+
+        if version >= 3:
+            os.mkdir(self.fullpath(
+                "vm-templates/test-template-clone/apps.tempicons"))
+            for icon in appmenus_list:
+                shutil.copy("/usr/share/icons/hicolor/48x48/apps/qubes.png",
+                    self.fullpath(
+                        "vm-templates/test-template-clone/apps.tempicons/"
+                        "{}.png".format(icon)))
+
+            os.mkdir(self.fullpath(
+                "vm-templates/test-template-clone/apps.icons"))
+            for icon in ['org.gnome.Software', 'org.gnome.Terminal',
+                    'gpk-update-viewer']:
+                shutil.copy("/usr/share/icons/hicolor/48x48/apps/qubes.png",
+                    self.fullpath(
+                        "vm-templates/test-template-clone/apps.tempicons/"
+                        "{}.png".format(icon)))
+
+
+
+        # HVM template
+        if version >= 3:
+            os.mkdir(self.fullpath('vm-templates/test-hvmtemplate'))
+            shutil.copy("/usr/share/qubes/icons/green.png",
+                       self.fullpath("vm-templates/test-hvmtemplate/icon.png"))
+            self.create_private_img(
+                self.fullpath("vm-templates/test-hvmtemplate/private.img"))
+            self.create_sparse(self.fullpath(
+                "vm-templates/test-hvmtemplate/root-cow.img"), 10 * 2 ** 30)
+            self.create_sparse(self.fullpath(
+                "vm-templates/test-hvmtemplate/root.img"), 10 * 2 ** 30)
+            self.fill_image(self.fullpath(
+                "vm-templates/test-hvmtemplate/root.img"), 1 * 2 ** 30, True)
+            self.create_volatile_img(self.fullpath(
+                "vm-templates/test-hvmtemplate/volatile.img"))
+            open(self.fullpath(
+                    "vm-templates/test-hvmtemplate/test-hvmtemplate.conf"),
+                'w').close()  # TODO
+            os.mkdir(self.fullpath(
+                    "vm-templates/test-hvmtemplate/apps.templates"))
+            with open(self.fullpath(
+                    "vm-templates/test-hvmtemplate/apps.templates/qubes-start"
+                    ".desktop"), 'w') as f:
+                f.write(APPTEMPLATE_HVM_START_R32)
+            os.mkdir(
+                self.fullpath("vm-templates/test-hvmtemplate/apps"))
+            with open(self.fullpath(
+                    "vm-templates/test-hvmtemplate/apps/test-hvmtemplate"
+                    "-vm.directory"), 'w') as f:
+                f.write(APPTEMPLATE_DIR_R32.
+                    replace('%VMNAME', 'test-hvmtemplate').
+                    replace('%XDGICON%', 'appvm-green').
+                    replace('%VMTYPE%', 'Template'))
+            with open(self.fullpath(
+                    "vm-templates/test-hvmtemplate/apps/test-hvmtemplate"
+                    "-qubes-appmenu-select.destop"), 'w') as f:
+                f.write(APPTEMPLATE_APPMENU_SELECT_R32.
+                    replace('%VMNAME', 'test-hvmtemplate').
+                    replace('%XDGICON%', 'appvm-green').
+                    replace('%VMTYPE%', 'Template'))
+            with open(self.fullpath(
+                    "vm-templates/test-hvmtemplate/apps/test-hvmtemplate"
+                    "-qubes-start.destop"), 'w') as f:
+                f.write(APPTEMPLATE_HVM_START_R32.
+                    replace('%VMNAME', 'test-hvmtemplate').
+                    replace('%XDGICON%', 'appvm-green').
+                    replace('%VMTYPE%', 'Template'))
+
+        if version >= 3:
+            os.mkdir(self.fullpath('dom0-home'))
+            os.mkdir(self.fullpath('dom0-home/user'))
+            os.mkdir(self.fullpath('dom0-home/user/Desktop'))
+            with open(self.fullpath('dom0-home/user/Desktop/some-file.txt'),
+                    'w') as f:
+                f.write('This is test\n')
+            os.mkdir(self.fullpath('dom0-home/user/Documents'))
+            with open(self.fullpath(
+                    'dom0-home/user/Documents/another-file.txt'),
+                    'w') as f:
+                f.write('This is test\n')
 
     def calculate_hmac(self, f_name, algorithm="sha512", password="qubes"):
         subprocess.check_call(["openssl", "dgst", "-"+algorithm, "-hmac",
@@ -392,7 +625,7 @@ class TC_00_BackupCompatibility(qubes.tests.BackupTestsMixin, qubes.tests.QubesT
         self.handle_v3_file("qubes.xml", "", output, encrypted=encrypted,
                             compressed=compressed)
 
-        self.create_v1_files(r2b2=True)
+        self.create_files(version=2)
         for vm_type in ["appvms", "servicevms"]:
             for vm_name in os.listdir(self.fullpath(vm_type)):
                 vm_dir = os.path.join(vm_type, vm_name)
@@ -418,8 +651,73 @@ class TC_00_BackupCompatibility(qubes.tests.BackupTestsMixin, qubes.tests.QubesT
 
         output.close()
 
+    def create_v3_backup_r32(self, compressed=False, encrypted=False,
+            custom_header=None, custom_qubes_xml=None):
+        # this is intentionally mostly duplicate of create_v3_backup
+
+        output = open(self.fullpath("backup.bin"), "w")
+        with open(self.fullpath("backup-header"), "w") as f:
+            if custom_header is not None:
+                f.write(custom_header)
+            else:
+                f.write(BACKUP_HEADER_R32.format(
+                    encrypted=str(encrypted),
+                    compressed=str(compressed),
+                    compression_filter=(
+                        'compression-filter=gzip\n' if compressed else '')
+                ))
+        self.calculate_hmac("backup-header")
+        self.append_backup_stream("backup-header", output)
+        self.append_backup_stream("backup-header.hmac", output)
+
+        with open(self.fullpath("qubes.xml"), "w") as f:
+            if custom_qubes_xml is not None:
+                f.write(custom_qubes_xml)
+            else:
+                if encrypted:
+                    qubesxml = QUBESXML_R32
+                    for vmname, subdir in MANGLED_SUBDIRS_R32.items():
+                        qubesxml = re.sub(r"[a-z-]*/{}".format(vmname),
+                                          subdir, qubesxml)
+                    f.write(qubesxml)
+                else:
+                    f.write(QUBESXML_R32)
+
+        self.handle_v3_file("qubes.xml", "", output, encrypted=encrypted,
+                            compressed=compressed)
+
+        self.create_files(version=3)
+        for vm_type in ["appvms", "servicevms"]:
+            for vm_name in os.listdir(self.fullpath(vm_type)):
+                vm_dir = os.path.join(vm_type, vm_name)
+                for f_name in os.listdir(self.fullpath(vm_dir)):
+                    if encrypted:
+                        subdir = MANGLED_SUBDIRS_R32[vm_name]
+                    else:
+                        subdir = vm_dir
+                    self.handle_v3_file(
+                        os.path.join(vm_dir, f_name),
+                        subdir+'/', output, encrypted=encrypted,
+                        compressed=compressed)
+
+        for vm_name in os.listdir(self.fullpath("vm-templates")):
+            vm_dir = os.path.join("vm-templates", vm_name)
+            if encrypted:
+                subdir = MANGLED_SUBDIRS_R32[vm_name]
+            else:
+                subdir = vm_dir
+            self.handle_v3_file(
+                os.path.join(vm_dir, "."),
+                subdir+'/', output, encrypted=encrypted, compressed=compressed)
+
+        self.handle_v3_file(
+            os.path.join('dom0-home', 'user', "."),
+            'dom0-home/', output, encrypted=encrypted, compressed=compressed)
+
+
+
     def test_100_r1(self):
-        self.create_v1_files(r2b2=False)
+        self.create_files(version=1)
 
         f = open(self.fullpath("qubes.xml"), "w")
         f.write(QUBESXML_R1)
@@ -440,7 +738,7 @@ class TC_00_BackupCompatibility(qubes.tests.BackupTestsMixin, qubes.tests.QubesT
                          self.qc.get_vm_by_name("test-template-clone"))
 
     def test_200_r2b2(self):
-        self.create_v1_files(r2b2=True)
+        self.create_files(version=2)
 
         f = open(self.fullpath("qubes.xml"), "w")
         f.write(QUBESXML_R2B2)
@@ -496,3 +794,55 @@ class TC_00_BackupCompatibility(qubes.tests.BackupTestsMixin, qubes.tests.QubesT
         self.assertEqual(self.qc.get_vm_by_name("test-custom-template-appvm")
                          .template,
                          self.qc.get_vm_by_name("test-template-clone"))
+
+    def assertCorrectlyRestoredR32(self):
+        self.assertIsNotNone(self.qc.get_vm_by_name("test-template-clone"))
+        self.assertIsNotNone(self.qc.get_vm_by_name("test-testproxy"))
+        self.assertIsNotNone(self.qc.get_vm_by_name("test-net"))
+        self.assertIsNotNone(self.qc.get_vm_by_name("test-work"))
+        self.assertIsNotNone(self.qc.get_vm_by_name("test-testhvm"))
+        self.assertIsNotNone(self.qc.get_vm_by_name("test-hvmtemplate"))
+        self.assertIsNotNone(self.qc.get_vm_by_name("test-template-based-hvm"))
+        self.assertIsNotNone(self.qc.get_vm_by_name("test-standalonevm"))
+        self.assertIsNotNone(self.qc.get_vm_by_name(
+            "test-custom-template-appvm"))
+        self.assertEqual(self.qc.get_vm_by_name("test-custom-template-appvm")
+                         .template,
+                         self.qc.get_vm_by_name("test-template-clone"))
+        self.assertEqual(self.qc.get_vm_by_name("test-template-based-hvm")
+                         .template,
+                         self.qc.get_vm_by_name("test-hvmtemplate"))
+        self.assertEqual(self.qc.get_vm_by_name("test-work").netvm,
+            self.qc.get_vm_by_name("test-net"))
+        self.assertEqual(self.qc.get_vm_by_name("test-work").dispvm_netvm,
+            self.qc.get_vm_by_name("test-testproxy"))
+
+    def test_300_r32(self):
+        self.create_v3_backup_r32(compressed=False, encrypted=False)
+
+        self.restore_backup(self.fullpath("backup.bin"), options={
+            'use-default-template': True,
+            'use-default-netvm': True,
+            'dom0-home': False,  # TODO
+        })
+        self.assertCorrectlyRestoredR32()
+
+    def test_301_r32_compressed(self):
+        self.create_v3_backup_r32(compressed=True, encrypted=False)
+
+        self.restore_backup(self.fullpath("backup.bin"), options={
+            'use-default-template': True,
+            'use-default-netvm': True,
+            'dom0-home': False,  # TODO
+        })
+        self.assertCorrectlyRestoredR32()
+
+    def test_302_r32_encrypted_compressed(self):
+        self.create_v3_backup_r32(compressed=True, encrypted=True)
+
+        self.restore_backup(self.fullpath("backup.bin"), options={
+            'use-default-template': True,
+            'use-default-netvm': True,
+            'dom0-home': False,  # TODO
+        })
+        self.assertCorrectlyRestoredR32()


### PR DESCRIPTION
Introduce qvm-backup-restore --paranoid-mode option for:
   - disable dom0 home restore
   - reject compressed backups
   - reject old backup formats (Qubes R2 and older)
   - more strict validation of VM names (for example don't allow '..' in it)
   - do not restore firewall rules, attached PCI devices, attached block devices, menu entries

See QubesOS/qubes-issues#2737 for details.