### PR TITLE
Fix removing expired firewall rules

### DIFF
--- a/linux/systemd/Makefile
+++ b/linux/systemd/Makefile
@@ -7,8 +7,6 @@ install:
 	mkdir -p $(DESTDIR)$(UNITDIR)
 	cp qubes-core.service $(DESTDIR)$(UNITDIR)
 	cp qubes-vm@.service $(DESTDIR)$(UNITDIR)
-	cp qubes-reload-firewall@.service $(DESTDIR)$(UNITDIR)
-	cp qubes-reload-firewall@.timer $(DESTDIR)$(UNITDIR)
 	cp qubes-qmemman.service $(DESTDIR)$(UNITDIR)
 	cp qubesd.service $(DESTDIR)$(UNITDIR)
 	install -d $(DESTDIR)$(UNITDIR)/lvm2-pvscan@.service.d

--- a/rpm_spec/core-dom0.spec
+++ b/rpm_spec/core-dom0.spec
@@ -399,8 +399,6 @@ fi
 %{_unitdir}/qubes-qmemman.service
 %{_unitdir}/qubes-vm@.service
 %{_unitdir}/qubesd.service
-%{_unitdir}/qubes-reload-firewall@.service
-%{_unitdir}/qubes-reload-firewall@.timer
 %attr(2770,root,qubes) %dir /var/lib/qubes
 %attr(2770,root,qubes) %dir /var/lib/qubes/vm-templates
 %attr(2770,root,qubes) %dir /var/lib/qubes/appvms


### PR DESCRIPTION
Since qubesd service is present, do not use systemd for reloading firewall rules (which wasn't converted to R4.0 anyway). Instead, use asyncio call_later function.

Fixes QubesOS/qubes-issues#1173