### PR TITLE
qvm-clock-sync fails with permissions error

### DIFF
--- a/qvm-tools/qvm-sync-clock
+++ b/qvm-tools/qvm-sync-clock
@@ -27,7 +27,7 @@ from qubesadmin import Qubes
 
 def main():
     if os.geteuid() != 0:
-        sys.stderr.write('This program must be run as root to set the date.')
+        sys.stderr.write('This program must be run as root to set the date, aborting!\n')
         sys.exit(1)
     app = Qubes()
     clockvm = app.clockvm

--- a/qvm-tools/qvm-sync-clock
+++ b/qvm-tools/qvm-sync-clock
@@ -20,12 +20,15 @@
 #
 #
 import sys
+import os
 import re
 import subprocess
 from qubesadmin import Qubes
 
 def main():
-
+    if os.geteuid() != 0:
+        sys.stderr.write('This program must be run as root to set the date.')
+        sys.exit(1)
     app = Qubes()
     clockvm = app.clockvm
 


### PR DESCRIPTION
This patch prevents the `date -s` failure by requesting root in an error message.

The current behavior of `qvm-sync-clock` is a python exception due to `date -s` returning 1 in the subprocess.