### PR TITLE
Small improvements for storage Admin API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ ADMIN_API_METHODS_SIMPLE = \
 	admin.pool.volume.Resize \
 	admin.pool.volume.Revert \
 	admin.pool.volume.Set.revisions_to_keep \
+	admin.pool.volume.Set.rw \
 	admin.pool.volume.Snapshot \
 	admin.property.Get \
 	admin.property.GetDefault \
@@ -100,6 +101,7 @@ ADMIN_API_METHODS_SIMPLE = \
 	admin.vm.volume.Resize \
 	admin.vm.volume.Revert \
 	admin.vm.volume.Set.revisions_to_keep \
+	admin.vm.volume.Set.rw \
 	admin.vm.Stats \
 	$(null)
 

--- a/qubes/api/admin.py
+++ b/qubes/api/admin.py
@@ -606,19 +606,26 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
 
         self.fire_event_for_permission(pool=pool)
 
-        size_info = ''
+        other_info = ''
         try:
-            size_info += 'size={}\n'.format(pool.size)
+            other_info += 'size={}\n'.format(pool.size)
         except NotImplementedError:
             pass
         try:
-            size_info += 'usage={}\n'.format(pool.usage)
+            other_info += 'usage={}\n'.format(pool.usage)
+        except NotImplementedError:
+            pass
+
+        try:
+            included_in = pool.included_in(self.app)
+            if included_in:
+                other_info += 'included_in={}\n'.format(str(included_in))
         except NotImplementedError:
             pass
 
         return ''.join('{}={}\n'.format(prop, val)
             for prop, val in sorted(pool.config.items())) + \
-            size_info
+            other_info
 
     @qubes.api.method('admin.pool.Add',
         scope='global', write=True)

--- a/qubes/api/admin.py
+++ b/qubes/api/admin.py
@@ -607,14 +607,13 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
         self.fire_event_for_permission(pool=pool)
 
         other_info = ''
-        try:
-            other_info += 'size={}\n'.format(pool.size)
-        except NotImplementedError:
-            pass
-        try:
-            other_info += 'usage={}\n'.format(pool.usage)
-        except NotImplementedError:
-            pass
+        pool_size = pool.size
+        if pool_size is not None:
+            other_info += 'size={}\n'.format(pool_size)
+
+        pool_usage = pool.usage
+        if pool_usage is not None:
+            other_info += 'usage={}\n'.format(pool_usage)
 
         try:
             included_in = pool.included_in(self.app)

--- a/qubes/api/admin.py
+++ b/qubes/api/admin.py
@@ -336,9 +336,16 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
         # properties defined in API
         volume_properties = [
             'pool', 'vid', 'size', 'usage', 'rw', 'source',
-            'save_on_stop', 'snap_on_start']
-        return ''.join('{}={}\n'.format(key, getattr(volume, key)) for key in
-            volume_properties)
+            'save_on_stop', 'snap_on_start', 'revisions_to_keep', 'is_outdated']
+
+        def _serialize(value):
+            if callable(value):
+                value = value()
+            if value is None:
+                value = ''
+            return str(value)
+        return ''.join('{}={}\n'.format(key, _serialize(getattr(volume, key)))
+            for key in volume_properties)
 
     @qubes.api.method('admin.vm.volume.ListSnapshots', no_payload=True,
         scope='local', read=True)

--- a/qubes/api/admin.py
+++ b/qubes/api/admin.py
@@ -503,6 +503,26 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
         self.dest.volumes[self.arg].revisions_to_keep = newvalue
         self.app.save()
 
