### PR TITLE
Storage fixes, integration tests fixes

### DIFF
--- a/qubes/app.py
+++ b/qubes/app.py
@@ -672,23 +672,28 @@ class Qubes(qubes.PropertyHolder):
 
     default_pool = qubes.property('default_pool', load_stage=3,
         default=_default_pool,
+        setter=_setter_pool,
         doc='Default storage pool')
 
     default_pool_private = qubes.property('default_pool_private', load_stage=3,
         default=lambda app: app.default_pool,
+        setter=_setter_pool,
         doc='Default storage pool for private volumes')
 
     default_pool_root = qubes.property('default_pool_root', load_stage=3,
         default=lambda app: app.default_pool,
+        setter=_setter_pool,
         doc='Default storage pool for root volumes')
 
     default_pool_volatile = qubes.property('default_pool_volatile',
         load_stage=3,
         default=lambda app: app.default_pool,
+        setter=_setter_pool,
         doc='Default storage pool for volatile volumes')
 
     default_pool_kernel = qubes.property('default_pool_kernel', load_stage=3,
         default=lambda app: app.default_pool,
+        setter=_setter_pool,
         doc='Default storage pool for kernel volumes')
 
     # TODO #1637 #892

--- a/qubes/app.py
+++ b/qubes/app.py
@@ -577,7 +577,7 @@ def _default_pool(app):
         for pool in app.pools.values():
             if pool.config.get('driver', None) != 'file':
                 continue
-            if pool.config['dir_path'] == '/var/lib/qubes':
+            if pool.config['dir_path'] == qubes.config.qubes_base_dir:
                 return pool
         raise AttributeError('Cannot determine default storage pool')
 
@@ -966,11 +966,8 @@ class Qubes(qubes.PropertyHolder):
         # check if the default LVM Thin pool qubes_dom0/pool00 exists
         if os.path.exists('/dev/mapper/qubes_dom0-pool00-tpool'):
             self.add_pool(volume_group='qubes_dom0', thin_pool='pool00',
-                          name='default', driver='lvm_thin')
-        else:
-            self.pools['default'] = self._get_pool(
-                dir_path=qubes.config.qubes_base_dir,
-                name='default', driver='file')
+                          name='lvm', driver='lvm_thin')
+        # pool based on /var/lib/qubes will be created here:
         for name, config in qubes.config.defaults['pool_configs'].items():
             self.pools[name] = self._get_pool(**config)
 

--- a/qubes/app.py
+++ b/qubes/app.py
@@ -120,6 +120,8 @@ class VirConnectWrapper(object):
         attr = getattr(self._conn, attrname)
         if not isinstance(attr, collections.Callable):
             return attr
+        if attrname == 'close':
+            return attr
 
         @functools.wraps(attr)
         def wrapper(*args, **kwargs):

--- a/qubes/firewall.py
+++ b/qubes/firewall.py
@@ -123,7 +123,8 @@ class DstHost(RuleOption):
                     self.type = 'dsthost'
                     self.prefixlen = 0
                     safe_set = string.ascii_lowercase + string.digits + '-._'
-                    assert all(c in safe_set for c in untrusted_value)
+                    if not all(c in safe_set for c in untrusted_value):
+                        raise ValueError('Invalid hostname')
                     value = untrusted_value
         else:
             untrusted_host, untrusted_prefixlen = untrusted_value.split('/', 1)

--- a/qubes/qmemman/__init__.py
+++ b/qubes/qmemman/__init__.py
@@ -30,7 +30,6 @@ import functools
 import xen.lowlevel.xc
 import xen.lowlevel.xs
 
-import qubes
 import qubes.qmemman.algo
 
 
@@ -141,24 +140,16 @@ class SystemState(object):
                     self.domdict[i].memory_actual <= self.domdict[i].last_target + self.XEN_FREE_MEM_LEFT/4:
                 dom_name = self.xs.read('', '/local/domain/%s/name' % str(i))
                 if dom_name is not None:
