### PR TITLE
Changes to speed up qvm-ls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ ADMIN_API_METHODS_SIMPLE = \
 	admin.vm.CreateInPool.StandaloneVM \
 	admin.vm.CreateInPool.TemplateVM \
 	admin.vm.CreateDisposable \
+	admin.vm.GetAllData \
 	admin.vm.Kill \
 	admin.vm.List \
 	admin.vm.Pause \

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ ADMIN_API_METHODS_SIMPLE = \
 	admin.pool.volume.Revert \
 	admin.pool.volume.Snapshot \
 	admin.property.Get \
+	admin.property.GetAll \
 	admin.property.GetDefault \
 	admin.property.Help \
 	admin.property.HelpRst \
@@ -79,6 +80,7 @@ ADMIN_API_METHODS_SIMPLE = \
 	admin.vm.firewall.SetPolicy \
 	admin.vm.firewall.Reload \
 	admin.vm.property.Get \
+	admin.vm.property.GetAll \
 	admin.vm.property.GetDefault \
 	admin.vm.property.Help \
 	admin.vm.property.HelpRst \

--- a/qubes/__init__.py
+++ b/qubes/__init__.py
@@ -200,6 +200,10 @@ class property(object):  # pylint: disable=redefined-builtin,invalid-name
             lambda self, prop, value: str(value))
         self.type = type
         self._default = default
+        self._default_function = None
+        if isinstance(default, collections.Callable):
+            self._default_function = default
+
         self._write_once = write_once
         self.order = order
         self.load_stage = load_stage
@@ -227,8 +231,8 @@ class property(object):  # pylint: disable=redefined-builtin,invalid-name
         if self._default is self._NO_DEFAULT:
             raise AttributeError(
                 'property {!r} have no default'.format(self.__name__))
-        elif isinstance(self._default, collections.Callable):
-            return self._default(instance)
+        elif self._default_function:
+            return self._default_function(instance)
         else:
             return self._default
 

--- a/qubes/__init__.py
+++ b/qubes/__init__.py
@@ -227,6 +227,9 @@ class property(object):  # pylint: disable=redefined-builtin,invalid-name
         except AttributeError:
             return self.get_default(instance)
 
