### PR TITLE
qubes: admin extension

### DIFF
--- a/qubes/ext/admin.py
+++ b/qubes/ext/admin.py
@@ -29,6 +29,8 @@ class AdminExtension(qubes.ext.Extension):
         '''Forbid changing specific tags'''
         # pylint: disable=no-self-use,unused-argument
         if arg.startswith('created-by-'):
-            raise qubes.api.PermissionDenied()
+            raise qubes.api.PermissionDenied(
+                'changing this tag is prohibited by {}.{}'.format(
+                    __name__, type(self).__name__))
 
-    # TODO create that extension in the first place
+    # TODO create that tag here (need to figure out how to pass mgmtvm name)

--- a/qubes/ext/admin.py
+++ b/qubes/ext/admin.py
@@ -1,0 +1,34 @@
+# -*- encoding: utf8 -*-
+#
+# The Qubes OS Project, http://www.qubes-os.org
+#
+# Copyright (C) 2017 Wojtek Porczyk <woju@invisiblethingslab.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+import qubes.api
+import qubes.ext
+
+class AdminExtension(qubes.ext.Extension):
+    # pylint: disable=too-few-public-methods
+    @qubes.ext.handler(
+        'mgmt-permission:admin.vm.tag.Set',
+        'mgmt-permission:admin.vm.tag.Remove')
+    def on_tag_set_or_remove(self, vm, event, arg, **kwargs):
+        '''Forbid changing specific tags'''
+        # pylint: disable=no-self-use,unused-argument
+        if arg.startswith('created-by-'):
+            raise qubes.api.PermissionDenied()
+
+    # TODO create that extension in the first place

--- a/rpm_spec/core-dom0.spec
+++ b/rpm_spec/core-dom0.spec
@@ -285,6 +285,7 @@ fi
 %dir %{python3_sitelib}/qubes/ext/__pycache__
 %{python3_sitelib}/qubes/ext/__pycache__/*
 %{python3_sitelib}/qubes/ext/__init__.py
+%{python3_sitelib}/qubes/ext/admin.py
 %{python3_sitelib}/qubes/ext/block.py
 %{python3_sitelib}/qubes/ext/core_features.py
 %{python3_sitelib}/qubes/ext/gui.py

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ if __name__ == '__main__':
                 'DispVM = qubes.vm.dispvm:DispVM',
             ],
             'qubes.ext': [
+                'qubes.ext.admin = qubes.ext.admin:AdminExtension',
                 'qubes.ext.core_features = qubes.ext.core_features:CoreFeatures',
                 'qubes.ext.qubesmanager = qubes.ext.qubesmanager:QubesManager',
                 'qubes.ext.gui = qubes.ext.gui:GUI',


### PR DESCRIPTION
forbid mangling `created-by-<vm>` tags