### PR TITLE
Critical fix for qmemman, plus various tests improvements

### DIFF
--- a/qubes/app.py
+++ b/qubes/app.py
@@ -483,7 +483,8 @@ class VMCollection(object):
             raise qubes.exc.QubesVMNotHaltedError(vm)
         self.app.fire_event('domain-pre-delete', pre_event=True, vm=vm)
         try:
-            vm.libvirt_domain.undefine()
+            if vm.libvirt_domain:
+                vm.libvirt_domain.undefine()
             # pylint: disable=protected-access
             vm._libvirt_domain = None
         except libvirt.libvirtError as e:

--- a/qubes/qmemman/__init__.py
+++ b/qubes/qmemman/__init__.py
@@ -140,6 +140,8 @@ class SystemState(object):
     def clear_outdated_error_markers(self):
         # Clear outdated errors
         for i in self.domdict.keys():
+            if self.domdict[i].mem_used is None:
+                continue
             # clear markers excluding VM from memory balance, if:
             #  - VM have responded to previous request (with some safety margin)
             #  - VM request more memory than it has assigned

--- a/qubes/tests/__init__.py
+++ b/qubes/tests/__init__.py
@@ -60,6 +60,7 @@ import qubes.config
 import qubes.devices
 import qubes.events
 import qubes.exc
+import qubes.ext.pci
 import qubes.vm.standalonevm
 import qubes.vm.templatevm
 
@@ -378,6 +379,7 @@ class QubesTestCase(unittest.TestCase):
 
         self.loop = asyncio.get_event_loop()
         self.addCleanup(self.cleanup_loop)
+        self.addCleanup(qubes.ext.pci._cache_get.cache_clear)
 
     def cleanup_gc(self):
         gc.collect()

--- a/qubes/tests/extra.py
+++ b/qubes/tests/extra.py
@@ -62,6 +62,9 @@ class VMWrapper(object):
     def __eq__(self, other):
         return self._vm == other
 
+    def __hash__(self):
+        return hash(self._vm)
+
     def start(self):
         return self._loop.run_until_complete(self._vm.start())
 

--- a/qubes/tests/integ/backup.py
+++ b/qubes/tests/integ/backup.py
@@ -90,7 +90,10 @@ class BackupTestsMixin(object):
         block_size = 4096
 
         self.log.debug("Filling %s" % path)
-        f = open(path, 'wb+')
+        try:
+            f = open(path, 'rb+')
+        except FileNotFoundError:
+            f = open(path, 'wb+')
         if size is None:
             f.seek(0, 2)
             size = f.tell()

--- a/qubes/tests/integ/basic.py
+++ b/qubes/tests/integ/basic.py
@@ -91,6 +91,7 @@ class TC_00_Basic(qubes.tests.SystemTestCase):
         self.vm = self.app.add_new_vm('StandaloneVM', label='red', name=vmname)
         self.loop.run_until_complete(self.vm.create_on_disk())
         self.vm.kernel = None
+        self.vm.virt_mode = 'hvm'
 
         iso_path = self.create_bootable_iso()
         # start the VM using qvm-start tool, to test --cdrom option there

--- a/qubes/tests/integ/vm_qrexec_gui.py
+++ b/qubes/tests/integ/vm_qrexec_gui.py
@@ -925,15 +925,17 @@ int main(int argc, char **argv) {
         # it is important to have some changing content there, to generate
         # content update events (aka damage notify)
         proc = yield from self.testvm1.run(
-            'gnome-terminal --full-screen -e top')
+            'xterm -maximized -e top')
 
         # help xdotool a little...
         yield from asyncio.sleep(2)
+        if proc.returncode is not None:
+            self.fail('xterm failed to start')
         # get window ID
         winid = (yield from asyncio.get_event_loop().run_in_executor(None,
             subprocess.check_output,
             ['xdotool', 'search', '--sync', '--onlyvisible', '--class',
-                self.testvm1.name + ':.*erminal'])).decode()
+                self.testvm1.name + ':xterm'])).decode()
         xprop = yield from asyncio.get_event_loop().run_in_executor(None,
             subprocess.check_output,
             ['xprop', '-notype', '-id', winid, '_QUBES_VMWINDOWID'])

--- a/qubes/tools/qmemmand.py
+++ b/qubes/tools/qmemmand.py
@@ -242,10 +242,6 @@ def main():
         ha_file.setFormatter(
             logging.Formatter('%(asctime)s %(name)s[%(process)d]: %(message)s'))
         logging.root.addHandler(ha_stderr)
-    else:
-        # close io
-        sys.stdout.close()
-        sys.stderr.close()
 
     sys.stdin.close()
 

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -570,6 +570,9 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
         if self._libvirt_domain is not None:
             return self._libvirt_domain
 
+        if self.app.vmm.offline_mode:
+            return None
+
         # XXX _update_libvirt_domain?
         try:
             self._libvirt_domain = self.app.vmm.libvirt_conn.lookupByUUID(

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -391,8 +391,8 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
     virt_mode = qubes.property('virt_mode',
         type=str, setter=_setter_virt_mode,
         default=_default_virt_mode,
-        doc='''Virtualisation mode: full virtualisation ("hvm"),
-            or paravirtualisation ("pv"), or hybrid ("pvh")''')
+        doc='''Virtualisation mode: full virtualisation ("HVM"),
+            or paravirtualisation ("PV"), or hybrid ("PVH")''')
 
     installed_by_rpm = qubes.property('installed_by_rpm',
         type=bool, setter=qubes.property.bool,
@@ -869,6 +869,9 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
 
             qmemman_client = None
             try:
+                if self.virt_mode == 'pvh' and self.kernel is None:
+                    raise qubes.exc.QubesException(
+                        'virt_mode PVH require kernel to be set')
                 yield from self.storage.verify()
 
                 if self.netvm is not None:


### PR DESCRIPTION
Previous fix for QubesOS/qubes-issues#3265 breaks qmemman badly - it stops balancing memory just after startup. Here is a fix for it.

Largely unrelated, but fix also some more tests.