### PR TITLE
Disallow 'default' as VM name

### DIFF
--- a/core-modules/000QubesVm.py
+++ b/core-modules/000QubesVm.py
@@ -575,6 +575,9 @@ class QubesVm(object):
         if name.endswith('-dm'):
             # avoid conflict with device model stubdomain names for HVMs
             return False
+        if name == 'default':
+            # disallow keywords as VM names
+            return False
         return re.match(r"^[a-zA-Z][a-zA-Z0-9_.-]*$", name) is not None
 
     def pre_rename(self, new_name):


### PR DESCRIPTION
Small fix to disallow 'default' as name for a VM. Reasoning: it's
a keyword.

fixes QubesOS/qubes-issues#2857