### PR TITLE
Order qubesd before systemd-user-sessions

### DIFF
--- a/linux/systemd/qubesd.service
+++ b/linux/systemd/qubesd.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Qubes OS daemon
+Before=systemd-user-sessions.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
`qubes-vm@.service` would already [cause this ordering](https://github.com/QubesOS/qubes-core-admin/blob/e1378f70fbf8d686f744a679f44bd1f08a0100d2/linux/systemd/qubes-vm%40.service#L3-L4), but not every user has any `autostart=True` VMs.

Also needed to maybe f*x QubesOS/qubes-issues#3149 at some point.