### PR TITLE
Add support for asynchronous event handlers

### DIFF
--- a/contrib/check-events
+++ b/contrib/check-events
@@ -81,7 +81,7 @@ class EventVisitor(ast.NodeVisitor):
             # events this way
             return
 
-        if name.endswith('.fire_event') or name.endswith('.fire_event_pre'):
+        if name.endswith('.fire_event') or name.endswith('.fire_event_async'):
             # here we throw events; event name is the first argument; sometimes
             # it is expressed as 'event-stem:' + some_variable
             eventnode = node.args[0]

--- a/doc/qubes-events.rst
+++ b/doc/qubes-events.rst
@@ -143,6 +143,75 @@ returned to the caller as list. The order of this list is undefined.
    effect = o.fire_event('event1')
 
 
+Asynchronous event handling
+---------------------------
+
+Event handlers can be defined as coroutine. This way they can execute long
+running actions without blocking the whole qubesd process. To define
+asynchronous event handler, annotate a coroutine (a function defined with
+`async def`, or decorated with `py:func:`asyncio.coroutine`) with
+py:func:`qubes.events.handler` decorator. By definition, order of
+such handlers is undefined.
+
+Asynchronous events can be fired using
+:py:meth:`qubes.events.Emitter.fire_event_async` method. It will handle both
+synchronous and asynchronous handlers. It's an error to register asynchronous
+handler (a coroutine) for synchronous event (the one fired with
+:py:meth:`qubes.events.Emitter.fire_event`) - it will result in
+:py:exc:`RuntimeError` exception.
+
+.. code-block:: python
+
+   import asyncio
+   import qubes.events
+
+   class MyClass(qubes.events.Emitter):
+       @qubes.events.handler('event1', 'event2')
+       @asyncio.coroutine
+       def event_handler(self, event):
+           if event == 'event1':
+               print('Got event 1, starting long running action')
+               yield from asyncio.sleep(10)
+               print('Done')
+
+   o = MyClass()
+   loop = asyncio.get_event_loop()
+   loop.run_until_complete(o.fire_event_async('event1'))
+
+Asynchronous event handlers can also return value - but only a collection, not
+yield individual values (because of python limitation):
+
+.. code-block:: python
+
+   import asyncio
+   import qubes.events
+
+   class MyClass(qubes.events.Emitter):
+       @qubes.events.handler('event1')
+       @asyncio.coroutine
+       def event_handler(self, event):
+            print('Got event, starting long running action')
+            yield from asyncio.sleep(10)
+            return ('result1', 'result2')
+
+       @qubes.events.handler('event1')
+       @asyncio.coroutine
+       def another_handler(self, event):
+            print('Got event, starting long running action')
+            yield from asyncio.sleep(10)
+            return ('result3', 'result4')
+
+       @qubes.events.handler('event1')
+       def synchronous_handler(self, event):
+            yield 'sync result'
+
+   o = MyClass()
+   loop = asyncio.get_event_loop()
+   # returns ['sync result', 'result1', 'result2', 'result3', 'result4'],
+   # possibly not in order
+   effects = loop.run_until_complete(o.fire_event_async('event1'))
+
+
 Module contents
 ---------------
 

--- a/doc/qubes-events.rst
+++ b/doc/qubes-events.rst
@@ -22,10 +22,10 @@ parent class and then for it's child. For each class, first are called handlers
 defined in it's source, then handlers from extensions and last the callers added
 manually.
 
-There is second method, :py:meth:`qubes.events.Emitter.fire_event_pre`, which
-fires events in reverse order. It is suitable for events fired before some
-action is performed. You may at your own responsibility raise exceptions from
-such events to try to prevent such action.
+The :py:meth:`qubes.events.Emitter.fire_event` method have keyword argument
+`pre_event`, which fires events in reverse order. It is suitable for events
+fired before some action is performed. You may at your own responsibility raise
+exceptions from such events to try to prevent such action.
 
 Events handlers may yield values. Those values are aggregated and returned
 to the caller as a list of those values. See below for details.

--- a/doc/qubes-events.rst
+++ b/doc/qubes-events.rst
@@ -149,8 +149,8 @@ Asynchronous event handling
 Event handlers can be defined as coroutine. This way they can execute long
 running actions without blocking the whole qubesd process. To define
 asynchronous event handler, annotate a coroutine (a function defined with
-`async def`, or decorated with `py:func:`asyncio.coroutine`) with
-py:func:`qubes.events.handler` decorator. By definition, order of
+`async def`, or decorated with :py:func:`asyncio.coroutine`) with
+:py:func:`qubes.events.handler` decorator. By definition, order of
 such handlers is undefined.
 
 Asynchronous events can be fired using

