### PR TITLE
Fix resizing volumes

### DIFF
--- a/qubes/storage/lvm.py
+++ b/qubes/storage/lvm.py
@@ -225,6 +225,8 @@ class ThinVolume(qubes.storage.Volume):
     @property
     def size(self):
         try:
+            if self.is_dirty():
+                return qubes.storage.lvm.size_cache[self._vid_snap]['size']
             return qubes.storage.lvm.size_cache[self.vid]['size']
         except KeyError:
             return self._size
@@ -430,10 +432,11 @@ class ThinVolume(qubes.storage.Volume):
         if size == self.size:
             return
 
-        cmd = ['extend', self.vid, str(size)]
-        qubes_lvm(cmd, self.log)
         if self.is_dirty():
             cmd = ['extend', self._vid_snap, str(size)]
+            qubes_lvm(cmd, self.log)
+        elif self.save_on_stop or not self.snap_on_start:
+            cmd = ['extend', self.vid, str(size)]
             qubes_lvm(cmd, self.log)
         reset_cache()
 

--- a/qubes/storage/lvm.py
+++ b/qubes/storage/lvm.py
@@ -425,9 +425,9 @@ class ThinVolume(qubes.storage.Volume):
         if size < self.size:
             raise qubes.storage.StoragePoolException(
                 'For your own safety, shrinking of %s is'
-                ' disabled. If you really know what you'
+                ' disabled (%d < %d). If you really know what you'
                 ' are doing, use `lvresize` on %s manually.' %
-                (self.name, self.vid))
+                (self.name, size, self.size, self.vid))
 
         if size == self.size:
             return


### PR DESCRIPTION
This fixes resizing non-persistent volumes, like DispVM:private. But also makes
resize affecting only the most recent volume revision, so when VM is running,
previous volume revision will be unaffected by the resize.

Add also a test for this.

Fixes QubesOS/qubes-issues#3519