### PR TITLE
qubes/vm: Improve stopped event handling

### DIFF
--- a/qubes/app.py
+++ b/qubes/app.py
@@ -1183,7 +1183,7 @@ class Qubes(qubes.PropertyHolder):
             return
 
         if event == libvirt.VIR_DOMAIN_EVENT_STOPPED:
-            vm.fire_event('domain-shutdown')
+            vm.on_libvirt_domain_stopped()
 
     @qubes.events.handler('domain-pre-delete')
     def on_domain_pre_deleted(self, event, vm):

--- a/qubes/tests/integ/basic.py
+++ b/qubes/tests/integ/basic.py
@@ -137,7 +137,6 @@ class TC_00_Basic(qubes.tests.SystemTestCase):
             self.test_failure_reason = 'domain-shutdown event received twice'
         self.domain_shutdown_handled = True
 
-    @unittest.expectedFailure
     def test_201_shutdown_event_race(self):
         '''Regression test for 3164 - pure events edition'''
         vmname = self.make_vm_name('appvm')


### PR DESCRIPTION
The previous version did not ensure that the stopped/shutdown event was
handled before a new VM start. This can easily lead to problems like in
QubesOS/qubes-issues#3164.

This improved version now ensures that the stopped/shutdown events are
handled before a new VM start.

Additionally this version should be more robust against unreliable
events from libvirt. It handles missing, duplicated and delayed stopped
events.

Instead of one 'domain-shutdown' event there are now 'domain-stopped'
and 'domain-shutdown'. The later is generated after the former. This way
it's easy to run code after the VM is shutdown including the stop of
it's storage.