-                    try:
-                        qubes.Qubes().domains[str(dom_name)].fire_event(
-                            'status:no-error', status='no-error',
-                            msg=slow_memset_react_msg)
-                    except LookupError:
-                        pass
+                    # TODO: report it somewhere, qubesd or elsewhere
+                    pass
                 self.domdict[i].slow_memset_react = False
 
             if self.domdict[i].no_progress and \
                     self.domdict[i].memory_actual <= self.domdict[i].last_target + self.XEN_FREE_MEM_LEFT/4:
                 dom_name = self.xs.read('', '/local/domain/%s/name' % str(i))
                 if dom_name is not None:
-                    try:
-                        qubes.Qubes().domains[str(dom_name)].fire_event(
-                            'status:no-error', status='no-error',
-                            msg=no_progress_msg)
-                    except LookupError:
-                        pass
+                    # TODO: report it somewhere, qubesd or elsewhere
+                    pass
                 self.domdict[i].no_progress = False
 
 #the below works (and is fast), but then 'xm list' shows unchanged memory value
@@ -343,13 +334,8 @@ class SystemState(object):
                                 self.domdict[dom2].no_progress = True
                                 dom_name = self.xs.read('', '/local/domain/%s/name' % str(dom2))
                                 if dom_name is not None:
-                                    try:
-                                        qubes.Qubes().domains[str(
-                                            dom_name)].fire_event(
-                                            'status:error', status='error',
-                                            msg=no_progress_msg)
-                                    except LookupError:
-                                        pass
+                                    # TODO: report it somewhere, qubesd or elsewhere
+                                    pass
                             else:
                                 self.log.warning('dom {!r} still hold more'
                                     ' memory than have assigned ({} > {})'
@@ -359,13 +345,8 @@ class SystemState(object):
                                 self.domdict[dom2].slow_memset_react = True
                                 dom_name = self.xs.read('', '/local/domain/%s/name' % str(dom2))
                                 if dom_name is not None:
-                                    try:
-                                        qubes.Qubes().domains[str(
-                                            dom_name)].fire_event(
-                                            'status:error', status='error',
-                                            msg=slow_memset_react_msg)
-                                    except LookupError:
-                                        pass
+                                    # TODO: report it somewhere, qubesd or elsewhere
+                                    pass
                     self.mem_set(dom, self.get_free_xen_memory() + self.domdict[dom].memory_actual - self.XEN_FREE_MEM_LEFT)
                     return
 

--- a/qubes/storage/__init__.py
+++ b/qubes/storage/__init__.py
@@ -373,15 +373,15 @@ class Storage(object):
 
     def init_volume(self, name, volume_config):
         ''' Initialize Volume instance attached to this domain '''
-        assert 'pool' in volume_config, "Pool missing in volume_config " + str(
-            volume_config)
 
         if 'name' not in volume_config:
             volume_config['name'] = name
+
+        # if pool still unknown, load default
         if 'pool' not in volume_config:
-            pool = getattr(self.vm.app, 'default_pool_' + name)
-        else:
-            pool = self.vm.app.get_pool(volume_config['pool'])
+            volume_config['pool'] = \
+                getattr(self.vm.app, 'default_pool_' + name)
+        pool = self.vm.app.get_pool(volume_config['pool'])
         if 'internal' in volume_config:
             # migrate old config
             del volume_config['internal']

--- a/qubes/storage/file.py
+++ b/qubes/storage/file.py
@@ -164,9 +164,6 @@ class FileVolume(qubes.storage.Volume):
             'Volume size must be > 0'
         if not self.snap_on_start:
             create_sparse_file(self.path, self.size)
-        # path_cow not needed only in volatile volume
-        if self.save_on_stop or self.snap_on_start:
-            create_sparse_file(self.path_cow, self.size)
 
     def remove(self):
         if not self.snap_on_start:

--- a/qubes/tests/__init__.py
+++ b/qubes/tests/__init__.py
@@ -756,11 +756,11 @@ class SystemTestCase(QubesTestCase):
             volumes = subprocess.check_output(
                 ['sudo', 'lvs', '--noheadings', '-o', 'vg_name,name',
                     '--separator', '/']).decode()
-            if ('/' + prefix) not in volumes:
+            if ('/vm-' + prefix) not in volumes:
                 return
             subprocess.check_call(['sudo', 'lvremove', '-f'] +
                 [vol.strip() for vol in volumes.splitlines()
-                    if ('/' + prefix) in vol],
+                    if ('/vm-' + prefix) in vol],
                 stdout=subprocess.DEVNULL)
         except subprocess.CalledProcessError:
             pass

