### PR TITLE
R3.2: PVH/HVM support

### DIFF
--- a/core-modules/000QubesVm.py
+++ b/core-modules/000QubesVm.py
@@ -444,7 +444,7 @@ class QubesVm(object):
             if vmm.offline_mode:
                 return 'default'
 
-            if vmm.hvm_supported and vmm.hap_supported and not self.pcidevs:
+            if vmm.pvh_supported and vmm.hap_supported and not self.pcidevs:
                 value = 'pvh'
             else:
                 value = 'pv'

--- a/core-modules/000QubesVm.py
+++ b/core-modules/000QubesVm.py
@@ -1964,6 +1964,8 @@ class QubesVm(object):
         MEM_OVERHEAD_PER_VCPU = 3 * 1024 * 1024 / 2
         if mem_required is None:
             mem_required = int(self.memory) * 1024 * 1024
+            if self.virt_mode == 'hvm':
+                mem_required += (128 + 8) * 1024 * 1024 # memory for stubdom
         if qmemman_present:
             qmemman_client = QMemmanClient()
             try:

--- a/core-modules/000QubesVm.py
+++ b/core-modules/000QubesVm.py
@@ -90,12 +90,6 @@ class QubesVm(object):
     hooks_verify_files = []
     hooks_set_attr = []
 
