### PR TITLE
Use default_dispvm (not default_template) for new DispVM

### DIFF
--- a/qubes/app.py
+++ b/qubes/app.py
@@ -1184,7 +1184,10 @@ class Qubes(qubes.PropertyHolder):
         # handle default template; specifically allow template=None (do not
         # override it with default template)
         if 'template' not in kwargs and hasattr(cls, 'template'):
-            kwargs['template'] = self.default_template
+            if cls == self.get_vm_class('DispVM'):
+                kwargs['template'] = self.default_dispvm
+            else:
+                kwargs['template'] = self.default_template
         elif 'template' in kwargs and isinstance(kwargs['template'], str):
             kwargs['template'] = self.domains[kwargs['template']]
 


### PR DESCRIPTION
When creating a new VM of type DispVM without specifying any template (e.g. `qvm-create --class DispVM --label red foo`), use `default_dispvm`. Otherwise it would fail saying `Got empty response from qubesd.`