--- a/qubes/tests/__init__.py
+++ b/qubes/tests/__init__.py
@@ -867,7 +867,7 @@ class SystemTestCase(QubesTestCase):
         while timeout > 0:
             if not vm.is_running():
                 return
-            time.sleep(1)
+            self.loop.run_until_complete(asyncio.sleep(1))
             timeout -= 1
         self.fail("Timeout while waiting for VM {} shutdown".format(vm.name))
 

--- a/qubes/tests/api_admin.py
+++ b/qubes/tests/api_admin.py
@@ -422,7 +422,6 @@ class TC_00_VMs(AdminAPITestCase):
         value = self.call_mgmt_func(b'admin.vm.volume.Revert',
             b'test-vm1', b'private', b'rev1')
         self.assertIsNone(value)
-        print(repr(self.vm.volumes.mock_calls))
         self.assertEqual(self.vm.volumes.mock_calls, [
             ('__getitem__', ('private', ), {}),
             ('__getitem__().revert', ('rev1', ), {}),
@@ -1532,6 +1531,7 @@ class TC_00_VMs(AdminAPITestCase):
     @unittest.mock.patch('qubes.storage.Storage.remove')
     @unittest.mock.patch('shutil.rmtree')
     def test_500_vm_remove(self, mock_rmtree, mock_remove):
+        mock_remove.side_effect = self.dummy_coro
         value = self.call_mgmt_func(b'admin.vm.Remove', b'test-vm1')
         self.assertIsNone(value)
         mock_rmtree.assert_called_once_with(
@@ -1542,6 +1542,7 @@ class TC_00_VMs(AdminAPITestCase):
     @unittest.mock.patch('qubes.storage.Storage.remove')
     @unittest.mock.patch('shutil.rmtree')
     def test_501_vm_remove_running(self, mock_rmtree, mock_remove):
+        mock_remove.side_effect = self.dummy_coro
         with unittest.mock.patch.object(
                 self.vm, 'get_power_state', lambda: 'Running'):
             with self.assertRaises(qubes.exc.QubesVMNotHaltedError):

--- a/qubes/tests/firewall.py
+++ b/qubes/tests/firewall.py
@@ -202,7 +202,6 @@ class TC_02_DstHost(qubes.tests.QubesTestCase):
         with self.assertRaises(ValueError):
             qubes.firewall.DstHost('2001:abcd:efab::3/64')
 
-    @unittest.expectedFailure
     def test_020_invalid_hostname(self):
         with self.assertRaises(ValueError):
             qubes.firewall.DstHost('www  qubes-os.org')

--- a/qubes/tests/init.py
+++ b/qubes/tests/init.py
@@ -229,12 +229,10 @@ class TC_20_PropertyHolder(qubes.tests.QubesTestCase):
         self.assertIs(self.holder.property_get_def(TestHolder.testprop1),
             TestHolder.testprop1)
 
-    @unittest.expectedFailure
     def test_002_load_properties(self):
         self.holder.load_properties()
 
-        self.assertEventFired(self.holder, 'property-loaded')
-        self.assertEventNotFired(self.holder, 'property-set:testprop1')
+        self.assertEventFired(self.holder, 'property-set:testprop1')
 
         self.assertEqual(self.holder.testprop1, 'testvalue1')
         self.assertEqual(self.holder.testprop2, 'testref2')

--- a/qubes/tests/integ/basic.py
+++ b/qubes/tests/integ/basic.py
@@ -180,15 +180,6 @@ class TC_01_Properties(qubes.tests.SystemTestCase):
                 name=self.vmname, label='red')
             self.loop.run_until_complete(self.vm2.create_on_disk())
 
-    def test_030_rename_conflict_app(self):
-        vm2name = self.make_vm_name('newname')
-
-        self.vm2 = self.app.add_new_vm(qubes.vm.appvm.AppVM,
-            name=vm2name, template=self.app.default_template, label='red')
-
-        with self.assertNotRaises(OSError):
-            with self.assertRaises(qubes.exc.QubesException):
-                self.vm2.name = self.vmname
 
 class TC_02_QvmPrefs(qubes.tests.SystemTestCase):
     # pylint: disable=attribute-defined-outside-init

--- a/qubes/tests/integ/basic.py
+++ b/qubes/tests/integ/basic.py
@@ -127,7 +127,6 @@ class TC_01_Properties(qubes.tests.SystemTestCase):
         testvm1.label = 'orange'
         testvm1.memory = 512
         firewall = testvm1.firewall
-        firewall.policy = 'drop'
         firewall.rules = [
             qubes.firewall.Rule(None, action='accept', dsthost='1.2.3.0/24',
                 proto='tcp', dstports=22)]
@@ -455,20 +454,20 @@ class TC_05_StandaloneVM(qubes.tests.SystemTestCase):
         super(TC_05_StandaloneVM, self).setUp()
         self.init_default_template()
 
-    @unittest.expectedFailure
     def test_000_create_start(self):
         testvm1 = self.app.add_new_vm(qubes.vm.standalonevm.StandaloneVM,
                                      name=self.make_vm_name('vm1'), label='red')
+        testvm1.features['qrexec'] = True
         self.loop.run_until_complete(
             testvm1.clone_disk_files(self.app.default_template))
         self.app.save()
         self.loop.run_until_complete(testvm1.start())
         self.assertEqual(testvm1.get_power_state(), "Running")
 
-    @unittest.expectedFailure
     def test_100_resize_root_img(self):
         testvm1 = self.app.add_new_vm(qubes.vm.standalonevm.StandaloneVM,
                                      name=self.make_vm_name('vm1'), label='red')
+        testvm1.features['qrexec'] = True
         self.loop.run_until_complete(
             testvm1.clone_disk_files(self.app.default_template))
         self.app.save()

--- a/qubes/tests/integ/basic.py
+++ b/qubes/tests/integ/basic.py
@@ -428,7 +428,7 @@ class TC_30_Gui_daemon(qubes.tests.SystemTestCase):
         # Then paste it to the other window
         window_title = 'user@{}'.format(testvm2.name)
         p = self.loop.run_until_complete(testvm2.run(
-            'zenity --entry --title={} > test.txt'.format(window_title)))
+            'zenity --entry --title={} > /tmp/test.txt'.format(window_title)))
         self.wait_for_window(window_title)
 
         subprocess.check_call(['xdotool', 'key', '--delay', '100',
@@ -437,7 +437,7 @@ class TC_30_Gui_daemon(qubes.tests.SystemTestCase):
 
         # And compare the result
         (test_output, _) = self.loop.run_until_complete(
-            testvm2.run_for_stdio('cat test.txt'))
+            testvm2.run_for_stdio('cat /tmp/test.txt'))
         self.assertEqual(test_string, test_output.strip().decode('ascii'))
 
         clipboard_content = \

--- a/qubes/tests/storage.py
+++ b/qubes/tests/storage.py
@@ -95,12 +95,12 @@ class TC_00_Pool(SystemTestCase):
     def test_002_get_pool_klass(self):
         """ Expect the default pool to be `FilePool` """
         # :pylint: disable=protected-access
-        result = self.app.get_pool('default')
+        result = self.app.get_pool('varlibqubes')
         self.assertIsInstance(result, FilePool)
 
     def test_003_pool_exists_default(self):
         """ Expect the default pool to exists """
-        self.assertPoolExists('default')
+        self.assertPoolExists('varlibqubes')
 
     def test_004_add_remove_pool(self):
         """ Tries to adding and removing a pool. """

--- a/qubes/tests/storage.py
+++ b/qubes/tests/storage.py
@@ -19,6 +19,7 @@
 #
 import unittest.mock
 import qubes.log
+import qubes.storage
 from qubes.exc import QubesException
 from qubes.storage import pool_drivers
 from qubes.storage.file import FilePool
@@ -30,9 +31,20 @@ from qubes.tests import SystemTestCase
 class TestPool(unittest.mock.Mock):
     def __init__(self, *args, **kwargs):
         super(TestPool, self).__init__(*args, spec=qubes.storage.Pool, **kwargs)
+        try:
+            self.name = kwargs['name']
+        except KeyError:
+            pass
 
     def __str__(self):
         return 'test'
+
+    def init_volume(self, vm, volume_config):
+        vol = unittest.mock.Mock(spec=qubes.storage.Volume)
+        vol.configure_mock(**volume_config)
+        vol.pool = self
+        vol.import_data.return_value = '/tmp/test-' + vm.name
+        return vol
 
 
 class TestVM(object):

--- a/qubes/tests/storage_file.py
+++ b/qubes/tests/storage_file.py
@@ -406,8 +406,7 @@ class TC_03_FilePool(qubes.tests.QubesTestCase):
                                    expected_private_path)
 
         expected_rootcow_path = os.path.join(expected_vmdir, 'root-cow.img')