+    def has_default(self):
+        return self._default is not self._NO_DEFAULT
+
     def get_default(self, instance):
         if self._default is self._NO_DEFAULT:
             raise AttributeError(

--- a/qubes/api/admin.py
+++ b/qubes/api/admin.py
@@ -82,6 +82,18 @@ class QubesMgmtEventsDispatcher(object):
         vm.remove_handler('*', self.vm_handler)
 
 
+def escape(unescaped_string):
+    '''Escape a string for the Admin API'''
+    result = unescaped_string
+    # TODO: can we do this faster?
+    result = result.replace("\\", "\\\\") # this must be the first one
+
+    result = result.replace("\r", "\\r")
+    result = result.replace("\n", "\\n")
+    result = result.replace("\t", "\\t")
+    result = result.replace("\0", "\\0")
+    return result
+
 class QubesAdminAPI(qubes.api.AbstractQubesAPI):
     '''Implementation of Qubes Management API calls
 
@@ -107,6 +119,15 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
         return ''.join('{}\n'.format(ep.name)
             for ep in entrypoints)
 
+    # pylint: disable=no-self-use
+    def _vm_line_strs(self, strs, vm):
+        strs.append(vm.name)
+        strs.append(" class=")
+        strs.append(vm.__class__.__name__)
+        strs.append(" state=")
+        strs.append(vm.get_power_state())
+        strs.append("\n")
+
     @qubes.api.method('admin.vm.List', no_payload=True,
         scope='global', read=True)
     @asyncio.coroutine
@@ -119,11 +140,10 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
         else:
             domains = self.fire_event_for_filter([self.dest])
 
-        return ''.join('{} class={} state={}\n'.format(
-                vm.name,
-                vm.__class__.__name__,
-                vm.get_power_state())
-            for vm in sorted(domains))
+        strs = []
+        for vm in sorted(domains):
+            self._vm_line_strs(strs, vm)
+        return ''.join(strs)
 
     @qubes.api.method('admin.vm.property.List', no_payload=True,
         scope='local', read=True)
@@ -154,6 +174,13 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
         '''Get a value of one property'''
         return self._property_get(self.dest)
 
+    @qubes.api.method('admin.vm.property.GetAll', no_payload=True,
+        scope='local', read=True)
+    @asyncio.coroutine
+    def vm_property_get_all(self):
+        '''Get the value of all properties'''
+        return self._property_get_all(self.dest)
+
     @qubes.api.method('admin.property.Get', no_payload=True,
         scope='global', read=True)
     @asyncio.coroutine
@@ -162,24 +189,39 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
         assert self.dest.name == 'dom0'
         return self._property_get(self.app)
 
+    @qubes.api.method('admin.property.GetAll', no_payload=True,
+        scope='global', read=True)
+    @asyncio.coroutine
+    def property_get_all(self):
+        '''Get a value of all global properties'''
+        assert self.dest.name == 'dom0'
+        return self._property_get_all(self.app)
+
+    # pylint: disable=no-self-use
+    def _property_type(self, property_def):
+        # explicit list to be sure that it matches protocol spec
+        property_def_type = property_def.type
+        if property_def_type is str:
+            property_type = 'str'
+        elif property_def_type is int:
+            property_type = 'int'
+        elif property_def_type is bool:
+            property_type = 'bool'
+        elif property_def.__name__ == 'label':
+            property_type = 'label'
+        elif isinstance(property_def, qubes.vm.VMProperty):
+            property_type = 'vm'
+        else:
+            property_type = 'str'
+        return property_type
+
     def _property_get(self, dest):
         if self.arg not in dest.property_list():
             raise qubes.exc.QubesNoSuchPropertyError(dest, self.arg)
 
         self.fire_event_for_permission()
-
         property_def = dest.property_get_def(self.arg)
-        # explicit list to be sure that it matches protocol spec
-        if isinstance(property_def, qubes.vm.VMProperty):
-            property_type = 'vm'
-        elif property_def.type is int:
-            property_type = 'int'
-        elif property_def.type is bool:
-            property_type = 'bool'
-        elif self.arg == 'label':
-            property_type = 'label'
-        else:
-            property_type = 'str'
+        property_type = self._property_type(property_def)
 
         try:
             value = getattr(dest, self.arg)
@@ -190,6 +232,49 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
                 str(dest.property_is_default(self.arg)),
                 property_type,
                 str(value) if value is not None else '')
+
+
+    # this is a performance critical function for qvm-ls
+    def _property_get_all_line_strs(self, strs, dest, property_def):
+        property_type = self._property_type(property_def)
+        property_attr = property_def._attr_name # pylint: disable=protected-access
+        dest_dict = dest.__dict__
+        property_is_default = property_attr not in dest_dict
+
+        if not property_is_default:
+            value = dest_dict[property_attr]
+        elif property_def.has_default():
+            value = property_def.get_default(dest)
+        else:
+            value = None
+
+        if value is None:
+            escaped_value = ""
+        elif property_type == "str":
+            escaped_value = escape(str(value))
+        else:
+            escaped_value = str(value)
+
+        strs.append(property_def.__name__)
+        strs.append("\tD\t" if property_is_default else "\t-\t")
+        strs.append(property_type)
+        strs.append("\t")
+        strs.append(escaped_value)
+        strs.append("\n")
+
+    def _property_get_all_strs(self, strs, dest, prefix=None):
+        assert not self.arg
+
+        properties = self.fire_event_for_filter(dest.property_list())
+        for prop in properties:
+            if prefix:
+                strs.append(prefix)
+            self._property_get_all_line_strs(strs, dest, prop)
+
+    def _property_get_all(self, dest):
+        strs = []
+        self._property_get_all_strs(strs, dest)
+        return "".join(strs)
 
     @qubes.api.method('admin.vm.property.GetDefault', no_payload=True,
         scope='local', read=True)

--- a/qubes/api/admin.py
+++ b/qubes/api/admin.py
@@ -145,6 +145,33 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
             self._vm_line_strs(strs, vm)
         return ''.join(strs)
 
+    @qubes.api.method('admin.vm.GetAllData', no_payload=True,
+        scope='global', read=True)
+    @asyncio.coroutine
+    def vm_get_all_data(self):
+        '''List all VMs and return the value of all their properties'''
+        assert not self.arg
+
+        if self.dest.name == 'dom0':
+            domains = self.fire_event_for_filter(self.app.domains)
+        else:
+            domains = self.fire_event_for_filter([self.dest])
+
+        strs = []
+        orig_dest = self.dest
+        orig_method = self.method
+        try:
+            for vm in sorted(domains):
+                self.dest = vm
+                self.method = "admin.vm.property.GetAll"
+                self._vm_line_strs(strs, vm)
+                self._property_get_all_strs(strs, vm, "\tP\t")
+        finally:
+            self.dest = orig_dest
+            self.method = orig_method
+
+        return ''.join(strs)
+
     @qubes.api.method('admin.vm.property.List', no_payload=True,
         scope='local', read=True)
     @asyncio.coroutine

--- a/qubes/app.py
+++ b/qubes/app.py
@@ -536,14 +536,6 @@ class VMCollection(object):
         raise LookupError("Cannot find unused qid!")
 
 
-    def get_new_unused_netid(self):
-        used_ids = set([vm.netid for vm in self])  # if vm.is_netvm()])
-        for i in range(1, qubes.config.max_netid):
-            if i not in used_ids:
-                return i
-        raise LookupError("Cannot find unused netid!")
-
-
     def get_new_unused_dispid(self):
         for _ in range(int(qubes.config.max_dispid ** 0.5)):
             dispid = random.SystemRandom().randrange(qubes.config.max_dispid)

--- a/qubes/app.py
+++ b/qubes/app.py
@@ -1040,10 +1040,13 @@ class Qubes(qubes.PropertyHolder):
         }
         assert max(self.labels.keys()) == qubes.config.max_default_label
 
-        # check if the default LVM Thin pool qubes_dom0/pool00 exists
-        if os.path.exists('/dev/mapper/qubes_dom0-pool00-tpool'):
-            self.add_pool(volume_group='qubes_dom0', thin_pool='pool00',
-                          name='lvm', driver='lvm_thin')
+        root_volume_group = RootThinPool.volume_group()
+        root_thin_pool = RootThinPool.thin_pool()
+
+        if root_thin_pool:
+            self.add_pool(
+                volume_group=root_volume_group, thin_pool=root_thin_pool,
+                name='lvm', driver='lvm_thin')
         # pool based on /var/lib/qubes will be created here:
         for name, config in qubes.config.defaults['pool_configs'].items():
             self.pools[name] = self._get_pool(**config)

--- a/qubes/app.py
+++ b/qubes/app.py
@@ -545,6 +545,55 @@ class VMCollection(object):
             'https://xkcd.com/221/',
             'http://dilbert.com/strip/2001-10-25')[random.randint(0, 1)])
 
+# pylint: disable=too-few-public-methods
+class RootThinPool:
+    '''The thin pool containing the rootfs device'''
+    _inited = False
+    _volume_group = None
+    _thin_pool = None
+
+    @classmethod
+    def _init(cls):
+        '''Find out the thin pool containing the root device'''
+        if not cls._inited:
+            cls._inited = True
+
+            try:
+                rootfs = os.stat('/')
+                root_major = (rootfs.st_dev & 0xff00) >> 8
+                root_minor = rootfs.st_dev & 0xff
+
+                root_table = subprocess.check_output(["dmsetup",
+                    "-j", str(root_major), "-m", str(root_minor),
+                    "table"])
+
+                _start, _sectors, target_type, target_args = \
+                    root_table.decode().split(" ", 3)
+                if target_type == "thin":
+                    thin_pool_devnum, _thin_pool_id = target_args.split(" ")
+                    with open("/sys/dev/block/{}/dm/name"
+                        .format(thin_pool_devnum), "r") as thin_pool_tpool_f:
+                        thin_pool_tpool = thin_pool_tpool_f.read().rstrip('\n')
+                    if thin_pool_tpool.endswith("-tpool"):
+                        volume_group, thin_pool, _tpool = \
+                            thin_pool_tpool.rsplit("-", 2)
+                        cls._volume_group = volume_group
+                        cls._thin_pool = thin_pool
+            except: # pylint: disable=bare-except
+                pass
+
+    @classmethod
+    def volume_group(cls):
+        '''Volume group of the thin pool containing the rootfs device'''
+        cls._init()
+        return cls._volume_group
+
+    @classmethod
+    def thin_pool(cls):
+        '''Thin pool name containing the rootfs device'''
+        cls._init()
+        return cls._thin_pool
+
 def _default_pool(app):
     ''' Default storage pool.
 
@@ -556,20 +605,16 @@ def _default_pool(app):
     if 'default' in app.pools:
         return app.pools['default']
     else:
-        rootfs = os.stat('/')
-        root_major = (rootfs.st_dev & 0xff00) >> 8
-        root_minor = rootfs.st_dev & 0xff
-        for pool in app.pools.values():
-            if pool.config.get('driver', None) != 'lvm_thin':
-                continue
-            thin_pool = pool.config['thin_pool']
-            thin_volumes = subprocess.check_output(
-                ['lvs', '--select', 'pool_lv=' + thin_pool,
-                '-o', 'lv_kernel_major,lv_kernel_minor', '--noheadings'])
-            thin_volumes = thin_volumes.decode()
-            if any([str(root_major), str(root_minor)] == thin_vol.split()
-                    for thin_vol in thin_volumes.splitlines()):
-                return pool
+        root_volume_group = RootThinPool.volume_group()
+        root_thin_pool = RootThinPool.thin_pool()
+        if root_thin_pool:
+            for pool in app.pools.values():
+                if pool.config.get('driver', None) != 'lvm_thin':
+                    continue
+                if (pool.config['volume_group'] == root_volume_group and
+                    pool.config['thin_pool'] == root_thin_pool):
+                    return pool
+
         # not a thin volume? look for file pools
         for pool in app.pools.values():
             if pool.config.get('driver', None) != 'file':

--- a/qubes/config.py
+++ b/qubes/config.py
@@ -100,7 +100,6 @@ defaults = {
 }
 
 max_qid = 254
-max_netid = 254
 max_dispid = 10000
 #: built-in standard labels, if creating new one, allocate them above this
 # number, at least until label index is removed from API

--- a/qubes/tests/api_admin.py
+++ b/qubes/tests/api_admin.py
@@ -1566,7 +1566,7 @@ class TC_00_VMs(AdminAPITestCase):
     def test_501_vm_remove_running(self, mock_rmtree, mock_remove):
         mock_remove.side_effect = self.dummy_coro
         with unittest.mock.patch.object(
-                self.vm, 'get_power_state', lambda: 'Running'):
+                self.vm, 'is_halted', lambda: False):
             with self.assertRaises(qubes.exc.QubesVMNotHaltedError):
                 self.call_mgmt_func(b'admin.vm.Remove', b'test-vm1')
         self.assertFalse(mock_rmtree.called)
