### PR TITLE
Add default_qrexec_timeout to qubes-prefs

### DIFF
--- a/qubes/app.py
+++ b/qubes/app.py
@@ -718,6 +718,13 @@ class Qubes(qubes.PropertyHolder):
         setter=_setter_pool,
         doc='Default storage pool for kernel volumes')
 
+    default_qrexec_timeout = qubes.property('default_qrexec_timeout',
+        load_stage=3,
+        default=60,
+        type=int,
+        doc='''Default time in seconds after which qrexec connection attempt is
+            deemed failed''')
+
     stats_interval = qubes.property('stats_interval',
         default=3,
         type=int,

--- a/qubes/tests/vm/__init__.py
+++ b/qubes/tests/vm/__init__.py
@@ -88,6 +88,7 @@ class TestApp(qubes.tests.TestEmitter):
         self.default_pool_root = 'default'
         self.default_pool_private = 'default'
         self.default_pool_kernel = 'linux-kernel'
+        self.default_qrexec_timeout = 60
         self.default_netvm = None
         self.domains = TestVMsCollection()
         #: jinja2 environment for libvirt XML templates

--- a/qubes/tests/vm/qubesvm.py
+++ b/qubes/tests/vm/qubesvm.py
@@ -459,6 +459,15 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
         self.assertPropertyInvalidValue(vm, 'qrexec_timeout', '-2')
         self.assertPropertyInvalidValue(vm, 'qrexec_timeout', '')
 
+    def test_272_qrexec_timeout_global_changed(self):
+        self.app.default_qrexec_timeout = 123
+        vm = self.get_vm()
+        self.assertPropertyDefaultValue(vm, 'qrexec_timeout', 123)
+        self.assertPropertyValue(vm, 'qrexec_timeout', 3, 3, '3')
+        del vm.qrexec_timeout
+        self.assertPropertyDefaultValue(vm, 'qrexec_timeout', 123)
+        self.assertPropertyValue(vm, 'qrexec_timeout', '3', 3, '3')
+
     def test_280_autostart(self):
         vm = self.get_vm()
         # FIXME any better idea to not involve systemctl call at this stage?

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -510,7 +510,8 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
 #           return self._default_user
 
     qrexec_timeout = qubes.property('qrexec_timeout', type=int,
-        default=_default_with_template('qrexec_timeout', 60),
+        default=_default_with_template('qrexec_timeout',
+            lambda self: self.app.default_qrexec_timeout),
         setter=_setter_positive_int,
         doc='''Time in seconds after which qrexec connection attempt is deemed
             failed. Operating system inside VM should be able to boot in this


### PR DESCRIPTION
When a VM (or its template) does not explicitly set a `qrexec_timeout`, fall back to a global `default_qrexec_timeout` (with default value 60), instead of hardcoding the fallback value to 60.

This makes it easy to set a higher timeout for the whole system, which helps users who habitually launch applications from several (not yet started) VMs at the same time. 60 seconds can be too short for that.