-        self.assertEqualAndExists(vm.volumes['root'].path_cow,
-                                   expected_rootcow_path)
+        self.assertEqual(vm.volumes['root'].path_cow, expected_rootcow_path)
 
     def assertEqualAndExists(self, result_path, expected_path):
         """ Check if the ``result_path``, matches ``expected_path`` and exists.

--- a/qubes/tests/storage_file.py
+++ b/qubes/tests/storage_file.py
@@ -80,7 +80,7 @@ class TC_00_FilePool(qubes.tests.QubesTestCase):
             .. sealso::
                Data :data:``qubes.qubes.defaults['pool_config']``.
         """
-        result = self.app.get_pool("default").dir_path
+        result = self.app.get_pool("varlibqubes").dir_path
         expected = '/var/lib/qubes'
         self.assertEqual(result, expected)
 

--- a/qubes/tests/storage_file.py
+++ b/qubes/tests/storage_file.py
@@ -24,6 +24,7 @@ import os
 import shutil
 
 import asyncio
+import unittest.mock
 
 import qubes.storage
 import qubes.tests.storage
@@ -50,6 +51,8 @@ class TestApp(qubes.Qubes):
     def cleanup(self):
         ''' Remove temporary directories '''
         shutil.rmtree(self.pools['linux-kernel'].dir_path)
