### PR TITLE
volume.Import: write data with sufficient privs

### DIFF
--- a/qubes-rpc/admin.vm.volume.Import
+++ b/qubes-rpc/admin.vm.volume.Import
@@ -43,7 +43,7 @@ size=$(tail -c +3 "$tmpfile"|cut -d ' ' -f 1)
 path=$(tail -c +3 "$tmpfile"|cut -d ' ' -f 2)
 
 # now process stdin into this path
-if dd bs=4k of="$path" count="$size" iflag=count_bytes,fullblock \
+if sudo dd bs=4k of="$path" count="$size" iflag=count_bytes,fullblock \
         conv=sparse,notrunc,nocreat,fdatasync status=none; then
     status="ok"
 else


### PR DESCRIPTION
Not sure how this ever worked before, if it did.

The device nodes pointed to by /dev/qubes_dom0/* are owned by
root:disk with perms 660, qubes user is not in disk group,
and service is invoked as qubes user, not root.