+    @qubes.api.method('admin.vm.volume.Set.rw',
+        scope='local', write=True)
+    @asyncio.coroutine
+    def vm_volume_set_rw(self, untrusted_payload):
+        assert self.arg in self.dest.volumes.keys()
+        try:
+            newvalue = qubes.property.bool(None, None,
+                untrusted_payload.decode('ascii'))
+        except (UnicodeDecodeError, ValueError):
+            raise qubes.api.ProtocolError('Invalid value')
+        del untrusted_payload
+
+        self.fire_event_for_permission(newvalue=newvalue)
+
+        if not self.dest.is_halted():
+            raise qubes.exc.QubesVMNotHaltedError(self.dest)
+
+        self.dest.volumes[self.arg].rw = newvalue
+        self.app.save()
+
     @qubes.api.method('admin.vm.tag.List', no_payload=True,
         scope='local', read=True)
     @asyncio.coroutine

--- a/qubes/storage/__init__.py
+++ b/qubes/storage/__init__.py
@@ -828,13 +828,13 @@ class Pool(object):
 
     @property
     def size(self):
-        ''' Storage pool size in bytes '''
-        raise self._not_implemented("size")
+        ''' Storage pool size in bytes, or None if unknown '''
+        return None
 
     @property
     def usage(self):
-        ''' Space used in the pool, in bytes '''
-        raise self._not_implemented("usage")
+        ''' Space used in the pool in bytes, or None if unknown '''
+        return None
 
     def _not_implemented(self, method_name):
         ''' Helper for emitting helpful `NotImplementedError` exceptions '''

--- a/qubes/storage/__init__.py
+++ b/qubes/storage/__init__.py
@@ -932,9 +932,12 @@ class DirectoryThinPool:
                 fs_major = (fs_stat.st_dev & 0xff00) >> 8
                 fs_minor = fs_stat.st_dev & 0xff
 
-                root_table = subprocess.check_output(["dmsetup",
+                sudo = []
+                if os.getuid():
+                    sudo = ['sudo']
+                root_table = subprocess.check_output(sudo + ["dmsetup",
                     "-j", str(fs_major), "-m", str(fs_minor),
-                    "table"])
+                    "table"], stderr=subprocess.DEVNULL)
 
                 _start, _sectors, target_type, target_args = \
                     root_table.decode().split(" ", 3)

--- a/qubes/storage/file.py
+++ b/qubes/storage/file.py
@@ -163,6 +163,12 @@ class FilePool(qubes.storage.Pool):
         statvfs = os.statvfs(self.dir_path)
         return statvfs.f_frsize * (statvfs.f_blocks - statvfs.f_bfree)
 