+        if os.path.exists(self.store):
+            os.unlink(self.store)
 
     def create_dummy_template(self):
         ''' Initalizes a dummy TemplateVM as the `default_template` '''
@@ -306,21 +309,32 @@ class TC_03_FilePool(qubes.tests.QubesTestCase):
     def setUp(self):
         """ Add a test file based storage pool """
         super(TC_03_FilePool, self).setUp()
-        self._orig_qubes_base_dir = qubes.config.qubes_base_dir
-        qubes.config.qubes_base_dir = '/tmp/qubes-test'
+        self.test_base_dir = '/tmp/qubes-test-dir'
+        self.base_dir_patch = unittest.mock.patch.dict(qubes.config.system_path,
+            {'qubes_base_dir': self.test_base_dir})
+        self.base_dir_patch2 = unittest.mock.patch(
+            'qubes.config.qubes_base_dir', self.test_base_dir)
+        self.base_dir_patch3 = unittest.mock.patch.dict(
+            qubes.config.defaults['pool_configs']['varlibqubes'],
+            {'dir_path': self.test_base_dir})
+        self.base_dir_patch.start()
+        self.base_dir_patch2.start()
+        self.base_dir_patch3.start()
         self.app = TestApp()
-        self.app.create_dummy_template()
         self.app.add_pool(**self.POOL_CONFIG)
