### PR TITLE
$tag:anon-vm $anyvm deny

### DIFF
--- a/qubes-rpc-policy/qubes.GetDate.policy
+++ b/qubes-rpc-policy/qubes.GetDate.policy
@@ -3,4 +3,5 @@
 
 ## Please use a single # to start your custom comments
 
+$tag:anon-vm	$anyvm	deny
 $anyvm	$anyvm	allow,target=dom0


### PR DESCRIPTION
Why do we set that using salt?

Simpler and more robust to just set it here.

https://github.com/QubesOS/qubes-mgmt-salt-dom0-virtual-machines/blob/master/qvm/template-whonix-ws.sls#L43
