### PR TITLE
test fixes around memory leaks

### DIFF
--- a/qubes/tests/__init__.py
+++ b/qubes/tests/__init__.py
@@ -410,7 +410,11 @@ class QubesTestCase(unittest.TestCase):
 
         # Check for unfinished libvirt business.
         if libvirt_event_impl is not None:
-            self.loop.run_until_complete(libvirt_event_impl.drain())
+            try:
+                self.loop.run_until_complete(asyncio.wait_for(
+                    libvirt_event_impl.drain(), timeout=4))
+            except asyncio.TimeoutError:
+                raise AssertionError('libvirt event impl drain timeout')
 
         # Check there are no Tasks left.
         assert not self.loop._ready

--- a/qubes/tests/api.py
+++ b/qubes/tests/api.py
@@ -97,8 +97,6 @@ class TC_00_QubesDaemonProtocol(qubes.tests.QubesTestCase):
         super(TC_00_QubesDaemonProtocol, self).setUp()
         self.app = unittest.mock.Mock()
         self.app.log = self.log
-        self.loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(self.loop)
         self.sock_client, self.sock_server = socket.socketpair()
         self.reader, self.writer = self.loop.run_until_complete(
             asyncio.open_connection(sock=self.sock_client))
@@ -113,9 +111,6 @@ class TC_00_QubesDaemonProtocol(qubes.tests.QubesTestCase):
     def tearDown(self):
         self.sock_server.close()
         self.sock_client.close()
-        self.loop.stop()
-        self.loop.run_forever()
-        self.loop.close()
         super(TC_00_QubesDaemonProtocol, self).tearDown()
 
     def test_000_message_ok(self):

--- a/qubes/tests/api_admin.py
+++ b/qubes/tests/api_admin.py
@@ -90,6 +90,11 @@ class AdminAPITestCase(qubes.tests.QubesTestCase):
         self.base_dir_patch.stop()
         if os.path.exists(self.test_base_dir):
             shutil.rmtree(self.test_base_dir)
+        del self.vm
+        del self.template
+        self.app.close()
+        del self.app
+        del self.emitter
         super(AdminAPITestCase, self).tearDown()
 
     def call_mgmt_func(self, method, dest, arg=b'', payload=b''):
@@ -1594,6 +1599,12 @@ class TC_00_VMs(AdminAPITestCase):
             self.vm.volumes['private']
         self.vm2.volumes['private'].import_volume.return_value = \
             self.vm2.volumes['private']
+
+        self.addCleanup(self.cleanup_for_clone)
+
+    def cleanup_for_clone(self):
+        del self.vm2
+        del self.pool
 
     def test_520_vm_volume_clone(self):
         self.setup_for_clone()

--- a/qubes/tests/app.py
+++ b/qubes/tests/app.py
@@ -160,6 +160,17 @@ class TC_30_VMCollection(qubes.tests.QubesTestCase):
         self.testvm2 = qubes.tests.init.TestVM(
             None, None, qid=2, name='testvm2')
 
+        self.addCleanup(self.cleanup_vmcollection)
+
+    def cleanup_vmcollection(self):
+        self.testvm1.close()
+        self.testvm2.close()
+        self.vms.close()
+        del self.testvm1
+        del self.testvm2
+        del self.vms
+        del self.app
+
     def test_000_contains(self):
         self.vms._dict = {1: self.testvm1}
 

--- a/qubes/tests/events.py
+++ b/qubes/tests/events.py
@@ -163,8 +163,6 @@ class TC_00_Emitter(qubes.tests.QubesTestCase):
         emitter.events_enabled = True
 
         effect = loop.run_until_complete(emitter.fire_event_async('testevent'))
-        loop.close()
-        asyncio.set_event_loop(None)
 
         self.assertCountEqual(effect,
             ('testvalue1', 'testvalue2', 'testvalue3', 'testvalue4'))

--- a/qubes/tests/init.py
+++ b/qubes/tests/init.py
@@ -320,6 +320,16 @@ class TC_30_VMCollection(qubes.tests.QubesTestCase):
 
         self.testvm1 = TestVM(None, None, qid=1, name='testvm1')
         self.testvm2 = TestVM(None, None, qid=2, name='testvm2')
