### PR TITLE
vm.run*(): Stop leaking terminal escapes via stderr!

### DIFF
--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -32,6 +32,7 @@ import os.path
 import shutil
 import string
 import subprocess
+import sys
 import uuid
 import warnings
 
@@ -1045,7 +1046,8 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
         return (yield from asyncio.create_subprocess_exec(
             qubes.config.system_path['qrexec_client_path'],
             '-d', str(self.name),
-            *(('-t', '-T') if filter_esc else ()),
+            *(('-t',) if filter_esc else ()),
+            *(('-T',) if filter_esc or os.isatty(sys.stderr.fileno()) else ()),
             '{}:QUBESRPC {} {}'.format(user, service, source),
             **kwargs))
 
@@ -1097,6 +1099,7 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
         return asyncio.create_subprocess_exec(
             qubes.config.system_path['qrexec_client_path'],
             '-d', str(self.name),
+            *(('-T',) if os.isatty(sys.stderr.fileno()) else ()),
             '{}:{}'.format(user, command),
             **kwargs)
 


### PR DESCRIPTION
This restores Qubes R3.2 behavior

Before this patch, the following:

    qvm-run -p sys-firewall 'echo -e "\e[0;46mcyan!" >&2' | wc -l

leaks the escape sequences through to the dom0 terminal via stderr,
in this case demonstrated by the ability to change the text color while
it should be fixed to red.

This can also be abused with xterm reporting sequences to cause input
to be sent to the dom0 terminal! This is potentially a security issue!