--- a/qubes/__init__.py
+++ b/qubes/__init__.py
@@ -250,10 +250,12 @@ class property(object):  # pylint: disable=redefined-builtin,invalid-name
             value = self.type(value)
 
         if has_oldvalue:
-            instance.fire_event_pre('property-pre-set:' + self.__name__,
+            instance.fire_event('property-pre-set:' + self.__name__,
+                pre_event=True,
                 name=self.__name__, newvalue=value, oldvalue=oldvalue)
         else:
-            instance.fire_event_pre('property-pre-set:' + self.__name__,
+            instance.fire_event('property-pre-set:' + self.__name__,
+                pre_event=True,
                 name=self.__name__, newvalue=value)
 
         instance._property_init(self, value) # pylint: disable=protected-access
@@ -276,14 +278,16 @@ class property(object):  # pylint: disable=redefined-builtin,invalid-name
             has_oldvalue = False
 
         if has_oldvalue:
-            instance.fire_event_pre('property-pre-del:' + self.__name__,
+            instance.fire_event('property-pre-del:' + self.__name__,
+                pre_event=True,
                 name=self.__name__, oldvalue=oldvalue)
             delattr(instance, self._attr_name)
             instance.fire_event('property-del:' + self.__name__,
                 name=self.__name__, oldvalue=oldvalue)
 
         else:
-            instance.fire_event_pre('property-pre-del:' + self.__name__,
+            instance.fire_event('property-pre-del:' + self.__name__,
+                pre_event=True,
                 name=self.__name__)
             instance.fire_event('property-del:' + self.__name__,
                 name=self.__name__)

--- a/qubes/api/__init__.py
+++ b/qubes/api/__init__.py
@@ -343,12 +343,12 @@ def create_servers(*args, force=False, loop=None, **kwargs):
     '''Create multiple Qubes API servers
 
     :param qubes.Qubes app: the app that is a backend of the servers
-    :param bool force: if :py:obj:`True`, unconditionaly remove existing \
+    :param bool force: if :py:obj:`True`, unconditionally remove existing \
         sockets; if :py:obj:`False`, raise an error if there is some process \
         listening to such socket
     :param asyncio.Loop loop: loop
 
-    *args* are supposed to be classess inheriting from
+    *args* are supposed to be classes inheriting from
     :py:class:`AbstractQubesAPI`
 
     *kwargs* (like *app* or *debug* for example) are passed to

--- a/qubes/api/__init__.py
+++ b/qubes/api/__init__.py
@@ -181,8 +181,8 @@ class AbstractQubesAPI(object):
 
     def fire_event_for_permission(self, **kwargs):
         '''Fire an event on the source qube to check for permission'''
-        return self.src.fire_event_pre('mgmt-permission:' + self.method,
-            dest=self.dest, arg=self.arg, **kwargs)
+        return self.src.fire_event('mgmt-permission:' + self.method,
+            pre_event=True, dest=self.dest, arg=self.arg, **kwargs)
 
     def fire_event_for_filter(self, iterable, **kwargs):
         '''Fire an event on the source qube to filter for permission'''

--- a/qubes/api/admin.py
+++ b/qubes/api/admin.py
@@ -969,7 +969,7 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
         assignment = qubes.devices.DeviceAssignment(
             dev.backend_domain, dev.ident,
             options=options, persistent=persistent)
-        self.dest.devices[devclass].attach(assignment)
+        yield from self.dest.devices[devclass].attach(assignment)
         self.app.save()
 
     @qubes.api.method('admin.vm.device.{endpoint}.Detach', endpoints=(ep.name
@@ -991,7 +991,7 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
 
         assignment = qubes.devices.DeviceAssignment(
             dev.backend_domain, dev.ident)
-        self.dest.devices[devclass].detach(assignment)
+        yield from self.dest.devices[devclass].detach(assignment)
         self.app.save()
 
     @qubes.api.method('admin.vm.firewall.Get', no_payload=True)

--- a/qubes/app.py
+++ b/qubes/app.py
@@ -476,7 +476,7 @@ class VMCollection(object):
         vm = self[key]
         if not vm.is_halted():
             raise qubes.exc.QubesVMNotHaltedError(vm)
-        self.app.fire_event_pre('domain-pre-delete', vm=vm)
+        self.app.fire_event('domain-pre-delete', pre_event=True, vm=vm)
         try:
             vm.libvirt_domain.undefine()
         except libvirt.libvirtError as e:

--- a/qubes/devices.py
+++ b/qubes/devices.py
@@ -24,8 +24,8 @@
 
 Main concept is that some domain main
 expose (potentially multiple) devices, which can be attached to other domains.
-Devices can be of different classes (like 'pci', 'usb', etc). Each device
-class is implemented by an extension.
+Devices can be of different buses (like 'pci', 'usb', etc). Each device
+bus is implemented by an extension.
 
 Devices are identified by pair of (backend domain, `ident`), where `ident` is
 :py:class:`str` and can contain only characters from `[a-zA-Z0-9._-]` set.
@@ -33,13 +33,13 @@ Devices are identified by pair of (backend domain, `ident`), where `ident` is
 Such extension should provide:
  - `qubes.devices` endpoint - a class descendant from
  :py:class:`qubes.devices.DeviceInfo`, designed to hold device description (
- including class-specific properties)
- - handle `device-attach:class` and `device-detach:class` events for
+ including bus-specific properties)
+ - handle `device-attach:bus` and `device-detach:bus` events for
  performing the attach/detach action; events are fired even when domain isn't
  running and extension should be prepared for this
- - handle `device-list:class` event - list devices exposed by particular
+ - handle `device-list:bus` event - list devices exposed by particular
  domain; it should return list of appropriate DeviceInfo objects
- - handle `device-get:class` event - get one device object exposed by this
+ - handle `device-get:bus` event - get one device object exposed by this
  domain of given identifier
  - handle `device-list-attached:class` event - list currently attached
  devices to this domain

--- a/qubes/devices.py
+++ b/qubes/devices.py
@@ -180,7 +180,7 @@ class DeviceCollection(object):
             raise DeviceAlreadyAttached(
                 'device {!s} of class {} already attached to {!s}'.format(
                     device, self._bus, self._vm))
-        self._vm.fire_event_pre('device-pre-attach:'+self._bus,
+        self._vm.fire_event('device-pre-attach:'+self._bus, pre_event=True,
             device=device, options=device_assignment.options)
         if device_assignment.persistent:
             self._set.add(device_assignment)
@@ -208,7 +208,8 @@ class DeviceCollection(object):
                     device_assignment.ident, self._bus, self._vm))
 
         device = device_assignment.device
-        self._vm.fire_event_pre('device-pre-detach:'+self._bus, device=device)
+        self._vm.fire_event('device-pre-detach:' + self._bus,
+            pre_event=True, device=device)
         if device in self._set:
             device_assignment.persistent = True
             self._set.discard(device_assignment)

--- a/qubes/events.py
+++ b/qubes/events.py
@@ -164,7 +164,7 @@ class Emitter(object, metaclass=EmitterMeta):
     def fire_event(self, event, **kwargs):
         '''Call all handlers for an event.
 
-        Handlers are called for class and all parent classess, in **reversed**
+        Handlers are called for class and all parent classes, in **reversed**
         method resolution order. For each class first are called bound handlers
         (specified in class definition), then handlers from extensions. Aside
         from above, remaining order is undefined.
@@ -172,7 +172,7 @@ class Emitter(object, metaclass=EmitterMeta):
         .. seealso::
             :py:meth:`fire_event_pre`
 
-        :param str event: event identificator
+        :param str event: event identifier
         :returns: list of effects
 
         All *kwargs* are passed verbatim. They are different for different
@@ -187,14 +187,14 @@ class Emitter(object, metaclass=EmitterMeta):
     def fire_event_pre(self, event, **kwargs):
         '''Call all handlers for an event.
 
-        Handlers are called for class and all parent classess, in **true**
+        Handlers are called for class and all parent classes, in **true**
         method resolution order. This is intended for ``-pre-`` events, where
         order of invocation should be reversed.
 
         .. seealso::
             :py:meth:`fire_event`
 
-        :param str event: event identificator
+        :param str event: event identifier
         :returns: list of effects
 
         All *kwargs* are passed verbatim. They are different for different

--- a/qubes/tests/__init__.py
+++ b/qubes/tests/__init__.py
@@ -159,6 +159,18 @@ class TestEmitter(qubes.events.Emitter):
         self.fired_events[(event, ev_kwargs)] += 1
         return effects
 
+    @asyncio.coroutine
+    def fire_event_async(self, event, pre_event=False, **kwargs):
+        effects = yield from super(TestEmitter, self).fire_event_async(
+            event, pre_event=pre_event, **kwargs)
+        ev_kwargs = frozenset(
+            (key,
+                frozenset(value.items()) if isinstance(value, dict) else value)
+            for key, value in kwargs.items()
+        )
+        self.fired_events[(event, ev_kwargs)] += 1
+        return effects
+
 
 def expectedFailureIfTemplate(templates):
     """

--- a/qubes/tests/__init__.py
+++ b/qubes/tests/__init__.py
@@ -159,17 +159,6 @@ class TestEmitter(qubes.events.Emitter):
         self.fired_events[(event, ev_kwargs)] += 1
         return effects
 
-    def fire_event_pre(self, event, **kwargs):
-        effects = super(TestEmitter, self).fire_event_pre(event, **kwargs)
-        ev_kwargs = frozenset(
-            (key,
-                frozenset(value.items()) if isinstance(value, dict)
-                else tuple(value) if isinstance(value, list)
-                else value)
-            for key, value in kwargs.items()
-        )
-        self.fired_events[(event, ev_kwargs)] += 1
-        return effects
 
 def expectedFailureIfTemplate(templates):
     """

--- a/qubes/tests/api_admin.py
+++ b/qubes/tests/api_admin.py
@@ -1319,7 +1319,8 @@ class TC_00_VMs(AdminAPITestCase):
     def test_470_vm_device_list_persistent(self):
         assignment = qubes.devices.DeviceAssignment(self.vm, '1234',
             persistent=True)
-        self.vm.devices['testclass'].attach(assignment)
+        self.loop.run_until_complete(
+            self.vm.devices['testclass'].attach(assignment))
         value = self.call_mgmt_func(b'admin.vm.device.testclass.List',
             b'test-vm1')
         self.assertEqual(value,
@@ -1329,10 +1330,12 @@ class TC_00_VMs(AdminAPITestCase):
     def test_471_vm_device_list_persistent_options(self):
         assignment = qubes.devices.DeviceAssignment(self.vm, '1234',
             persistent=True, options={'opt1': 'value'})
-        self.vm.devices['testclass'].attach(assignment)
+        self.loop.run_until_complete(
+            self.vm.devices['testclass'].attach(assignment))
         assignment = qubes.devices.DeviceAssignment(self.vm, '4321',
             persistent=True)
-        self.vm.devices['testclass'].attach(assignment)
+        self.loop.run_until_complete(
+            self.vm.devices['testclass'].attach(assignment))
         value = self.call_mgmt_func(b'admin.vm.device.testclass.List',
             b'test-vm1')
         self.assertEqual(value,
@@ -1360,7 +1363,8 @@ class TC_00_VMs(AdminAPITestCase):
             self.device_list_attached_testclass)
         assignment = qubes.devices.DeviceAssignment(self.vm, '4321',
             persistent=True)
-        self.vm.devices['testclass'].attach(assignment)
+        self.loop.run_until_complete(
+            self.vm.devices['testclass'].attach(assignment))
         value = self.call_mgmt_func(b'admin.vm.device.testclass.List',
             b'test-vm1')
         self.assertEqual(value,
@@ -1373,7 +1377,8 @@ class TC_00_VMs(AdminAPITestCase):
             self.device_list_attached_testclass)
         assignment = qubes.devices.DeviceAssignment(self.vm, '4321',
             persistent=True)
-        self.vm.devices['testclass'].attach(assignment)
+        self.loop.run_until_complete(
+            self.vm.devices['testclass'].attach(assignment))
         value = self.call_mgmt_func(b'admin.vm.device.testclass.List',
             b'test-vm1', b'test-vm1+1234')
         self.assertEqual(value,

--- a/qubes/tests/api_admin.py
+++ b/qubes/tests/api_admin.py
@@ -76,7 +76,6 @@ class AdminAPITestCase(qubes.tests.QubesTestCase):
 
         self.emitter = qubes.tests.TestEmitter()
         self.app.domains[0].fire_event = self.emitter.fire_event
-        self.app.domains[0].fire_event_pre = self.emitter.fire_event_pre
 
     def tearDown(self):
         self.base_dir_patch2.stop()
@@ -1793,8 +1792,6 @@ class TC_00_VMs(AdminAPITestCase):
     def test_590_firewall_reload(self):
         self.vm.firewall.save = unittest.mock.Mock()
         self.app.domains['test-vm1'].fire_event = self.emitter.fire_event
-        self.app.domains['test-vm1'].fire_event_pre = \
-            self.emitter.fire_event_pre
         value = self.call_mgmt_func(b'admin.vm.firewall.Reload',
                 b'test-vm1', b'')
         self.assertIsNone(value)

--- a/qubes/tests/api_admin.py
+++ b/qubes/tests/api_admin.py
@@ -1389,6 +1389,7 @@ class TC_00_VMs(AdminAPITestCase):
         self.vm.add_handler('device-list:testclass', self.device_list_testclass)
         mock_attach = unittest.mock.Mock()
         mock_attach.return_value = None
+        del mock_attach._is_coroutine
         self.vm.add_handler('device-attach:testclass', mock_attach)
         with unittest.mock.patch.object(qubes.vm.qubesvm.QubesVM,
                 'is_halted', lambda _: False):
@@ -1405,6 +1406,7 @@ class TC_00_VMs(AdminAPITestCase):
         self.vm.add_handler('device-list:testclass', self.device_list_testclass)
         mock_attach = unittest.mock.Mock()
         mock_attach.return_value = None
+        del mock_attach._is_coroutine
         self.vm.add_handler('device-attach:testclass', mock_attach)
         with unittest.mock.patch.object(qubes.vm.qubesvm.QubesVM,
                 'is_halted', lambda _: False):
@@ -1420,6 +1422,7 @@ class TC_00_VMs(AdminAPITestCase):
     def test_482_vm_device_attach_not_running(self):
         self.vm.add_handler('device-list:testclass', self.device_list_testclass)
         mock_attach = unittest.mock.Mock()
+        del mock_attach._is_coroutine
         self.vm.add_handler('device-attach:testclass', mock_attach)
         with self.assertRaises(qubes.exc.QubesVMNotRunningError):
             self.call_mgmt_func(b'admin.vm.device.testclass.Attach',
@@ -1432,6 +1435,7 @@ class TC_00_VMs(AdminAPITestCase):
         self.vm.add_handler('device-list:testclass', self.device_list_testclass)
         mock_attach = unittest.mock.Mock()
         mock_attach.return_value = None
+        del mock_attach._is_coroutine
         self.vm.add_handler('device-attach:testclass', mock_attach)
         with unittest.mock.patch.object(qubes.vm.qubesvm.QubesVM,
                 'is_halted', lambda _: False):
@@ -1449,6 +1453,7 @@ class TC_00_VMs(AdminAPITestCase):
         self.vm.add_handler('device-list:testclass', self.device_list_testclass)
         mock_attach = unittest.mock.Mock()
         mock_attach.return_value = None
+        del mock_attach._is_coroutine
         self.vm.add_handler('device-attach:testclass', mock_attach)
         value = self.call_mgmt_func(b'admin.vm.device.testclass.Attach',
             b'test-vm1', b'test-vm1+1234', b'persistent=yes')
@@ -1464,6 +1469,7 @@ class TC_00_VMs(AdminAPITestCase):
         self.vm.add_handler('device-list:testclass', self.device_list_testclass)
         mock_attach = unittest.mock.Mock()
         mock_attach.return_value = None
+        del mock_attach._is_coroutine
         self.vm.add_handler('device-attach:testclass', mock_attach)
         with unittest.mock.patch.object(qubes.vm.qubesvm.QubesVM,
                 'is_halted', lambda _: False):
@@ -1482,6 +1488,7 @@ class TC_00_VMs(AdminAPITestCase):
             self.device_list_attached_testclass)
         mock_detach = unittest.mock.Mock()
         mock_detach.return_value = None
+        del mock_detach._is_coroutine
         self.vm.add_handler('device-detach:testclass', mock_detach)
         with unittest.mock.patch.object(qubes.vm.qubesvm.QubesVM,
                 'is_halted', lambda _: False):
@@ -1495,6 +1502,7 @@ class TC_00_VMs(AdminAPITestCase):
     def test_491_vm_device_detach_not_attached(self):
         mock_detach = unittest.mock.Mock()
         mock_detach.return_value = None
+        del mock_detach._is_coroutine
         self.vm.add_handler('device-detach:testclass', mock_detach)
         with unittest.mock.patch.object(qubes.vm.qubesvm.QubesVM,
                 'is_halted', lambda _: False):

--- a/qubes/tests/devices.py
+++ b/qubes/tests/devices.py
@@ -91,15 +91,15 @@ class TC_00_DeviceCollection(qubes.tests.QubesTestCase):
         self.assertFalse(self.collection._set)
 
     def test_001_attach(self):
-        self.collection.attach(self.assignment)
+        self.loop.run_until_complete(self.collection.attach(self.assignment))
         self.assertEventFired(self.emitter, 'device-pre-attach:testclass')
         self.assertEventFired(self.emitter, 'device-attach:testclass')
         self.assertEventNotFired(self.emitter, 'device-pre-detach:testclass')
         self.assertEventNotFired(self.emitter, 'device-detach:testclass')
 
     def test_002_detach(self):
-        self.collection.attach(self.assignment)
-        self.collection.detach(self.assignment)
+        self.loop.run_until_complete(self.collection.attach(self.assignment))
+        self.loop.run_until_complete(self.collection.detach(self.assignment))
         self.assertEventFired(self.emitter, 'device-pre-attach:testclass')
         self.assertEventFired(self.emitter, 'device-attach:testclass')
         self.assertEventFired(self.emitter, 'device-pre-detach:testclass')
@@ -107,24 +107,27 @@ class TC_00_DeviceCollection(qubes.tests.QubesTestCase):
 
     def test_010_empty_detach(self):
         with self.assertRaises(LookupError):
-            self.collection.detach(self.assignment)
+            self.loop.run_until_complete(
+                self.collection.detach(self.assignment))
 
     def test_011_double_attach(self):
-        self.collection.attach(self.assignment)
+        self.loop.run_until_complete(self.collection.attach(self.assignment))
 
         with self.assertRaises(qubes.devices.DeviceAlreadyAttached):
-            self.collection.attach(self.assignment)
+            self.loop.run_until_complete(
+                self.collection.attach(self.assignment))
 
     def test_012_double_detach(self):
-        self.collection.attach(self.assignment)
-        self.collection.detach(self.assignment)
+        self.loop.run_until_complete(self.collection.attach(self.assignment))
+        self.loop.run_until_complete(self.collection.detach(self.assignment))
 
         with self.assertRaises(qubes.devices.DeviceNotAttached):
-            self.collection.detach(self.assignment)
+            self.loop.run_until_complete(
+                self.collection.detach(self.assignment))
 
     def test_013_list_attached_persistent(self):
         self.assertEqual(set([]), set(self.collection.persistent()))
-        self.collection.attach(self.assignment)
+        self.loop.run_until_complete(self.collection.attach(self.assignment))
         self.assertEventFired(self.emitter, 'device-list-attached:testclass')
         self.assertEqual({self.device}, set(self.collection.persistent()))
         self.assertEqual({self.device},
@@ -135,7 +138,7 @@ class TC_00_DeviceCollection(qubes.tests.QubesTestCase):
     def test_014_list_attached_non_persistent(self):
         self.assignment.persistent = False
         self.emitter.running = True
-        self.collection.attach(self.assignment)
+        self.loop.run_until_complete(self.collection.attach(self.assignment))
         # device-attach event not implemented, so manipulate object manually
         self.device.frontend_domain = self.emitter
         self.assertEqual({self.device},
@@ -167,6 +170,7 @@ class TC_01_DeviceManager(qubes.tests.QubesTestCase):
             backend_domain=device.backend_domain,
             ident=device.ident,
             persistent=True)
-        self.manager['testclass'].attach(assignment)
+        self.loop.run_until_complete(
+            self.manager['testclass'].attach(assignment))
         self.assertEventFired(self.emitter, 'device-attach:testclass')
 

--- a/qubes/tests/events.py
+++ b/qubes/tests/events.py
@@ -73,7 +73,6 @@ class TC_00_Emitter(qubes.tests.QubesTestCase):
 
         emitter = TestEmitter()
         emitter.events_enabled = True
-        emitter.fire_event('testevent')
 
         effect = emitter.fire_event('testevent')
 
@@ -129,8 +128,8 @@ class TC_00_Emitter(qubes.tests.QubesTestCase):
                 ['testevent_1'])
 
         with self.subTest('fire_event_pre'):
-            effect = emitter.fire_event_pre('testevent')
-            effect2 = emitter2.fire_event_pre('testevent')
+            effect = emitter.fire_event('testevent', pre_event=True)
+            effect2 = emitter2.fire_event('testevent', pre_event=True)
             self.assertEqual(list(effect),
                 ['testevent_2', 'testevent_1'])
             self.assertEqual(list(effect2),

--- a/qubes/vm/__init__.py
+++ b/qubes/vm/__init__.py
@@ -316,7 +316,7 @@ class BaseVM(qubes.PropertyHolder):
                     options,
                     persistent=True
                 )
-                self.devices[devclass].attach(device_assignment)
+                self.devices[devclass].load_persistent(device_assignment)
 
         # tags
         for node in self.xml.xpath('./tags/tag'):

--- a/qubes/vm/adminvm.py
+++ b/qubes/vm/adminvm.py
@@ -49,6 +49,11 @@ class AdminVM(qubes.vm.BaseVM):
         default='00000000-0000-0000-0000-000000000000',
         setter=qubes.property.forbidden)
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._qdb_connection = None
+
     def __str__(self):
         return self.name
 
@@ -157,6 +162,15 @@ class AdminVM(qubes.vm.BaseVM):
     @property
     def icon_path(self):
         return None
+
+    @property
+    def qdb(self):
+        '''QubesDB handle for this domain.'''
+        if self._qdb_connection is None:
+            import qubesdb  # pylint: disable=import-error
+            self._qdb_connection = qubesdb.QubesDB(self.name)
+        return self._qdb_connection
+
 
 #   def __init__(self, **kwargs):
 #       super(QubesAdminVm, self).__init__(qid=0, name="dom0", netid=0,

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -847,7 +847,8 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
 
             self.log.info('Starting {}'.format(self.name))
 
-            self.fire_event_pre('domain-pre-start',
+            self.fire_event('domain-pre-start',
+                pre_event=True,
                 start_guid=start_guid, mem_required=mem_required)
 
             yield from self.storage.verify()
@@ -935,7 +936,7 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
         if self.is_halted():
             raise qubes.exc.QubesVMNotStartedError(self)
 
-        self.fire_event_pre('domain-pre-shutdown', force=force)
+        self.fire_event('domain-pre-shutdown', pre_event=True, force=force)
 
         self.libvirt_domain.shutdown()
 
@@ -1071,7 +1072,7 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
             raise qubes.exc.QubesVMError(
                 self, 'Domain {!r}: qrexec not connected'.format(self.name))
 
-        self.fire_event_pre('domain-cmd-pre-run', start_guid=gui)
+        self.fire_event('domain-cmd-pre-run', pre_event=True, start_guid=gui)
 
         return (yield from asyncio.create_subprocess_exec(
             qubes.config.system_path['qrexec_client_path'],


### PR DESCRIPTION
Some event handlers need to call async actions (like qrexec service). Add support for it.
Two important design choices:
 - event handlers can still be normal python function (instead of a coroutine), if given handler don't need any async feature
 - not all events support async handlers - see appropriate event documentation for this information