+        self.app.create_dummy_template()
 
     def tearDown(self):
         """ Remove the file based storage pool after testing """
         self.app.remove_pool("test-pool")
         self.app.cleanup()
+        self.base_dir_patch3.stop()
+        self.base_dir_patch2.stop()
+        self.base_dir_patch.stop()
         super(TC_03_FilePool, self).tearDown()
         shutil.rmtree(self.POOL_DIR, ignore_errors=True)
-        if os.path.exists('/tmp/qubes-test'):
-            shutil.rmtree('/tmp/qubes-test')
-        qubes.config.qubes_base_dir = self._orig_qubes_base_dir
+        if os.path.exists('/tmp/qubes-test-dir'):
+            shutil.rmtree('/tmp/qubes-test-dir')
 
     def test_001_pool_exists(self):
         """ Check if the storage pool was added to the storage pool config """

--- a/qubes/tests/storage_lvm.py
+++ b/qubes/tests/storage_lvm.py
@@ -160,7 +160,7 @@ class TC_00_ThinPool(ThinPoolBase):
         volume.remove()
 
 @skipUnlessLvmPoolExists
-class TC_01_ThinPool(qubes.tests.SystemTestCase, ThinPoolBase):
+class TC_01_ThinPool(ThinPoolBase, qubes.tests.SystemTestCase):
     ''' Sanity tests for :py:class:`qubes.storage.lvm.ThinPool` '''
 
     def setUp(self):
@@ -176,7 +176,7 @@ class TC_01_ThinPool(qubes.tests.SystemTestCase, ThinPoolBase):
         vm.clone_disk_files(template_vm, pool='test-lvm')
         for v_name, volume in vm.volumes.items():
             if volume.save_on_stop:
