### PR TITLE
features: change 'service/' prefix to 'service.'

### DIFF
--- a/qubes/app.py
+++ b/qubes/app.py
@@ -806,13 +806,13 @@ class Qubes(qubes.PropertyHolder):
         # Disable ntpd in ClockVM - to not conflict with ntpdate (both are
         # using 123/udp port)
         if hasattr(self, 'clockvm') and self.clockvm is not None:
-            if self.clockvm.features.get('service/ntpd', False):
+            if self.clockvm.features.get('service.ntpd', False):
                 self.log.warning(
                     'VM set as clockvm (%r) has enabled \'ntpd\' service! '
                     'Expect failure when syncing time in dom0.',
                     self.clockvm)
             else:
-                self.clockvm.features['service/ntpd'] = ''
+                self.clockvm.features['service.ntpd'] = ''
 
         for vm in self.domains:
             vm.events_enabled = True
@@ -1149,12 +1149,12 @@ class Qubes(qubes.PropertyHolder):
         # pylint: disable=unused-argument,no-self-use
         if newvalue is None:
             return
-        if newvalue.features.get('service/ntpd', False):
+        if newvalue.features.get('service.ntpd', False):
             raise qubes.exc.QubesVMError(newvalue,
                 'Cannot set {!r} as {!r} since it has ntpd enabled.'.format(
                     newvalue.name, name))
         else:
-            newvalue.features['service/ntpd'] = ''
+            newvalue.features['service.ntpd'] = ''
 
 
     @qubes.events.handler(

--- a/qubes/ext/r3compatibility.py
+++ b/qubes/ext/r3compatibility.py
@@ -38,7 +38,7 @@ class R3Compatibility(qubes.ext.Extension):
     '''
 
     features_to_services = {
-        'service/ntpd': 'ntpd',
+        'service.ntpd': 'ntpd',
         'check-updates': 'qubes-update-check',
         'dvm': 'qubes-dvm',
 

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -1736,9 +1736,9 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
             self.qdb.write('/qubes-timezone', tzname)
 
         for feature, value in self.features.items():
-            if not feature.startswith('service/'):
+            if not feature.startswith('service.'):
                 continue
-            service = feature[len('service/'):]
+            service = feature[len('service.'):]
             # forcefully convert to '0' or '1'
             self.qdb.write('/qubes-service/{}'.format(service),
                 str(int(bool(value))))


### PR DESCRIPTION
'/' is not allowed in qrexec service call argument, but feature name is
passed there in Admin API.

Fixes QubesOS/qubes-issues#2906