+        self.addCleanup(self.cleanup_testvm)
+
+    def cleanup_testvm(self):
+        self.vms.close()
+        self.testvm1.close()
+        self.testvm2.close()
+        del self.testvm1
+        del self.testvm2
+        del self.vms
+        del self.app
 
     def test_000_contains(self):
         self.vms._dict = {1: self.testvm1}

--- a/qubes/tests/storage_file.py
+++ b/qubes/tests/storage_file.py
@@ -75,6 +75,8 @@ class TC_00_FilePool(qubes.tests.QubesTestCase):
 
     def tearDown(self):
         self.app.cleanup()
+        self.app.close()
+        del self.app
         super(TC_00_FilePool, self).tearDown()
 
     def test000_default_pool_dir(self):
@@ -120,6 +122,8 @@ class TC_01_FileVolumes(qubes.tests.QubesTestCase):
         """ Remove the file based storage pool after testing """
         self.app.remove_pool("test-pool")
         self.app.cleanup()
+        self.app.close()
+        del self.app
         super(TC_01_FileVolumes, self).tearDown()
         shutil.rmtree(self.POOL_DIR, ignore_errors=True)
 
@@ -328,6 +332,8 @@ class TC_03_FilePool(qubes.tests.QubesTestCase):
         """ Remove the file based storage pool after testing """
         self.app.remove_pool("test-pool")
         self.app.cleanup()
+        self.app.close()
+        del self.app
         self.base_dir_patch3.stop()
         self.base_dir_patch2.stop()
         self.base_dir_patch.stop()

--- a/qubes/tests/storage_kernels.py
+++ b/qubes/tests/storage_kernels.py
@@ -80,6 +80,8 @@ class TC_01_KernelVolumes(qubes.tests.QubesTestCase):
         """ Remove the file based storage pool after testing """
         self.app.remove_pool("test-pool")
         self.app.cleanup()
+        self.app.close()
+        del self.app
         super(TC_01_KernelVolumes, self).tearDown()
         shutil.rmtree(self.POOL_DIR, ignore_errors=True)
 
@@ -233,6 +235,8 @@ class TC_03_KernelPool(qubes.tests.QubesTestCase):
         """ Remove the file based storage pool after testing """
         self.app.remove_pool("test-pool")
         self.app.cleanup()
+        self.app.close()
+        del self.app
         super(TC_03_KernelPool, self).tearDown()
         shutil.rmtree(self.POOL_DIR, ignore_errors=True)
         if os.path.exists('/tmp/qubes-test'):

--- a/qubes/tests/vm/adminvm.py
+++ b/qubes/tests/vm/adminvm.py
@@ -39,10 +39,15 @@ class TC_00_AdminVM(qubes.tests.QubesTestCase):
                 self.vm = qubes.vm.adminvm.AdminVM(self.app,
                     xml=None)
                 mock_qdb.assert_called_once_with('dom0')
+                self.addCleanup(self.cleanup_adminvm)
         except:  # pylint: disable=bare-except
             if self.id().endswith('.test_000_init'):
                 raise
             self.skipTest('setup failed')
+
+    def cleanup_adminvm(self):
+        self.vm.close()
+        del self.vm
 
     def test_000_init(self):
         pass

--- a/qubes/tests/vm/appvm.py
+++ b/qubes/tests/vm/appvm.py
@@ -67,12 +67,21 @@ class TC_90_AppVM(qubes.tests.vm.qubesvm.QubesVMTestsMixin,
             qid=1, name=qubes.tests.VMPREFIX + 'template')
         self.app.domains[self.template.name] = self.template
         self.app.domains[self.template] = self.template
+        self.addCleanup(self.cleanup_appvm)
+
+    def cleanup_appvm(self):
+        self.template.close()
+        del self.template
+        self.app.domains.clear()
+        self.app.pools.clear()
 
     def get_vm(self, **kwargs):
