### PR TITLE
When running tests clean up and remove qubesd.socket

### DIFF
--- a/qubes/tests/__init__.py
+++ b/qubes/tests/__init__.py
@@ -235,7 +235,7 @@ class _AssertNotRaisesContext(object):
         self.exception = exc_value # store for later retrieval
 
 class _QrexecPolicyContext(object):
-    '''Context manager for SystemTestsMixin.qrexec_policy'''
+    '''Context manager for SystemTestCase.qrexec_policy'''
 
     def __init__(self, service, source, destination, allow=True):
         try:
@@ -365,8 +365,6 @@ class QubesTestCase(unittest.TestCase):
         asyncio.set_event_loop(self.loop)
 
     def tearDown(self):
-        super(QubesTestCase, self).tearDown()
-
         # The loop, when closing, throws a warning if there is
         # some unfinished bussiness. Let's catch that.
         with warnings.catch_warnings():
@@ -555,18 +553,18 @@ class QubesTestCase(unittest.TestCase):
             return VMPREFIX + name
 
 
-class SystemTestsMixin(object):
+class SystemTestCase(QubesTestCase):
     """
     Mixin for integration tests. All the tests here should use self.app
     object and when need qubes.xml path - should use :py:data:`XMLPATH`
     defined in this file.
-    Every VM created by test, must use :py:meth:`SystemTestsMixin.make_vm_name`
+    Every VM created by test, must use :py:meth:`SystemTestCase.make_vm_name`
     for VM name.
     By default self.app represents empty collection, if anything is needed
     there from the real collection it can be imported from self.host_app in
-    :py:meth:`SystemTestsMixin.setUp`. But *can not be modified* in any way -
+    :py:meth:`SystemTestCase.setUp`. But *can not be modified* in any way -
     this include both changing attributes in
-    :py:attr:`SystemTestsMixin.host_app` and modifying files of such imported
+    :py:attr:`SystemTestCase.host_app` and modifying files of such imported
     VM. If test need to make some modification, it must clone the VM first.
 
     If some group of tests needs class-wide initialization, first of all the
@@ -579,7 +577,7 @@ class SystemTestsMixin(object):
     def setUp(self):
         if not in_dom0:
             self.skipTest('outside dom0')
-        super(SystemTestsMixin, self).setUp()
+        super(SystemTestCase, self).setUp()
         self.remove_test_vms()
 
         # need some information from the real qubes.xml - at least installed
@@ -656,11 +654,11 @@ class SystemTestsMixin(object):
             for sock in server.sockets:
                 os.unlink(sock.getsockname())
             server.close()
+
         self.loop.run_until_complete(asyncio.wait([
             server.wait_closed() for server in self.qubesd]))
 
-        super(SystemTestsMixin, self).tearDown()
-
+        super(SystemTestCase, self).tearDown()
         # remove all references to VM objects, to release resources - most
         # importantly file descriptors; this object will live
         # during the whole test run, but all the file descriptors would be
@@ -673,7 +671,7 @@ class SystemTestsMixin(object):
 
     @classmethod
     def tearDownClass(cls):
-        super(SystemTestsMixin, cls).tearDownClass()
+        super(SystemTestCase, cls).tearDownClass()
         if not in_dom0:
             return
         cls.remove_test_vms(xmlpath=CLASS_XMLPATH, prefix=CLSVMPREFIX)

--- a/qubes/tests/extra.py
+++ b/qubes/tests/extra.py
@@ -26,7 +26,7 @@ import qubes.vm.appvm
 import qubes.vm.templatevm
 
 
-class ExtraTestCase(qubes.tests.SystemTestsMixin, qubes.tests.QubesTestCase):
+class ExtraTestCase(qubes.tests.SystemTestCase):
 
     template = None
 

--- a/qubes/tests/integ/backup.py
+++ b/qubes/tests/integ/backup.py
@@ -40,7 +40,7 @@ import qubes.vm.templatevm
 import qubes.vm.qubesvm
 
 # noinspection PyAttributeOutsideInit
-class BackupTestsMixin(qubes.tests.SystemTestsMixin):
+class BackupTestsMixin(object):
     class BackupErrorHandler(logging.Handler):
         def __init__(self, errors_queue, level=logging.NOTSET):
             super(BackupTestsMixin.BackupErrorHandler, self).__init__(level)
@@ -281,7 +281,7 @@ class BackupTestsMixin(qubes.tests.SystemTestsMixin):
                         vm.name))
 
 
-class TC_00_Backup(BackupTestsMixin, qubes.tests.QubesTestCase):
+class TC_00_Backup(BackupTestsMixin, qubes.tests.SystemTestCase):
     def test_000_basic_backup(self):
         vms = self.create_backup_vms()
         orig_hashes = self.vm_checksum(vms)

--- a/qubes/tests/integ/backupcompatibility.py
+++ b/qubes/tests/integ/backupcompatibility.py
@@ -143,7 +143,7 @@ compression-filter=gzip
 '''
 
 class TC_00_BackupCompatibility(
-    qubes.tests.integ.backup.BackupTestsMixin, qubes.tests.QubesTestCase):
+        qubes.tests.integ.backup.BackupTestsMixin, qubes.tests.SystemTestCase):
 
     def tearDown(self):
         self.remove_test_vms(prefix="test-")

--- a/qubes/tests/integ/basic.py
+++ b/qubes/tests/integ/basic.py
@@ -42,7 +42,7 @@ import qubes.vm.templatevm
 import libvirt  # pylint: disable=import-error
 
 
-class TC_00_Basic(qubes.tests.SystemTestsMixin, qubes.tests.QubesTestCase):
+class TC_00_Basic(qubes.tests.SystemTestCase):
     def setUp(self):
         super(TC_00_Basic, self).setUp()
         self.init_default_template()
@@ -66,7 +66,7 @@ class TC_00_Basic(qubes.tests.SystemTestsMixin, qubes.tests.QubesTestCase):
             vm.storage.verify()
 
 
-class TC_01_Properties(qubes.tests.SystemTestsMixin, qubes.tests.QubesTestCase):
+class TC_01_Properties(qubes.tests.SystemTestCase):
     # pylint: disable=attribute-defined-outside-init
     def setUp(self):
         super(TC_01_Properties, self).setUp()
@@ -75,7 +75,6 @@ class TC_01_Properties(qubes.tests.SystemTestsMixin, qubes.tests.QubesTestCase):
         self.vm = self.app.add_new_vm(qubes.vm.appvm.AppVM, name=self.vmname,
                                       template=self.app.default_template,
                                       label='red')
-        self.loop.run_until_complete(self.vm.create_on_disk())
 
     @unittest.expectedFailure
     def test_030_clone(self):
@@ -185,13 +184,12 @@ class TC_01_Properties(qubes.tests.SystemTestsMixin, qubes.tests.QubesTestCase):
 
         self.vm2 = self.app.add_new_vm(qubes.vm.appvm.AppVM,
             name=vm2name, template=self.app.default_template, label='red')
-        self.loop.run_until_complete(self.vm2.create_on_disk())
 
         with self.assertNotRaises(OSError):
             with self.assertRaises(qubes.exc.QubesException):
                 self.vm2.name = self.vmname
 
-class TC_02_QvmPrefs(qubes.tests.SystemTestsMixin, qubes.tests.QubesTestCase):
+class TC_02_QvmPrefs(qubes.tests.SystemTestCase):
     # pylint: disable=attribute-defined-outside-init
 
     def setUp(self):
@@ -302,8 +300,7 @@ class TC_02_QvmPrefs(qubes.tests.SystemTestsMixin, qubes.tests.QubesTestCase):
         self.execute_tests('kernel', [('default', '', False)])
         self.execute_tests('kernelopts', [('default', '', False)])
 
-class TC_03_QvmRevertTemplateChanges(qubes.tests.SystemTestsMixin,
-                                     qubes.tests.QubesTestCase):
+class TC_03_QvmRevertTemplateChanges(qubes.tests.SystemTestCase):
     # pylint: disable=attribute-defined-outside-init
 
     def setUp(self):
@@ -371,7 +368,7 @@ class TC_03_QvmRevertTemplateChanges(qubes.tests.SystemTestsMixin,
         self.setup_hvm_template()
         self._do_test()
 
-class TC_30_Gui_daemon(qubes.tests.SystemTestsMixin, qubes.tests.QubesTestCase):
+class TC_30_Gui_daemon(qubes.tests.SystemTestCase):
     def setUp(self):
         super(TC_30_Gui_daemon, self).setUp()
         self.init_default_template()
@@ -448,7 +445,7 @@ class TC_30_Gui_daemon(qubes.tests.SystemTestsMixin, qubes.tests.QubesTestCase):
         self.assertEqual(clipboard_source, "",
                           "Clipboard not wiped after paste - owner")
 
-class TC_05_StandaloneVM(qubes.tests.SystemTestsMixin, qubes.tests.QubesTestCase):
+class TC_05_StandaloneVM(qubes.tests.SystemTestCase):
     def setUp(self):
         super(TC_05_StandaloneVM, self).setUp()
         self.init_default_template()

--- a/qubes/tests/integ/devices_pci.py
+++ b/qubes/tests/integ/devices_pci.py
@@ -31,8 +31,7 @@ import qubes.ext.pci
 import qubes.tests
 
 
-class TC_00_Devices_PCI(qubes.tests.SystemTestsMixin,
-        qubes.tests.QubesTestCase):
+class TC_00_Devices_PCI(qubes.tests.SystemTestCase):
     def setUp(self):
         super(TC_00_Devices_PCI, self).setUp()
         if self._testMethodName not in ['test_000_list']:

--- a/qubes/tests/integ/dispvm.py
+++ b/qubes/tests/integ/dispvm.py
@@ -27,8 +27,7 @@ import unittest
 import os
 import time
 
-class TC_04_DispVM(qubes.tests.SystemTestsMixin,
-                   qubes.tests.QubesTestCase):
+class TC_04_DispVM(qubes.tests.SystemTestCase):
 
     def setUp(self):
         super(TC_04_DispVM, self).setUp()
@@ -91,7 +90,7 @@ class TC_04_DispVM(qubes.tests.SystemTestsMixin,
 
         self.assertNotIn(dispvm_name, self.app.domains)
 
-class TC_20_DispVMMixin(qubes.tests.SystemTestsMixin):
+class TC_20_DispVMMixin(object):
 
     def setUp(self):
         super(TC_20_DispVMMixin, self).setUp()
@@ -265,7 +264,7 @@ def load_tests(loader, tests, pattern):
         tests.addTests(loader.loadTestsFromTestCase(
             type(
                 'TC_20_DispVM_' + template,
-                (TC_20_DispVMMixin, qubes.tests.QubesTestCase),
+                (TC_20_DispVMMixin, qubes.tests.SystemTestCase),
                 {'template': template})))
 
     return tests

--- a/qubes/tests/integ/dom0_update.py
+++ b/qubes/tests/integ/dom0_update.py
@@ -32,7 +32,7 @@ VM_PREFIX = "test-"
 @unittest.skipUnless(os.path.exists('/usr/bin/rpmsign') and
                      os.path.exists('/usr/bin/rpmbuild'),
                      'rpm-sign and/or rpm-build not installed')
-class TC_00_Dom0UpgradeMixin(qubes.tests.SystemTestsMixin):
+class TC_00_Dom0UpgradeMixin(object):
     """
     Tests for downloading dom0 updates using VMs based on different templates
     """
@@ -369,7 +369,7 @@ def load_tests(loader, tests, pattern):
         tests.addTests(loader.loadTestsFromTestCase(
             type(
                 'TC_00_Dom0Upgrade_' + template,
-                (TC_00_Dom0UpgradeMixin, qubes.tests.QubesTestCase),
+                (TC_00_Dom0UpgradeMixin, qubes.tests.SystemTestCase),
                 {'template': template})))
 
     return tests

--- a/qubes/tests/integ/network.py
+++ b/qubes/tests/integ/network.py
@@ -37,7 +37,7 @@ class NcVersion:
     Nmap = 2
 
 # noinspection PyAttributeOutsideInit
-class VmNetworkingMixin(qubes.tests.SystemTestsMixin):
+class VmNetworkingMixin(object):
     test_ip = '192.168.123.45'
     test_name = 'test.example.com'
 
@@ -645,7 +645,7 @@ class VmNetworkingMixin(qubes.tests.SystemTestsMixin):
 
 
 # noinspection PyAttributeOutsideInit
-class VmUpdatesMixin(qubes.tests.SystemTestsMixin):
+class VmUpdatesMixin(object):
     """
     Tests for VM updates
     """
@@ -944,11 +944,11 @@ def load_tests(loader, tests, pattern):
         tests.addTests(loader.loadTestsFromTestCase(
             type(
                 'VmNetworking_' + template,
-                (VmNetworkingMixin, qubes.tests.QubesTestCase),
+                (VmNetworkingMixin, qubes.tests.SystemTestCase),
                 {'template': template})))
         tests.addTests(loader.loadTestsFromTestCase(
             type(
                 'VmUpdates_' + template,
-                (VmUpdatesMixin, qubes.tests.QubesTestCase),
+                (VmUpdatesMixin, qubes.tests.SystemTestCase),
                 {'template': template})))
     return tests

--- a/qubes/tests/integ/storage.py
+++ b/qubes/tests/integ/storage.py
@@ -29,7 +29,7 @@ import qubes.tests.storage_lvm
 import qubes.vm.appvm
 
 
-class StorageTestMixin(qubes.tests.SystemTestsMixin):
+class StorageTestMixin(object):
     def setUp(self):
         super(StorageTestMixin, self).setUp()
         self.init_default_template()
@@ -254,7 +254,7 @@ class StorageTestMixin(qubes.tests.SystemTestsMixin):
             user='root')
 
 
-class StorageFile(StorageTestMixin, qubes.tests.QubesTestCase):
+class StorageFile(StorageTestMixin, qubes.tests.SystemTestCase):
     def init_pool(self):
         self.dir_path = '/var/tmp/test-pool'
         self.pool = self.app.add_pool(dir_path=self.dir_path,
@@ -269,7 +269,7 @@ class StorageFile(StorageTestMixin, qubes.tests.QubesTestCase):
 
 
 @qubes.tests.storage_lvm.skipUnlessLvmPoolExists
-class StorageLVM(StorageTestMixin, qubes.tests.QubesTestCase):
+class StorageLVM(StorageTestMixin, qubes.tests.SystemTestCase):
     def init_pool(self):
         # check if the default LVM Thin pool qubes_dom0/pool00 exists
         volume_group, thin_pool = \

--- a/qubes/tests/integ/tools/qubes_create.py
+++ b/qubes/tests/integ/tools/qubes_create.py
@@ -25,8 +25,7 @@ import qubes.tools.qubes_create
 import qubes.tests
 
 @qubes.tests.skipUnlessDom0
-class TC_00_qubes_create(
-        qubes.tests.SystemTestsMixin, qubes.tests.QubesTestCase):
+class TC_00_qubes_create(qubes.tests.SystemTestCase):
     def test_000_basic(self):
         self.assertEqual(0, qubes.tools.qubes_create.main([
             '--qubesxml', qubes.tests.XMLPATH]))

--- a/qubes/tests/integ/vm_qrexec_gui.py
+++ b/qubes/tests/integ/vm_qrexec_gui.py
@@ -35,7 +35,7 @@ import qubes.vm.templatevm
 TEST_DATA = b"0123456789" * 1024
 
 
-class TC_00_AppVMMixin(qubes.tests.SystemTestsMixin):
+class TC_00_AppVMMixin(object):
     def setUp(self):
         super(TC_00_AppVMMixin, self).setUp()
         self.init_default_template(self.template)
@@ -959,7 +959,7 @@ int main(int argc, char **argv) {
         if vm_image != dom0_image:
             self.fail("Dom0 window doesn't match VM window content")
 
-class TC_10_Generic(qubes.tests.SystemTestsMixin, qubes.tests.QubesTestCase):
+class TC_10_Generic(qubes.tests.SystemTestCase):
     def setUp(self):
         super(TC_10_Generic, self).setUp()
         self.init_default_template()
@@ -1011,7 +1011,7 @@ def load_tests(loader, tests, pattern):
         tests.addTests(loader.loadTestsFromTestCase(
             type(
                 'TC_00_AppVM_' + template,
-                (TC_00_AppVMMixin, qubes.tests.QubesTestCase),
+                (TC_00_AppVMMixin, qubes.tests.SystemTestCase),
                 {'template': template})))
 
     return tests

--- a/qubes/tests/storage.py
+++ b/qubes/tests/storage.py
@@ -22,7 +22,7 @@ import qubes.log
 from qubes.exc import QubesException
 from qubes.storage import pool_drivers
 from qubes.storage.file import FilePool
-from qubes.tests import QubesTestCase
+from qubes.tests import SystemTestCase
 
 # :pylint: disable=invalid-name
 
@@ -75,7 +75,7 @@ class TestApp(qubes.Qubes):
             load=False, offline_mode=True, **kwargs)
         self.load_initial_values()
 
-class TC_00_Pool(QubesTestCase):
+class TC_00_Pool(SystemTestCase):
     """ This class tests the utility methods from :mod:``qubes.storage`` """
 
     def setUp(self):

--- a/qubes/tests/storage_lvm.py
+++ b/qubes/tests/storage_lvm.py
@@ -160,7 +160,7 @@ class TC_00_ThinPool(ThinPoolBase):
         volume.remove()
 
 @skipUnlessLvmPoolExists
-class TC_01_ThinPool(qubes.tests.SystemTestsMixin, ThinPoolBase):
+class TC_01_ThinPool(qubes.tests.SystemTestCase, ThinPoolBase):
     ''' Sanity tests for :py:class:`qubes.storage.lvm.ThinPool` '''
 
     def setUp(self):

--- a/qubespolicy/tests/gtkhelpers.py
+++ b/qubespolicy/tests/gtkhelpers.py
@@ -22,7 +22,9 @@
 import time
 import unittest
 
-from gi.repository import Gtk
+import gi  # isort:skip
+gi.require_version('Gtk', '3.0')  # isort:skip
+from gi.repository import Gtk  # isort:skip pylint:
 
 from qubespolicy.gtkhelpers import VMListModeler, GtkOneTimerHelper, \
     FocusStealingHelper


### PR DESCRIPTION
Changed the inheritance hierarchy:

1. Renamed `SystemTestsMixin` to `SystemTestCase`
2. `SystemTestCase` is a child of `QubesTestCase`
3. All classes extending the prior `SystemTestsMixin` now just extend `object`

Also: Fixed gi imports.
