### PR TITLE
Implement methods needed for qvm-start --cdrom=...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,14 +55,17 @@ ADMIN_API_METHODS_SIMPLE = \
 	admin.vm.device.pci.Available \
 	admin.vm.device.pci.Detach \
 	admin.vm.device.pci.List \
+	admin.vm.device.pci.Set.persistent \
 	admin.vm.device.block.Attach \
 	admin.vm.device.block.Available \
 	admin.vm.device.block.Detach \
 	admin.vm.device.block.List \
+	admin.vm.device.block.Set.persistent \
 	admin.vm.device.mic.Attach \
 	admin.vm.device.mic.Available \
 	admin.vm.device.mic.Detach \
 	admin.vm.device.mic.List \
+	admin.vm.device.mic.Set.persistent \
 	admin.vm.feature.CheckWithTemplate \
 	admin.vm.feature.Get \
 	admin.vm.feature.List \
@@ -188,6 +191,7 @@ endif
 		          admin.vm.device.testclass.Attach \
 				  admin.vm.device.testclass.Detach \
 				  admin.vm.device.testclass.List \
+				  admin.vm.device.testclass.Set.persistent \
 				  admin.vm.device.testclass.Available
 	# sanity check
 	for method in $(DESTDIR)/etc/qubes-rpc/policy/admin.*; do \

--- a/qubes/api/__init__.py
+++ b/qubes/api/__init__.py
@@ -325,6 +325,8 @@ class QubesDaemonProtocol(asyncio.Protocol):
             self.transport.write(content.encode('utf-8'))
 
     def send_event(self, subject, event, **kwargs):
+        if self.transport is None:
+            return
         self.event_sent = True
         self.send_header(0x31)
 

--- a/qubes/devices.py
+++ b/qubes/devices.py
@@ -352,8 +352,8 @@ class DeviceCollection(object):
         try:
             devices = self._vm.fire_event('device-list-attached:' + self._bus,
                 persistent=persistent)
-        except Exception as e:  # pylint: disable=broad-except
-            self._vm.log.exception(e, 'Failed to list {} devices'.format(
+        except Exception:  # pylint: disable=broad-except
+            self._vm.log.exception('Failed to list {} devices'.format(
                 self._bus))
             if persistent is True:
                 # don't break app.save()


### PR DESCRIPTION
Allow changing persistent device (required to boot the VM), to not-persistent -
making it one time attachment.

QubesOS/qubes-issues#3055