### PR TITLE
Allow to choose emulated video model via qvm-features

### DIFF
--- a/templates/libvirt/xen.xml
+++ b/templates/libvirt/xen.xml
@@ -167,7 +167,7 @@
                     />
                 <input type="tablet" bus="usb"/>
                 <video>
-                    <model type="vga"/>
+                    <model type="{{ vm.features.check_with_template('video-model', 'vga') }}"/>
                 </video>
                 {% if vm.features.check_with_template('linux-stubdom', True) %}
                     {# TODO only add qubes gui if gui-agent is not installed in HVM #}


### PR DESCRIPTION
Add feature named 'video-model' to choose custom video model. It needs
to be supported by libvirt: https://libvirt.org/formatdomain.html#elementsVideo

Example usage:

    qvm-features vm-name video-model cirrus

QubesOS/qubes-issues#2488
QubesOS/qubes-issues#3432