### PR TITLE
Improve LVM volume revisions handling

### DIFF
--- a/qubes/api/admin.py
+++ b/qubes/api/admin.py
@@ -335,7 +335,7 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
         volume = self.dest.volumes[self.arg]
         # properties defined in API
         volume_properties = [
-            'pool', 'vid', 'size', 'usage', 'rw', 'source',
+            'pool', 'vid', 'size', 'usage', 'rw', 'source', 'path',
             'save_on_stop', 'snap_on_start', 'revisions_to_keep']
 
         def _serialize(value):

--- a/qubes/storage/lvm.py
+++ b/qubes/storage/lvm.py
@@ -90,6 +90,12 @@ class ThinPool(qubes.storage.Pool):
 
         self._volume_objects_cache = {}
 
+    def __repr__(self):
+        return '<{} at {:#x} name={!r} volume_group={!r} thin_pool={!r}>'.\
+            format(
+                type(self).__name__, id(self),
+                self.name, self.volume_group, self.thin_pool)
+
     @property
     def config(self):
         return {

--- a/qubes/tests/__init__.py
+++ b/qubes/tests/__init__.py
@@ -421,6 +421,13 @@ class QubesTestCase(unittest.TestCase):
             except asyncio.TimeoutError:
                 raise AssertionError('libvirt event impl drain timeout')
 
+        # this is stupid, but apparently it requires two passes
+        # to cleanup SIGCHLD handlers
+        self.loop.stop()
+        self.loop.run_forever()
+        self.loop.stop()
+        self.loop.run_forever()
+
         # Check there are no Tasks left.
         assert not self.loop._ready
         assert not self.loop._scheduled

--- a/qubes/tests/api_admin.py
+++ b/qubes/tests/api_admin.py
@@ -39,7 +39,7 @@ import qubes.storage
 
 # properties defined in API
 volume_properties = [
-    'pool', 'vid', 'size', 'usage', 'rw', 'source',
+    'pool', 'vid', 'size', 'usage', 'rw', 'source', 'path',
     'save_on_stop', 'snap_on_start', 'revisions_to_keep']
 
 

--- a/qubes/tests/integ/basic.py
+++ b/qubes/tests/integ/basic.py
@@ -570,7 +570,8 @@ class TC_03_QvmRevertTemplateChanges(qubes.tests.SystemTestCase):
 
     def get_rootimg_checksum(self):
         return subprocess.check_output(
-            ['sha1sum', self.test_template.volumes['root'].path])
+            ['sha1sum', self.test_template.volumes['root'].path]).\
+            decode().split(' ')[0]
 
     def _do_test(self):
         checksum_before = self.get_rootimg_checksum()

--- a/qubes/tests/storage_lvm.py
+++ b/qubes/tests/storage_lvm.py
@@ -138,7 +138,7 @@ class TC_00_ThinPool(ThinPoolBase):
         self.assertEqual(volume.size, qubes.config.defaults['root_img_size'])
         volume.create()
         path = "/dev/%s" % volume.vid
-        self.assertTrue(os.path.exists(path))
+        self.assertTrue(os.path.exists(path), path)
         volume.remove()
 
     def test_003_read_write_volume(self):
@@ -158,7 +158,7 @@ class TC_00_ThinPool(ThinPoolBase):
         self.assertEqual(volume.size, qubes.config.defaults['root_img_size'])
         volume.create()
         path = "/dev/%s" % volume.vid
-        self.assertTrue(os.path.exists(path))
+        self.assertTrue(os.path.exists(path), path)
         volume.remove()
 
     def test_004_size(self):

--- a/qubes/tests/storage_lvm.py
+++ b/qubes/tests/storage_lvm.py
@@ -84,7 +84,7 @@ class ThinPoolBase(qubes.tests.QubesTestCase):
         ''' Returns the pool matching the specified ``volume_group`` &
             ``thin_pool``, or None.
         '''
-        pools = [p for p in self.app.pools
+        pools = [p for p in self.app.pools.values()
             if issubclass(p.__class__, ThinPool)]
         for pool in pools:
             if pool.volume_group == volume_group \


### PR DESCRIPTION
The main change here is to keep the most recent volume version (the current
one) in LV with revision number already appended. And abandon -back suffix.
This means that committing new revision is just renaming LV to the one with
largest revision number. One atomic operation, no need to worry about
interrupted commits, parallel commits etc. And also faster.
This require unambitious revision ordering. Previously a timestamp was used,
but this is susceptible to time changes. Since now it could result in data
loss, something better is needed. In addition to timestamp, prefix revision id
with monotonous number.

Since this change make volume commit simpler and cheaper, use it also for other
cases. First of all, when importing new volume content, do it into temporary
volume and only commit it when operation is finished (successfully). This has multiple benefits, including security relevant ones - see aae56fec for details.

Since this is potentially fragile change, also add multiple new tests for LVM
storage driver.

QubesOS/qubes-issues#2256