### PR TITLE
Fix regex error preventing USB hubs from working

### DIFF
--- a/core/qubesutils.py
+++ b/core/qubesutils.py
@@ -469,7 +469,7 @@ def block_detach_all(vm):
 ####### USB devices ######
 
 usb_ver_re = re.compile(r"^(1|2)$")
-usb_device_re = re.compile(r"^[0-9]+-[0-9]+(_[0-9]+)?$")
+usb_device_re = re.compile(r"^[0-9]+-[0-9]+(_[0-9]+)*$")
 usb_port_re = re.compile(r"^$|^[0-9]+-[0-9]+(\.[0-9]+)?$")
 usb_desc_re = re.compile(r"^[ -~]{1,255}$")
 # should match valid VM name


### PR DESCRIPTION
On my machine, attaching a device to a USB hub results in a device name such as "5-4_1_1".  This fails to match a regex in qubesutils.py, which only expects one "_1" component.

With this change, qvm-usb and USB passthrough work as expected for me.  I don't know enough about qubes/Xen to exhaustively test if there are any unintended consequences for other use cases.