@@ -1582,7 +1582,7 @@ class TC_00_VMs(AdminAPITestCase):
 
     def test_511_vm_volume_import_running(self):
         with unittest.mock.patch.object(
-                self.vm, 'get_power_state', lambda: 'Running'):
+                self.vm, 'is_halted', lambda: False):
             with self.assertRaises(qubes.exc.QubesVMNotHaltedError):
                 self.call_mgmt_func(b'admin.vm.volume.Import', b'test-vm1',
                     b'private')

--- a/qubes/tests/app.py
+++ b/qubes/tests/app.py
@@ -257,12 +257,6 @@ class TC_30_VMCollection(qubes.tests.QubesTestCase):
 
         self.vms.get_new_unused_qid()
 
-    def test_101_get_new_unused_netid(self):
-        self.vms.add(self.testvm1)
-        self.vms.add(self.testvm2)
-
-        self.vms.get_new_unused_netid()
-
 #   def test_200_get_vms_based_on(self):
 #       pass
 

--- a/qubes/tests/init.py
+++ b/qubes/tests/init.py
@@ -323,7 +323,6 @@ class TC_20_PropertyHolder(qubes.tests.QubesTestCase):
 class TestVM(qubes.vm.BaseVM):
     qid = qubes.property('qid', type=int)
     name = qubes.property('name')