-        return qubes.vm.appvm.AppVM(self.app, None,
+        vm = qubes.vm.appvm.AppVM(self.app, None,
             qid=2, name=qubes.tests.VMPREFIX + 'test',
             template=self.template,
             **kwargs)
+        self.addCleanup(vm.close)
+        return vm
 
     def test_000_init(self):
         self.get_vm()

--- a/qubes/tests/vm/dispvm.py
+++ b/qubes/tests/vm/dispvm.py
@@ -57,6 +57,15 @@ class TC_00_DispVM(qubes.tests.QubesTestCase):
             name='test-vm', template=self.template, label='red')
         self.app.domains[self.appvm.name] = self.appvm
         self.app.domains[self.appvm] = self.appvm
+        self.addCleanup(self.cleanup_dispvm)
+
+    def cleanup_dispvm(self):
+        self.template.close()
+        self.appvm.close()
+        del self.template
+        del self.appvm
+        self.app.domains.clear()
+        self.app.pools.clear()
 
     @asyncio.coroutine
     def mock_coro(self, *args, **kwargs):

--- a/qubes/tests/vm/mix/net.py
+++ b/qubes/tests/vm/mix/net.py
@@ -52,6 +52,18 @@ class TC_00_NetVMMixin(
             self.app.domains._dict[domain.qid] = domain
         self.app.default_netvm = self.netvm1
         self.app.default_fw_netvm = self.netvm1
+        self.addCleanup(self.cleanup_netvms)
+
+    def cleanup_netvms(self):
+        self.netvm1.close()
+        self.netvm2.close()
+        self.nonetvm.close()
+        self.app.domains.close()
+        del self.netvm1
+        del self.netvm2
+        del self.nonetvm
+        del self.app.default_netvm
+        del self.app.default_fw_netvm
 
 
     @qubes.tests.skipUnlessDom0
@@ -81,6 +93,7 @@ class TC_00_NetVMMixin(
     def test_143_netvm_loopback(self):
         vm = self.get_vm()
         self.app.domains = {1: vm, vm: vm}
+        self.addCleanup(self.app.domains.clear)
         self.assertPropertyInvalidValue(vm, 'netvm', vm)
 
     def test_150_ip(self):

--- a/qubes/tests/vm/qubesvm.py
+++ b/qubes/tests/vm/qubesvm.py
@@ -122,9 +122,11 @@ class QubesVMTestsMixin(object):
         self.app.vmm.offline_mode = True
 
     def get_vm(self, **kwargs):
-        return qubes.vm.qubesvm.QubesVM(self.app, None,
+        vm = qubes.vm.qubesvm.QubesVM(self.app, None,
             qid=1, name=qubes.tests.VMPREFIX + 'test',
             **kwargs)
+        self.addCleanup(vm.close)
+        return vm
 
     def assertPropertyValue(self, vm, prop_name, set_value, expected_value,
             expected_xml_content=None):

--- a/qubes/vm/__init__.py
+++ b/qubes/vm/__init__.py
@@ -384,14 +384,16 @@ class BaseVM(qubes.PropertyHolder):
     def __repr__(self):
         proprepr = []
         for prop in self.property_list():
+            if prop.__name__ in ('name', 'qid'):
+                continue
             try:
                 proprepr.append('{}={!s}'.format(
                     prop.__name__, getattr(self, prop.__name__)))
             except AttributeError:
                 continue
 
-        return '<{} object at {:#x} {}>'.format(
-            self.__class__.__name__, id(self), ' '.join(proprepr))
+        return '<{} at {:#x} name={!r} qid={!r} {}>'.format(type(self).__name__,
+            id(self), self.name, self.qid, ' '.join(proprepr))
 
     #
     # xml serialising methods

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -710,6 +710,8 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
         if self._qdb_connection is not None:
             self._qdb_connection.close()
             self._qdb_connection = None
+        if self._libvirt_domain is not None:
+            self._libvirt_domain = None
         super().close()
 
     def __hash__(self):

--- a/test-packages/libvirt.py
+++ b/test-packages/libvirt.py
@@ -11,6 +11,12 @@ added as needed.
 class libvirtError(Exception):
     pass
 
+class virConnect:
+    pass
+
+class virDomain:
+    pass
+
 def openReadOnly(*args, **kwargs):
     raise libvirtError('mock module, always raises')
 


### PR DESCRIPTION
This PR adds one way any test can fail, i.e. by leaking (keeping references) to some predefined objects. If you don't like that, comment out `self.addCleanup(self.cleanup_gc)` in `QubesTestCase.setUp()`.