+    def included_in(self, app):
+        ''' Check if there is pool containing this one - either as a
+        filesystem or its LVM volume'''
+        return qubes.storage.search_pool_containing_dir(
+            [pool for pool in app.pools.values() if pool is not self],
+            self.dir_path)
 
 class FileVolume(qubes.storage.Volume):
     ''' Parent class for the xen volumes implementation which expects a

--- a/qubes/storage/kernels.py
+++ b/qubes/storage/kernels.py
@@ -23,18 +23,20 @@
 
 import os
 
+import qubes.exc
 from qubes.storage import Pool, StoragePoolException, Volume
 
 
 class LinuxModules(Volume):
     ''' A volume representing a ro linux kernel '''
-    rw = False
 
     def __init__(self, target_dir, kernel_version, **kwargs):
         kwargs['vid'] = ''
         super(LinuxModules, self).__init__(**kwargs)
         self._kernel_version = kernel_version
         self.target_dir = target_dir
+        assert self.revisions_to_keep == 0
+        assert self.rw is False
 
     @property
     def vid(self):
@@ -104,6 +106,28 @@ class LinuxModules(Volume):
     def is_outdated(self):
         return False
 
+    @property
+    def revisions_to_keep(self):
+        return 0
+
+    @revisions_to_keep.setter
+    def revisions_to_keep(self, value):
+        # pylint: disable=no-self-use
+        if value:
+            raise qubes.exc.QubesValueError(
+                'LinuxModules supports only revisions_to_keep=0')
+
+    @property
+    def rw(self):
+        return False
+
+    @rw.setter
+    def rw(self, value):
+        # pylint: disable=no-self-use
+        if value:
+            raise qubes.exc.QubesValueError(
+                'LinuxModules supports only read-only volumes')
+
     def start(self):
         return self
 
@@ -131,7 +155,7 @@ class LinuxKernel(Pool):
 
     def __init__(self, name=None, dir_path=None):
         assert dir_path, 'Missing dir_path'
-        super(LinuxKernel, self).__init__(name=name)
+        super(LinuxKernel, self).__init__(name=name, revisions_to_keep=0)
         self.dir_path = dir_path
 
     def init_volume(self, vm, volume_config):
@@ -166,6 +190,17 @@ class LinuxKernel(Pool):
 
     def setup(self):
         pass
+
+    @property
+    def revisions_to_keep(self):
+        return 0
+
+    @revisions_to_keep.setter
+    def revisions_to_keep(self, value):
+        # pylint: disable=no-self-use
+        if value:
+            raise qubes.exc.QubesValueError(
+                'LinuxModules supports only revisions_to_keep=0')
 
     @property
     def volumes(self):

--- a/qubes/storage/kernels.py
+++ b/qubes/storage/kernels.py
@@ -24,6 +24,7 @@
 import os
 
 import qubes.exc
+import qubes.storage
 from qubes.storage import Pool, StoragePoolException, Volume
 
 
@@ -201,6 +202,12 @@ class LinuxKernel(Pool):
         if value:
             raise qubes.exc.QubesValueError(
                 'LinuxModules supports only revisions_to_keep=0')
+
+    def included_in(self, app):
+        ''' Check if there is pool containing /var/lib/qubes/vm-kernels '''
+        return qubes.storage.search_pool_containing_dir(
+            [pool for pool in app.pools.values() if pool is not self],
+            self.dir_path)
 
     @property
     def volumes(self):

--- a/qubes/storage/reflink.py
+++ b/qubes/storage/reflink.py
@@ -108,6 +108,12 @@ class ReflinkPool(qubes.storage.Pool):
         statvfs = os.statvfs(self.dir_path)
         return statvfs.f_frsize * (statvfs.f_blocks - statvfs.f_bfree)
 
+    def included_in(self, app):
+        ''' Check if there is pool containing this one - either as a
+        filesystem or its LVM volume'''
+        return qubes.storage.search_pool_containing_dir(
+            [pool for pool in app.pools.values() if pool is not self],
+            self.dir_path)
 
 class ReflinkVolume(qubes.storage.Volume):
     def create(self):

--- a/qubes/tests/api_admin.py
+++ b/qubes/tests/api_admin.py
@@ -40,7 +40,7 @@ import qubes.storage
 # properties defined in API
 volume_properties = [
     'pool', 'vid', 'size', 'usage', 'rw', 'source',
-    'save_on_stop', 'snap_on_start']
+    'save_on_stop', 'snap_on_start', 'revisions_to_keep', 'is_outdated']
 
 
 class AdminAPITestCase(qubes.tests.QubesTestCase):

--- a/qubes/tests/api_admin.py
+++ b/qubes/tests/api_admin.py
@@ -567,13 +567,10 @@ class TC_00_VMs(AdminAPITestCase):
     def test_151_pool_info_unsupported_size(self):
         self.app.pools = {
             'pool1': unittest.mock.Mock(config={
-                'param1': 'value1', 'param2': 'value2'})
+                'param1': 'value1', 'param2': 'value2'},
+                size=None, usage=None),
         }
         self.app.pools['pool1'].included_in.return_value = None
-        type(self.app.pools['pool1']).size = unittest.mock.PropertyMock(
-            side_effect=NotImplementedError)
-        type(self.app.pools['pool1']).usage = unittest.mock.PropertyMock(
-            side_effect=NotImplementedError)
         value = self.call_mgmt_func(b'admin.pool.Info', b'dom0', b'pool1')
 
         self.assertEqual(value,

--- a/qubes/tests/api_admin.py
+++ b/qubes/tests/api_admin.py
@@ -2371,6 +2371,34 @@ class TC_00_VMs(AdminAPITestCase):
             self.call_mgmt_func(b'admin.vm.volume.Set.revisions_to_keep',
                 b'test-vm1', b'private', b'abc')
 
+    def test_680_vm_volume_set_rw(self):
+        self.vm.volumes = unittest.mock.MagicMock()
+        volumes_conf = {
+            'keys.return_value': ['root', 'private', 'volatile', 'kernel'],
+        }
+        self.vm.volumes.configure_mock(**volumes_conf)
+        self.vm.storage = unittest.mock.Mock()
+        value = self.call_mgmt_func(b'admin.vm.volume.Set.rw',
+            b'test-vm1', b'private', b'True')
+        self.assertIsNone(value)
+        self.assertEqual(self.vm.volumes.mock_calls,
+            [unittest.mock.call.keys(),
+            ('__getitem__', ('private',), {})])
+        self.assertEqual(self.vm.volumes['private'].rw, True)
+        self.app.save.assert_called_once_with()
+
+    def test_681_vm_volume_set_rw_invalid(self):
+        self.vm.volumes = unittest.mock.MagicMock()
+        volumes_conf = {
+            'keys.return_value': ['root', 'private', 'volatile', 'kernel'],
+        }
+        self.vm.volumes.configure_mock(**volumes_conf)
+        self.vm.storage = unittest.mock.Mock()
+        with self.assertRaises(AssertionError):
+            self.call_mgmt_func(b'admin.vm.volume.Set.revisions_to_keep',
+                b'test-vm1', b'private', b'abc')
+        self.assertFalse(self.app.save.called)
+
     def test_990_vm_unexpected_payload(self):
         methods_with_no_payload = [
             b'admin.vm.List',

--- a/qubes/tests/api_admin.py
+++ b/qubes/tests/api_admin.py
@@ -557,6 +557,7 @@ class TC_00_VMs(AdminAPITestCase):
                 usage=102400,
                 size=204800)
         }
+        self.app.pools['pool1'].included_in.return_value = None
         value = self.call_mgmt_func(b'admin.pool.Info', b'dom0', b'pool1')
 
         self.assertEqual(value,
@@ -568,6 +569,7 @@ class TC_00_VMs(AdminAPITestCase):
             'pool1': unittest.mock.Mock(config={
                 'param1': 'value1', 'param2': 'value2'})
         }
+        self.app.pools['pool1'].included_in.return_value = None
         type(self.app.pools['pool1']).size = unittest.mock.PropertyMock(
             side_effect=NotImplementedError)
         type(self.app.pools['pool1']).usage = unittest.mock.PropertyMock(
@@ -576,6 +578,24 @@ class TC_00_VMs(AdminAPITestCase):
 
         self.assertEqual(value,
             'param1=value1\nparam2=value2\n')
+        self.assertFalse(self.app.save.called)
+
+    def test_152_pool_info_included_in(self):
+        self.app.pools = {
+            'pool1': unittest.mock.MagicMock(config={
+                'param1': 'value1',
+                'param2': 'value2'},
+                usage=102400,
+                size=204800)
+        }
+        self.app.pools['pool1'].included_in.return_value = \
+            self.app.pools['pool1']
+        self.app.pools['pool1'].__str__.return_value = 'pool1'
+        value = self.call_mgmt_func(b'admin.pool.Info', b'dom0', b'pool1')
+
+        self.assertEqual(value,
+            'param1=value1\nparam2=value2\nsize=204800\nusage=102400'
+            '\nincluded_in=pool1\n')
         self.assertFalse(self.app.save.called)
 
     @unittest.mock.patch('qubes.storage.pool_drivers')


### PR DESCRIPTION
- include 'revisions_to_keep' and 'is_outdated' in volume info
- allow changing 'rw' property of a volume
- fix 'usage' default - not every volume implement it, like linux-kernel pool,
  don't crash on it