-    @staticmethod
-    def __virt_mode(value):
-        if value not in ["pv", "pvh", "hvm"]:
-            raise QubesException("Invalid virt_mode.")
-        return value
-
     def get_attrs_config(self):
         """ Object attributes for serialization/deserialization
             inner dict keys:
@@ -132,6 +126,7 @@ class QubesVm(object):
             "virt_mode": {
                 "default": "pvh",
                 "order": 10,
+                "attr": '_virt_mode',
                 "func": self.__virt_mode},
             ### order >= 20: have template set
             "uses_default_netvm": { "default": True, 'order': 20 },
@@ -437,6 +432,20 @@ class QubesVm(object):
         # fire hooks
         for hook in self.hooks_label_setter:
             hook(self, new_label)
+
+    @staticmethod
+    def __virt_mode(value):
+        if value not in ["pv", "pvh", "hvm"]:
+            raise QubesException("Invalid virt_mode.")
+        return value
+
+    @property
+    def virt_mode(self):
+        return self._virt_mode
+
+    @virt_mode.setter
+    def virt_mode(self, new_value):
+        self._virt_mode = self.__virt_mode(new_value)
 
     @property
     def netvm(self):

--- a/core-modules/000QubesVm.py
+++ b/core-modules/000QubesVm.py
@@ -1981,6 +1981,11 @@ class QubesVm(object):
         self.log.debug('start('
             'preparing_dvm={!r}, start_guid={!r}, mem_required={!r})'.format(
                 preparing_dvm, start_guid, mem_required))
+
+        if len(self.pcidevs) != 0 and self.virt_mode == 'pvh':
+            raise QubesException(
+                "pvh mode can't be set if pci devices are attached")
+
         if dry_run:
             return
 

--- a/core-modules/000QubesVm.py
+++ b/core-modules/000QubesVm.py
@@ -444,7 +444,7 @@ class QubesVm(object):
             if vmm.offline_mode:
                 return 'default'
 
-            if vmm.hvm_supported and not self.pcidevs:
+            if vmm.hvm_supported and vmm.hap_supported and not self.pcidevs:
                 value = 'pvh'
             else:
                 value = 'pv'

--- a/core-modules/01QubesDisposableVm.py
+++ b/core-modules/01QubesDisposableVm.py
@@ -102,6 +102,7 @@ class QubesDisposableVm(QubesVm):
             kwargs['kernelopts'] = disp_template.kernelopts
             kwargs['uses_default_kernelopts'] = \
                 disp_template.uses_default_kernelopts
+            kwargs['virt_mode'] = disp_template.virt_mode
         super(QubesDisposableVm, self).__init__(**kwargs)
 
         assert self.template is not None, "Missing template for DisposableVM!"

--- a/core/qubes.py
+++ b/core/qubes.py
@@ -53,6 +53,7 @@ dry_run = False
 if not dry_run:
     import libvirt
     try:
+        import xen.lowlevel.xc
         import xen.lowlevel.xs
     except ImportError:
         pass
@@ -136,6 +137,7 @@ class QubesVMMConnection(object):
         self._offline_mode = False
         self._hvm_supported = None
         self._hap_supported = None
+        self._pvh_supported = None
 
     @property
     def offline_mode(self):
@@ -159,6 +161,8 @@ class QubesVMMConnection(object):
             # Do not initialize in offline mode
             return
 
+        if 'xen.lowlevel.xc' in sys.modules:
+            self._xc = xen.lowlevel.xc.xc()
         if 'xen.lowlevel.xs' in sys.modules:
             self._xs = xen.lowlevel.xs.xs()
         self._libvirt_conn = libvirt.open(defaults['libvirt_uri'])
@@ -181,6 +185,13 @@ class QubesVMMConnection(object):
         return self._common_getter('_libvirt_conn')
 
     @property
+    def xc(self):
+        if 'xen.lowlevel.xc' in sys.modules:
+            return self._common_getter('_xc')
+        else:
+            return None
+
+    @property
     def xs(self):
         if 'xen.lowlevel.xs' in sys.modules:
             return self._common_getter('_xs')
@@ -198,10 +209,16 @@ class QubesVMMConnection(object):
     @property
     def hap_supported(self):
         if self._hap_supported is None:
-            caps_xml = lxml.etree.fromstring(self.libvirt_conn.getCapabilities())
-            self._hap_supported = bool(
-                    caps_xml.xpath('./guest/features/hap'))
+            xen_caps = self.xc.xeninfo()['xen_caps'].split()
+            self._hap_supported = 'qubes-hap' in xen_caps
         return self._hap_supported
+
+    @property
+    def pvh_supported(self):
+        if self._pvh_supported is None:
+            xen_caps = self.xc.xeninfo()['xen_caps'].split()
+            self._pvh_supported = 'qubes-pvh' in xen_caps
+        return self._pvh_supported
 
 
 ##### VMM global variable definition #####

--- a/core/qubes.py
+++ b/core/qubes.py
@@ -134,6 +134,7 @@ class QubesVMMConnection(object):
         self._xs = None
         self._xc = None
         self._offline_mode = False
+        self._hvm_supported = None
 
     @property
     def offline_mode(self):
@@ -184,6 +185,14 @@ class QubesVMMConnection(object):
             return self._common_getter('_xs')
         else:
             return None
+
+    @property
+    def hvm_supported(self):
+        if self._hvm_supported is None:
+            caps_xml = lxml.etree.fromstring(self.libvirt_conn.getCapabilities())
+            self._hvm_supported = bool(
+                    caps_xml.xpath('./guest/os_type[text()=\'hvm\']'))
+        return self._hvm_supported
 
 
 ##### VMM global variable definition #####

--- a/core/qubes.py
+++ b/core/qubes.py
@@ -135,6 +135,7 @@ class QubesVMMConnection(object):
         self._xc = None
         self._offline_mode = False
         self._hvm_supported = None
+        self._hap_supported = None
 
     @property
     def offline_mode(self):
@@ -193,6 +194,14 @@ class QubesVMMConnection(object):
             self._hvm_supported = bool(
                     caps_xml.xpath('./guest/os_type[text()=\'hvm\']'))
         return self._hvm_supported
+
+    @property
+    def hap_supported(self):
+        if self._hap_supported is None:
+            caps_xml = lxml.etree.fromstring(self.libvirt_conn.getCapabilities())
+            self._hap_supported = bool(
+                    caps_xml.xpath('./guest/features/hap'))
+        return self._hap_supported
 
 
 ##### VMM global variable definition #####

--- a/dispvm/qfile-daemon-dvm
+++ b/dispvm/qfile-daemon-dvm
@@ -141,6 +141,15 @@ class QfileDaemonDvm:
         if dvm_kernel_path != '/var/lib/qubes/vm-kernels/' + dvm_current_kernel + '/vmlinuz':
             is_ok = False
 
+        dvm_virt_mode = ('pv' if subprocess.check_output(['xmllint', '--xpath',
+                'string(/domain/os/type/@machine)',
+                os.path.join(dvm_vmdir, dvm_name + '.conf')]) == 'xenpv'
+                else 'pvh')
+        dvm_current_virt_mode = subprocess.check_output(
+                ['qvm-prefs', '--get', dvm_name, 'virt_mode']).strip()
+        if dvm_virt_mode != dvm_current_virt_mode:
+            is_ok = False
+
         # force DispVM rebuild on template root.img change
         dvm_mtime = os.stat(current_savefile).st_mtime
         root_mtime = os.stat(dvmdata_dir+'savefile-root').st_mtime

--- a/qvm-tools/qvm-prefs
+++ b/qvm-tools/qvm-prefs
@@ -42,6 +42,7 @@ def do_list(vm):
     print fmt.format ("type", vm.type)
     if vm.template is not None:
         print fmt.format ("template", vm.template.name)
+    print fmt.format ("virt_mode", vm.virt_mode)
     if vm.netvm is not None:
         print fmt.format ("netvm", vm.netvm.name)
     if vm.qid != 0:
@@ -496,6 +497,14 @@ def set_timezone(vms, vm, args):
     vm.timezone = args[0]
     return True
 
+def set_virt_mode(vms, vm, args):
+    if len (args) != 1:
+        print >> sys.stderr, "Missing value (pv, pvh, hvm)!"
+        return False
+
+    vm.virt_mode = args[0]
+    return True
+
 properties = {
     "include_in_backups": set_include_in_backups,
     "pcidevs": set_pcidevs,
@@ -522,6 +531,7 @@ properties = {
     "timezone": set_timezone,
     "internal": set_internal,
     "autostart": set_autostart,
+    "virt_mode": set_virt_mode,
 }
 
 

--- a/rpm_spec/core-dom0.spec
+++ b/rpm_spec/core-dom0.spec
@@ -64,6 +64,7 @@ Requires:       libvirt-python
 Requires:       xen-runtime
 Requires:       xen-hvm
 Requires:       libvirt-daemon-xen >= 1.2.20-6
+Requires:       python2-xen
 %endif
 Requires:       createrepo
 Requires:       gnome-packagekit

--- a/vm-config/xen-vm-template.xml
+++ b/vm-config/xen-vm-template.xml
@@ -4,10 +4,23 @@
   <memory unit='MiB'>{maxmem}</memory>
   <currentMemory unit='MiB'>{mem}</currentMemory>
   <vcpu placement='static'>{vcpus}</vcpu>
+  {cpu_begin}
+  <cpu mode='host-passthrough'>
+    <feature name='vmx' policy='disable'/>
+    <feature name='svm' policy='disable'/>
+    <feature name='smap' policy='disable'/>
+  </cpu>
+  {cpu_end}
   <os>
-    <type arch='x86_64' machine='xenpv'>linux</type>
+    <type arch='x86_64' machine='{machine}'>{type}</type>
+    {boot_begin}
+    <loader>hvmloader</loader>
+    <boot dev="hd"/>
+    {boot_end}
+    {kernel_begin}
     <kernel>{kerneldir}/vmlinuz</kernel>
     <initrd>{kerneldir}/initramfs</initrd>
+    {kernel_end}
     <cmdline>root=/dev/mapper/dmroot ro nomodeset console=hvc0 rd_NO_PLYMOUTH rd.plymouth.enable=0 plymouth.enable=0 {kernelopts}</cmdline>
   </os>
   <features>{features}</features>
@@ -18,6 +31,9 @@
   <on_reboot>destroy</on_reboot>
   <on_crash>destroy</on_crash>
   <devices>
+    {emulator_begin}
+    <emulator type="{emulator_type}"/>
+    {emulator_end}
 {rootdev}
 {privatedev}
 {volatiledev}


### PR DESCRIPTION
Related PRs:
 - https://github.com/QubesOS/qubes-core-admin-linux/pull/35
 - https://github.com/QubesOS/qubes-core-libvirt/pull/8
 - https://github.com/QubesOS/qubes-linux-utils/pull/32
 - https://github.com/QubesOS/qubes-vmm-xen-stubdom-linux/pull/13
 - https://github.com/QubesOS/qubes-linux-kernel/pull/13 (for R3.2 and R4.0)

Additionally needed:
 - vmm-xen: build branch xen-4.8 for R3.2
 - core-vchan-xen: rebuild against new xen-libs
 - gui-daemon: rebuild against new xen-libs

Missing:
 - Migration handling. Currently every domain will be pvh after installing the update.