### PR TITLE
sdwdate-gui-qubes qrexec policy

### DIFF
--- a/qubes-rpc-policy/whonix.GatewayCommand
+++ b/qubes-rpc-policy/whonix.GatewayCommand
@@ -1,0 +1,3 @@
+$tag:anon-gateway $tag:anon-vm allow
+$anyvm $anyvm deny        
+

--- a/qubes-rpc-policy/whonix.GatewayCommand
+++ b/qubes-rpc-policy/whonix.GatewayCommand
@@ -1,3 +1,4 @@
 $tag:anon-gateway $tag:anon-vm allow
+sys-whonix $tag:anon-vm allow
 $anyvm $anyvm deny        
 

--- a/qubes-rpc-policy/whonix.NewStatus
+++ b/qubes-rpc-policy/whonix.NewStatus
@@ -1,0 +1,3 @@
+$tag:anon-vm $tag:anon-gateway allow
+$anyvm $anyvm deny  
+

--- a/qubes-rpc-policy/whonix.NewStatus
+++ b/qubes-rpc-policy/whonix.NewStatus
@@ -1,3 +1,4 @@
 $tag:anon-vm $tag:anon-gateway allow
+$tag:anon-vm sys-whonix allow
 $anyvm $anyvm deny  
 

--- a/qubes-rpc-policy/whonix.SdwdateStatus
+++ b/qubes-rpc-policy/whonix.SdwdateStatus
@@ -1,0 +1,3 @@
+$tag:anon-gateway $tag:anon-vm allow
+$anyvm $anyvm deny        
+

--- a/qubes-rpc-policy/whonix.SdwdateStatus
+++ b/qubes-rpc-policy/whonix.SdwdateStatus
@@ -1,3 +1,4 @@
 $tag:anon-gateway $tag:anon-vm allow
+sys-whonix $tag:anon-vm allow
 $anyvm $anyvm deny        
 


### PR DESCRIPTION
Using `sys-whonix $tag:anon-vm allow` verbatim in case anyone is missing the tag. That sorts out at least most users who just go with the defaults.

(As far I know qubes-core-admin-addon-whonix does not have a mechanism to add tags for already created VMs.)

References:

* https://forums.whonix.org/t/sdwdate-gui-for-qubes-testers-wanted-developpers-welcome
* https://phabricator.whonix.org/T534