-    netid = qid
     uuid = uuid.uuid5(uuid.NAMESPACE_DNS, 'testvm')
 
     def __lt__(self, other):
@@ -451,12 +450,6 @@ class TC_30_VMCollection(qubes.tests.QubesTestCase):
         self.vms.add(self.testvm2)
 
         self.vms.get_new_unused_qid()
-
-    def test_101_get_new_unused_netid(self):
-        self.vms.add(self.testvm1)
-        self.vms.add(self.testvm2)
-
-        self.vms.get_new_unused_netid()
 
 #   def test_200_get_vms_based_on(self):
 #       pass

--- a/qubes/tests/vm/appvm.py
+++ b/qubes/tests/vm/appvm.py
@@ -125,8 +125,8 @@ class TC_90_AppVM(qubes.tests.vm.qubesvm.QubesVMTestsMixin,
 
     def test_003_template_change_running(self):
         vm = self.get_vm()
-        with mock.patch.object(vm, 'get_power_state') as mock_power:
-            mock_power.return_value = 'Running'
+        with mock.patch.object(vm, 'is_halted') as mock_power:
+            mock_power.return_value = False
             with self.assertRaises(qubes.exc.QubesVMNotHaltedError):
                 vm.template = self.template
 

--- a/qubes/tools/qubesd.py
+++ b/qubes/tools/qubesd.py
@@ -51,9 +51,15 @@ def main(args=None):
         for sock in server.sockets:
             socknames.append(sock.getsockname())
 
-    for signame in ('SIGINT', 'SIGTERM'):
-        loop.add_signal_handler(getattr(signal, signame),
-            sighandler, loop, signame, servers)
+    # don't replace pdb debugger's SIGINT handler
+    old_sigint = signal.getsignal(signal.SIGINT)
+    if (old_sigint == signal.SIG_DFL or old_sigint == signal.SIG_IGN or
+        old_sigint == signal.default_int_handler):
+        loop.add_signal_handler(signal.SIGINT,
+            sighandler, loop, "SIGINT", servers)
+
+    loop.add_signal_handler(signal.SIGTERM,
+        sighandler, loop, "SIGTERM", servers)
 
     qubes.utils.systemd_notify()
     # make sure children will not inherit this

--- a/qubes/vm/__init__.py
+++ b/qubes/vm/__init__.py
@@ -511,6 +511,12 @@ class BaseVM(qubes.PropertyHolder):
         '''Domain class name'''
         return type(self).__name__
 
+    def libvirt_connected(self):
+        pass
+
+    def libvirt_lifecycle_event(self, event, detail):
+        pass
+
 class VMProperty(qubes.property):
     '''Property that is referring to a VM
 

--- a/qubes/vm/adminvm.py
+++ b/qubes/vm/adminvm.py
@@ -189,7 +189,7 @@ class AdminVM(qubes.vm.BaseVM):
 
 
 #   def __init__(self, **kwargs):
-#       super(QubesAdminVm, self).__init__(qid=0, name="dom0", netid=0,
+#       super(QubesAdminVm, self).__init__(qid=0, name="dom0",
 #                                            dir_path=None,
 #                                            private_img = None,
 #                                            template = None,

--- a/qubes/vm/mix/net.py
+++ b/qubes/vm/mix/net.py
@@ -123,13 +123,13 @@ class NetVMMixin(qubes.events.Emitter):
     def visible_gateway(self):
         '''Default gateway of this domain as seen by the domain.'''
         return self.features.check_with_template('net.fake-gateway', None) or \
-            self.netvm.gateway
+            (self.netvm.gateway if self.netvm else None)
 
     @qubes.stateless_property
     def visible_netmask(self):
         '''Netmask as seen by the domain.'''
         return self.features.check_with_template('net.fake-netmask', None) or \
-            self.netvm.netmask
+            (self.netvm.netmask if self.netvm else None)
 
     #
     # used in netvms (provides_network=True)

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -1074,6 +1074,10 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
         if user is None:
             user = self.default_user
 
+        # wait for start to complete
+        with (yield from self.startup_lock):
+            pass
+
         if self.is_paused():
             # XXX what about autostart?
             raise qubes.exc.QubesVMNotRunningError(

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -1577,9 +1577,10 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
             return 0
 
         try:
-            if not self.libvirt_domain.isActive():
+            info = self.libvirt_domain.info()
+            if info[0] == libvirt.VIR_DOMAIN_SHUTOFF:
                 return 0
-            return self.libvirt_domain.info()[1]
+            return info[1]
 
         except libvirt.libvirtError as e:
             if e.get_error_code() in (
@@ -1632,20 +1633,16 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
         if self.libvirt_domain is None:
             return 0
 
-        if self.libvirt_domain is None:
-            return 0
-        if not self.libvirt_domain.isActive():
-            return 0
-
         try:
-            if not self.libvirt_domain.isActive():
-                return 0
-
         # this does not work, because libvirt
 #           return self.libvirt_domain.getCPUStats(
 #               libvirt.VIR_NODE_CPU_STATS_ALL_CPUS, 0)[0]['cpu_time']/10**9
 
-            return self.libvirt_domain.info()[4]
+            info = self.libvirt_domain.info()
+            if info[0] == libvirt.VIR_DOMAIN_SHUTOFF:
+                return 0
+
+            return info[4]
 
         except libvirt.libvirtError as e:
             if e.get_error_code() in (

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -489,32 +489,11 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
         Or not Xen, but ID.
         '''
 
-        if self.libvirt_domain is None:
-            return -1
-        try:
-            return self.libvirt_domain.ID()
-        except libvirt.libvirtError as e:
-            if e.get_error_code() == libvirt.VIR_ERR_NO_DOMAIN:
-                return -1
-            else:
-                self.log.exception('libvirt error code: {!r}'.format(
-                    e.get_error_code()))
-                raise
+        return self._xid
 
     @qubes.stateless_property
     def stubdom_xid(self):
-        if not self.is_running():
-            return -1
-
-        if self.app.vmm.xs is None:
-            return -1
-
-        stubdom_xid_str = self.app.vmm.xs.read('',
-            '/local/domain/{}/image/device-model-domid'.format(self.xid))
-        if stubdom_xid_str is None or not stubdom_xid_str.isdigit():
-            return -1
-
-        return int(stubdom_xid_str)
+        return self._stubdom_xid
 
     @property
     def attached_volumes(self):
@@ -539,19 +518,24 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
 
         May be :py:obj:`None`, if libvirt knows nothing about this domain.
         '''
+        return self._get_libvirt_domain(True)
 
+    def _get_libvirt_domain(self, update):
         if self._libvirt_domain is not None:
             return self._libvirt_domain
 
-        # XXX _update_libvirt_domain?
-        try:
-            self._libvirt_domain = self.app.vmm.libvirt_conn.lookupByUUID(
-                self.uuid.bytes)
-        except libvirt.libvirtError as e:
-            if e.get_error_code() == libvirt.VIR_ERR_NO_DOMAIN:
-                self._update_libvirt_domain()
-            else:
-                raise
+        if not self.app.vmm.offline_mode:
+            # XXX _update_libvirt_domain?
+            try:
+                self._libvirt_domain = self.app.vmm.libvirt_conn.lookupByUUID(
+                    self.uuid.bytes)
+            except libvirt.libvirtError as e:
+                if e.get_error_code() == libvirt.VIR_ERR_NO_DOMAIN:
+                    if update:
+                        self._update_libvirt_domain()
+                else:
+                    raise
+
         return self._libvirt_domain
 
     @property
@@ -642,6 +626,10 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
 
         self._libvirt_domain = None
         self._qdb_connection = None
+        self._libvirt_state = libvirt.VIR_DOMAIN_SHUTOFF
+        self._libvirt_substate = 0 # libvirt.VIR_DOMAIN_SHUTOFF_UNKNOWN
+        self._xid = -1
+        self._stubdom_xid = -1
 
         if xml is None:
             # we are creating new VM and attributes came through kwargs
@@ -695,6 +683,49 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
 
         return element
 
+    def libvirt_connected(self):
+        self._update_libvirt_state()
+
+    def libvirt_lifecycle_event(self, event, detail):
+        # TODO: we could perhaps determine the new state from the event
+        #   without asking libvirtd
+        self._update_libvirt_state()
+
+    def _update_libvirt_state(self):
+        was_halted = self.is_halted()
+
+        if self.libvirt_domain is not None:
+            try:
+                state = self.libvirt_domain.state()
+                self._libvirt_state = state[0]
+                self._libvirt_substate = state[1]
+            except libvirt.libvirtError as e:
+                if e.get_error_code() != libvirt.VIR_ERR_NO_DOMAIN:
+                    self.log.exception('libvirt error code: {!r}'.format(
+                        e.get_error_code()))
+                    raise
+
+            try:
+                self._xid = self.libvirt_domain.ID()
+            except libvirt.libvirtError as e:
+                if e.get_error_code() != libvirt.VIR_ERR_NO_DOMAIN:
+                    self.log.exception('libvirt error code: {!r}'.format(
+                        e.get_error_code()))
+                    raise
+
+            if self.is_running() and self.app.vmm.xs is not None:
+                stubdom_xid_str = self.app.vmm.xs.read('',
+                    '/local/domain/{}/image/device-model-domid'
+                        .format(self.xid))
+                if stubdom_xid_str is not None and stubdom_xid_str.isdigit():
+                    self._stubdom_xid = int(stubdom_xid_str)
+
+        if self.is_halted() and not was_halted:
+            self.fire_event('domain-shutdown')
+
+    def _update_libvirt_state_after_op(self):
+        self._update_libvirt_state()
+
     #
     # event handlers
     #
@@ -709,6 +740,8 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
         # it might be already initialized by a recursive call from a child VM
         if self.storage is None:
             self.storage = qubes.storage.Storage(self)
+
+        self._update_libvirt_state()
 
         if not self.app.vmm.offline_mode and self.is_running():
             self.start_qdb_watch()
@@ -828,6 +861,7 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
 
                 self.libvirt_domain.createWithFlags(
                     libvirt.VIR_DOMAIN_START_PAUSED)
+                self._update_libvirt_state()
 
             except Exception as exc:
                 # let anyone receiving domain-pre-start know that startup failed
@@ -850,6 +884,7 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
 
                 self.log.warning('Activating the {} VM'.format(self.name))
                 self.libvirt_domain.resume()
+                self._update_libvirt_state_after_op()
 
                 yield from self.start_qrexec_daemon()
 
@@ -905,6 +940,8 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
 
         self.libvirt_domain.shutdown()
 
+        self._update_libvirt_state_after_op()
+
         while wait and not self.is_halted():
             yield from asyncio.sleep(0.25)
 
@@ -922,6 +959,8 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
             raise qubes.exc.QubesVMNotStartedError(self)
 
         self.libvirt_domain.destroy()
+
+        self._update_libvirt_state_after_op()
 
         return self
 
@@ -951,6 +990,8 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
         else:
             self.libvirt_domain.suspend()
 
+        self._update_libvirt_state_after_op()
+
         return self
 
     @asyncio.coroutine
@@ -961,6 +1002,8 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
             raise qubes.exc.QubesVMNotRunningError(self)
 
         self.libvirt_domain.suspend()
+
+        self._update_libvirt_state_after_op()
 
         return self
 
@@ -975,6 +1018,9 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
         # pylint: disable=not-an-iterable
         if self.get_power_state() == "Suspended":
             self.libvirt_domain.pMWakeup()
+
+            self._update_libvirt_state_after_op()
+
             yield from self.run_service_for_stdio('qubes.SuspendPost',
                 user='root')
         else:
@@ -989,6 +1035,8 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
             raise qubes.exc.QubesVMNotPausedError(self)
 
         self.libvirt_domain.resume()
+
+        self._update_libvirt_state_after_op()
 
         return self
 
@@ -1444,52 +1492,24 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
                 Libvirt's enum describing precise state of a domain.
         '''  # pylint: disable=too-many-return-statements
 
-        # don't try to define libvirt domain, if it isn't there, VM surely
-        # isn't running
-        # reason for this "if": allow vm.is_running() in PCI (or other
-        # device) extension while constructing libvirt XML
-        if self.app.vmm.offline_mode:
-            return 'Halted'
-        if self._libvirt_domain is None:
-            try:
-                self._libvirt_domain = self.app.vmm.libvirt_conn.lookupByUUID(
-                    self.uuid.bytes)
-            except libvirt.libvirtError as e:
-                if e.get_error_code() == libvirt.VIR_ERR_NO_DOMAIN:
-                    return 'Halted'
-                else:
-                    raise
+        state = self._libvirt_state
+        if state == libvirt.VIR_DOMAIN_PAUSED:
+            return "Paused"
+        elif state == libvirt.VIR_DOMAIN_CRASHED:
+            return "Crashed"
+        elif state == libvirt.VIR_DOMAIN_SHUTDOWN:
+            return "Halting"
+        elif state == libvirt.VIR_DOMAIN_SHUTOFF:
+            return "Halted"
+        elif state == libvirt.VIR_DOMAIN_PMSUSPENDED:  # nopep8
+            return "Suspended"
+        elif state == libvirt.VIR_DOMAIN_RUNNING:
+            if not self.is_fully_usable():
+                return "Transient"
 
-        libvirt_domain = self.libvirt_domain
-        if libvirt_domain is None:
-            return 'Halted'
-
-        try:
-            if libvirt_domain.isActive():
-                # pylint: disable=line-too-long
-                if libvirt_domain.state()[0] == libvirt.VIR_DOMAIN_PAUSED:
-                    return "Paused"
-                elif libvirt_domain.state()[0] == libvirt.VIR_DOMAIN_CRASHED:
-                    return "Crashed"
-                elif libvirt_domain.state()[0] == libvirt.VIR_DOMAIN_SHUTDOWN:
-                    return "Halting"
-                elif libvirt_domain.state()[0] == libvirt.VIR_DOMAIN_SHUTOFF:
-                    return "Dying"
-                elif libvirt_domain.state()[0] == libvirt.VIR_DOMAIN_PMSUSPENDED:  # nopep8
-                    return "Suspended"
-                else:
-                    if not self.is_fully_usable():
-                        return "Transient"
-
-                    return "Running"
-
-            return 'Halted'
-        except libvirt.libvirtError as e:
-            if e.get_error_code() == libvirt.VIR_ERR_NO_DOMAIN:
-                return 'Halted'
-            raise
-
-        assert False
+            return "Running"
+        else:
+            assert False
 
     def is_halted(self):
         ''' Check whether this domain's state is 'Halted'
@@ -1497,7 +1517,7 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
                 :py:obj:`False` otherwise.
             :rtype: bool
         '''
-        return self.get_power_state() == 'Halted'
+        return self._libvirt_state == libvirt.VIR_DOMAIN_SHUTOFF
 
     def is_running(self):
         '''Check whether this domain is running.
@@ -1507,24 +1527,7 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
         :rtype: bool
         '''
 
-        if self.app.vmm.offline_mode:
-            return False
-
-        # don't try to define libvirt domain, if it isn't there, VM surely
-        # isn't running
-        # reason for this "if": allow vm.is_running() in PCI (or other
-        # device) extension while constructing libvirt XML
-        if self._libvirt_domain is None:
-            try:
-                self._libvirt_domain = self.app.vmm.libvirt_conn.lookupByUUID(
-                    self.uuid.bytes)
-            except libvirt.libvirtError as e:
-                if e.get_error_code() == libvirt.VIR_ERR_NO_DOMAIN:
-                    return False
-                else:
-                    raise
-
-        return self.libvirt_domain.isActive()
+        return self._libvirt_state != libvirt.VIR_DOMAIN_SHUTOFF
 
     def is_paused(self):
         '''Check whether this domain is paused.
@@ -1534,8 +1537,7 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
         :rtype: bool
         '''
 
-        return self.libvirt_domain \
-            and self.libvirt_domain.state()[0] == libvirt.VIR_DOMAIN_PAUSED
+        return self._libvirt_state == libvirt.VIR_DOMAIN_PAUSED
 
     def is_qrexec_running(self):
         '''Check whether qrexec for this domain is available.
@@ -1751,6 +1753,7 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
         try:
             self._libvirt_domain = self.app.vmm.libvirt_conn.defineXML(
                 domain_config)
+            self._update_libvirt_state()
         except libvirt.libvirtError as e:
             if e.get_error_code() == libvirt.VIR_ERR_OS_TYPE \
                     and e.get_str2() == 'hvm':


### PR DESCRIPTION
This is the server part of a bunch of changes that get qvm-ls to around 200ms run time.

Warning: I haven't tested them much, and they change fundamental code, so they probably need fixes

The first major change is the introduction of APIs that allow to get all properties of a VM or of Qubes and all properties of all VMs in a single call.

The second major change is storing the libvirt state in qubesd (and changing it in response to events), so that libvirtd calls are not required to get the system state.

Finally, there's some optimization and fixes.