-                expected = "/dev/{!s}/{!s}-{!s}".format(
+                expected = "/dev/{!s}/vm-{!s}-{!s}".format(
                     DEFAULT_LVM_POOL.split('/')[0], vm.name, v_name)
                 self.assertEqual(volume.path, expected)
         with self.assertNotRaises(qubes.exc.QubesException):
@@ -188,7 +188,7 @@ class TC_01_ThinPool(qubes.tests.SystemTestCase, ThinPoolBase):
         vm.create_on_disk(pool='test-lvm')
         for v_name, volume in vm.volumes.items():
             if volume.save_on_stop:
-                expected = "/dev/{!s}/{!s}-{!s}".format(
+                expected = "/dev/{!s}/vm-{!s}-{!s}".format(
                     DEFAULT_LVM_POOL.split('/')[0], vm.name, v_name)
                 self.assertEqual(volume.path, expected)
         with self.assertNotRaises(qubes.exc.QubesException):

--- a/qubes/tests/vm/__init__.py
+++ b/qubes/tests/vm/__init__.py
@@ -60,6 +60,10 @@ class TestApp(qubes.tests.TestEmitter):
         self.vmm = TestVMM()
         self.host = TestHost()
         self.pools = {}
+        self.default_pool_volatile = 'default'
+        self.default_pool_root = 'default'
+        self.default_pool_private = 'default'
+        self.default_pool_kernel = 'linux-kernel'
         self.domains = {}
         #: jinja2 environment for libvirt XML templates
         self.env = jinja2.Environment(

--- a/qubes/tests/vm/appvm.py
+++ b/qubes/tests/vm/appvm.py
@@ -110,7 +110,7 @@ class TC_90_AppVM(qubes.tests.vm.qubesvm.QubesVMTestsMixin,
         self.assertNotEqual(vm.volume_config['root'].get('source', None),
             self.template.volumes['root'].source)
         self.assertEqual(vm.volume_config['root'].get('source', None),
-            template2.volumes['root'].source)
+            template2.volumes['root'])
 
     def test_003_template_change_running(self):
         vm = self.get_vm()

--- a/qubes/vm/appvm.py
+++ b/qubes/vm/appvm.py
@@ -79,12 +79,6 @@ class AppVM(qubes.vm.qubesvm.QubesVM):
             # template is only passed if the AppVM is created, in other cases we
             # don't need to patch the volume_config because the config is
             # coming from XML, already as we need it
-
-            for name, conf in self.volume_config.items():
-                tpl_volume = template.volumes[name]
-
-                self.config_volume_from_source(conf, tpl_volume)
-
             for name, config in template.volume_config.items():
                 # in case the template vm has more volumes add them to own
                 # config
@@ -120,9 +114,5 @@ class AppVM(qubes.vm.qubesvm.QubesVM):
             if conf.get('snap_on_start', False) and \
                     conf.get('source', None) is None:
                 config = conf.copy()
-                template_volume = newvalue.volumes[volume_name]
-                self.volume_config[volume_name] = \
-                    self.config_volume_from_source(
-                        config,
-                        template_volume)
+                self.volume_config[volume_name] = config
                 self.storage.init_volume(volume_name, config)

--- a/qubes/vm/appvm.py
+++ b/qubes/vm/appvm.py
@@ -44,7 +44,6 @@ class AppVM(qubes.vm.qubesvm.QubesVM):
     default_volume_config = {
             'root': {
                 'name': 'root',
-                'pool': 'default',
                 'snap_on_start': True,
                 'save_on_stop': False,
                 'rw': False,
@@ -52,7 +51,6 @@ class AppVM(qubes.vm.qubesvm.QubesVM):
             },
             'private': {
                 'name': 'private',
-                'pool': 'default',
                 'snap_on_start': False,
                 'save_on_stop': True,
                 'rw': True,
@@ -60,7 +58,6 @@ class AppVM(qubes.vm.qubesvm.QubesVM):
             },
             'volatile': {
                 'name': 'volatile',
-                'pool': 'default',
                 'snap_on_start': False,
                 'save_on_stop': False,
                 'size': defaults['root_img_size'],
@@ -68,7 +65,6 @@ class AppVM(qubes.vm.qubesvm.QubesVM):
             },
             'kernel': {
                 'name': 'kernel',
-                'pool': 'linux-kernel',
                 'snap_on_start': False,
                 'save_on_stop': False,
                 'rw': False,

--- a/qubes/vm/dispvm.py
+++ b/qubes/vm/dispvm.py
@@ -43,7 +43,6 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
         self.volume_config = {
             'root': {
                 'name': 'root',
-                'pool': 'default',
                 'snap_on_start': True,
                 'save_on_stop': False,
                 'rw': False,
@@ -51,7 +50,6 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
             },
             'private': {
                 'name': 'private',
-                'pool': 'default',
                 'snap_on_start': True,
                 'save_on_stop': False,
                 'rw': True,
@@ -59,7 +57,6 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
             },
             'volatile': {
                 'name': 'volatile',
-                'pool': 'default',
                 'snap_on_start': False,
                 'save_on_stop': False,
                 'rw': True,
@@ -68,7 +65,6 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
             },
             'kernel': {
                 'name': 'kernel',
-                'pool': 'linux-kernel',
                 'snap_on_start': False,
                 'save_on_stop': False,
                 'rw': False,

--- a/qubes/vm/dispvm.py
+++ b/qubes/vm/dispvm.py
@@ -78,11 +78,6 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
             # template is only passed if the AppVM is created, in other cases we
             # don't need to patch the volume_config because the config is
             # coming from XML, already as we need it
-
-            for name, conf in self.volume_config.items():
-                tpl_volume = template.volumes[name]
-                self.config_volume_from_source(conf, tpl_volume)
-
             for name, config in template.volume_config.items():
                 # in case the template vm has more volumes add them to own
                 # config

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -1682,24 +1682,6 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
     # helper methods
     #
 
-    @staticmethod
-    def config_volume_from_source(volume_config, source):
-        '''Adjust storage volume config to use given volume as a source'''
-
-        volume_config['size'] = source.size
-        volume_config['pool'] = source.pool
-
-        needs_source = (
-            'source' in volume_config)
-        is_snapshot = 'snap_on_start' in volume_config and volume_config[
-            'snap_on_start']
-        if is_snapshot and needs_source:
-            if source.source is not None:
-                volume_config['source'] = source.source
-            else:
-                volume_config['source'] = source
-        return volume_config
-
     def relative_path(self, path):
         '''Return path relative to py:attr:`dir_path`.
 

--- a/qubes/vm/standalonevm.py
+++ b/qubes/vm/standalonevm.py
@@ -30,7 +30,6 @@ class StandaloneVM(qubes.vm.qubesvm.QubesVM):
         self.volume_config = {
             'root': {
                 'name': 'root',
-                'pool': 'default',
                 'snap_on_start': False,
                 'save_on_stop': True,
                 'rw': True,
@@ -39,7 +38,6 @@ class StandaloneVM(qubes.vm.qubesvm.QubesVM):
             },
             'private': {
                 'name': 'private',
-                'pool': 'default',
                 'snap_on_start': False,
                 'save_on_stop': True,
                 'rw': True,
@@ -48,7 +46,6 @@ class StandaloneVM(qubes.vm.qubesvm.QubesVM):
             },
             'volatile': {
                 'name': 'volatile',
-                'pool': 'default',
                 'snap_on_start': False,
                 'save_on_stop': False,
                 'rw': True,
@@ -56,7 +53,6 @@ class StandaloneVM(qubes.vm.qubesvm.QubesVM):
             },
             'kernel': {
                 'name': 'kernel',
-                'pool': 'linux-kernel',
                 'snap_on_start': False,
                 'save_on_stop': False,
                 'rw': False,

--- a/qubes/vm/templatevm.py
+++ b/qubes/vm/templatevm.py
@@ -65,7 +65,6 @@ class TemplateVM(QubesVM):
         self.volume_config = {
             'root': {
                 'name': 'root',
-                'pool': 'default',
                 'snap_on_start': False,
                 'save_on_stop': True,
                 'rw': True,
@@ -74,7 +73,6 @@ class TemplateVM(QubesVM):
             },
             'private': {
                 'name': 'private',
-                'pool': 'default',
                 'snap_on_start': False,
                 'save_on_stop': True,
                 'rw': True,
@@ -84,7 +82,6 @@ class TemplateVM(QubesVM):
             },
             'volatile': {
                 'name': 'volatile',
-                'pool': 'default',
                 'size': defaults['root_img_size'],
                 'snap_on_start': False,
                 'save_on_stop': False,
@@ -92,7 +89,6 @@ class TemplateVM(QubesVM):
             },
             'kernel': {
                 'name': 'kernel',
-                'pool': 'linux-kernel',
                 'snap_on_start': False,
                 'save_on_stop': False,
                 'rw': False


### PR DESCRIPTION
Two major things here:
1. Fix `default_pool_*` global properties to be really used in all cases. Do not create `default` storage pool by default - instead create separate file and lvm, then point `default_pool` to one of them.
2. Integration tests now have fixed `tearDown` function, which means it is finally possible to run full test suite, not just individual tests. At this point it is possible to fix individual tests (or actual bugs detected by them). There are still a lot of file descriptor leaks though, so `ulimit -n some-large-number` is advised...

Besides this, some minor fixes:
 - fix `storage.clone*` functions (not exposed outside of qubesd, but used by integration tests)
 - fix invalid hostname handling in firewall (proper exception type)
 - don't load qubes.xml in qmemman (can lead to a deadlock)
 - fix some individual tests