### PR TITLE
app: define values for default_dispvm=None, updatevm=None

### DIFF
--- a/qubes/app.py
+++ b/qubes/app.py
@@ -729,7 +729,7 @@ class Qubes(qubes.PropertyHolder):
         vmclass=qubes.vm.templatevm.TemplateVM,
         doc='Default template for new AppVMs')
     updatevm = qubes.VMProperty('updatevm', load_stage=3,
-        allow_none=True,
+        default=None, allow_none=True,
         doc='''Which VM to use as `yum` proxy for updating AdminVM and
             TemplateVMs''')
     clockvm = qubes.VMProperty('clockvm', load_stage=3,
@@ -738,6 +738,7 @@ class Qubes(qubes.PropertyHolder):
     default_kernel = qubes.property('default_kernel', load_stage=3,
         doc='Which kernel to use when not overriden in VM')
     default_dispvm = qubes.VMProperty('default_dispvm', load_stage=3,
+        default=None,
         doc='Default DispVM base for service calls', allow_none=True)
 
     default_pool = qubes.property('default_pool', load_stage=3,


### PR DESCRIPTION
If those VMs are not set, default to None, instead of throwing
AttributeError.

Fixes QubesOS/qubes-issues#3475