### PR TITLE
remove Whonix specific exceptions

### DIFF
--- a/qubes-rpc-policy/qubes.OpenInVM.policy
+++ b/qubes-rpc-policy/qubes.OpenInVM.policy
@@ -3,8 +3,5 @@
 
 ## Please use a single # to start your custom comments
 
-sys-whonix anon-whonix allow
-whonix-gw anon-whonix allow
-whonix-ws anon-whonix allow
 $anyvm	$dispvm	allow
 $anyvm	$anyvm	ask


### PR DESCRIPTION
Whonix will use `qvm-open-in-dvm` so no more exceptions required.