### PR TITLE
Use maxmem=0 to disable dynamic memory management, instead of cryptic service.meminfo-writer feature

### DIFF
--- a/qubes/ext/services.py
+++ b/qubes/ext/services.py
@@ -39,6 +39,10 @@ class ServicesExtension(qubes.ext.Extension):
             vm.untrusted_qdb.write('/qubes-service/{}'.format(service),
                 str(int(bool(value))))
 
+        # always set meminfo-writer according to maxmem
+        vm.untrusted_qdb.write('/qubes-service/meminfo-writer',
+            '1' if vm.maxmem > 0 else '0')
+
     @qubes.ext.handler('domain-feature-set:*')
     def on_domain_feature_set(self, vm, event, feature, value, oldvalue=None):
         '''Update /qubes-service/ QubesDB tree in runtime'''

--- a/qubes/ext/services.py
+++ b/qubes/ext/services.py
@@ -47,6 +47,20 @@ class ServicesExtension(qubes.ext.Extension):
     def on_domain_feature_set(self, vm, event, feature, value, oldvalue=None):
         '''Update /qubes-service/ QubesDB tree in runtime'''
         # pylint: disable=unused-argument
+
+        # TODO: remove this compatibility hack in Qubes 4.1
+        if feature == 'service.meminfo-writer':
+            # if someone try to enable meminfo-writer ...
+            if value:
+                # ... reset maxmem to default
+                vm.maxmem = qubes.property.DEFAULT
+            else:
+                # otherwise, set to 0
+                vm.maxmem = 0
+            # in any case, remove the entry, as it does not indicate memory
+            # balancing state anymore
+            del vm.features['service.meminfo-writer']
+
         if not vm.is_running():
             return
         if not feature.startswith('service.'):
@@ -65,7 +79,21 @@ class ServicesExtension(qubes.ext.Extension):
         if not feature.startswith('service.'):
             return
         service = feature[len('service.'):]
+        # this one is excluded from user control
+        if service == 'meminfo-writer':
+            return
         vm.untrusted_qdb.rm('/qubes-service/{}'.format(service))
+
+    @qubes.ext.handler('domain-load')
+    def on_domain_load(self, vm, event):
+        '''Migrate meminfo-writer service into maxmem'''
+        # pylint: disable=no-self-use,unused-argument
+        if 'service.meminfo-writer' in vm.features:
+            # if was set to false, force maxmem=0
+            # otherwise, simply ignore as the default is fine
+            if not vm.features['service.meminfo-writer']:
+                vm.maxmem = 0
+            del vm.features['service.meminfo-writer']
 
     @qubes.ext.handler('features-request')
     def supported_services(self, vm, event, untrusted_features):

--- a/qubes/tests/ext.py
+++ b/qubes/tests/ext.py
@@ -224,6 +224,7 @@ class TC_20_Services(qubes.tests.QubesTestCase):
         self.features = {}
         self.vm.configure_mock(**{
             'template': None,
+            'maxmem': 1024,
             'is_running.return_value': True,
             'features.get.side_effect': self.features.get,
             'features.items.side_effect': self.features.items,
@@ -239,6 +240,7 @@ class TC_20_Services(qubes.tests.QubesTestCase):
 
         self.ext.on_domain_qdb_create(self.vm, 'domain-qdb-create')
         self.assertEqual(sorted(self.vm.untrusted_qdb.mock_calls), [
+            ('write', ('/qubes-service/meminfo-writer', '1'), {}),
             ('write', ('/qubes-service/test1', '1'), {}),
             ('write', ('/qubes-service/test2', '0'), {}),
         ])

--- a/qubes/tests/vm/qubesvm.py
+++ b/qubes/tests/vm/qubesvm.py
@@ -665,7 +665,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
         expected = '''<domain type="xen">
         <name>test-inst-test</name>
         <uuid>7db78950-c467-4863-94d1-af59806384ea</uuid>
-        <memory unit="MiB">500</memory>
+        <memory unit="MiB">400</memory>
         <currentMemory unit="MiB">400</currentMemory>
         <vcpu placement="static">2</vcpu>
         <cpu mode='host-passthrough'>
@@ -766,6 +766,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
         vm = self.get_vm(uuid=my_uuid)
         vm.netvm = None
         vm.virt_mode = 'hvm'
+        vm.features['qrexec'] = True
         with unittest.mock.patch('qubes.config.qubes_base_dir',
                 '/tmp/qubes-test'):
             kernel_dir = '/tmp/qubes-test/vm-kernels/dummy'
@@ -906,6 +907,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
         vm = self.get_vm(uuid=my_uuid)
         vm.netvm = netvm
         vm.virt_mode = 'hvm'
+        vm.features['qrexec'] = True
         with self.subTest('ipv4_only'):
             libvirt_xml = vm.create_config_file()
             self.assertXMLEqual(lxml.etree.XML(libvirt_xml),
@@ -969,6 +971,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             '/qubes-iptables-error': '',
             '/qubes-iptables-header': iptables_header,
             '/qubes-service/qubes-update-check': '0',
+            '/qubes-service/meminfo-writer': '1',
         })
 
     @unittest.mock.patch('qubes.utils.get_timezone')
@@ -1029,6 +1032,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             '/qubes-iptables-error': '',
             '/qubes-iptables-header': iptables_header,
             '/qubes-service/qubes-update-check': '0',
+            '/qubes-service/meminfo-writer': '1',
             '/qubes-ip': '10.137.0.3',
             '/qubes-netmask': '255.255.255.255',
             '/qubes-gateway': '10.137.0.2',

--- a/templates/libvirt/xen.xml
+++ b/templates/libvirt/xen.xml
@@ -2,11 +2,12 @@
     {% block basic %}
         <name>{{ vm.name }}</name>
         <uuid>{{ vm.uuid }}</uuid>
-        {% if vm.virt_mode == 'hvm' and vm.devices['pci'].persistent() | list %}
+        {% if ((vm.virt_mode == 'hvm' and vm.devices['pci'].persistent() | list)
+            or vm.maxmem == 0) -%}
             <memory unit="MiB">{{ vm.memory }}</memory>
-        {% else %}
+        {% else -%}
             <memory unit="MiB">{{ vm.maxmem }}</memory>
-        {% endif %}
+        {% endif -%}
         <currentMemory unit="MiB">{{ vm.memory }}</currentMemory>
         <vcpu placement="static">{{ vm.vcpus }}</vcpu>
     {% endblock %}


### PR DESCRIPTION
In general, this change makes "maxmem" property strictly bound to dynamic
memory management (aka qmemman). In fact setting maxmem!=(initial) memory makes
only sense in such a case.
If maxmem=0, dynamic memory management is disabled and VM have just 'memory' RAM.
If it is greater than zero, dynamic memory management is enabled and VM can use
up to 'maxmem' RAM. Under the hood, meminfo-writer service is also enabled, as
it's necessary on the VM side for this mechanism; but that's only internal
detail, should not be used as a main knob for this feature.

Having the main knob as a proparty (instead of a "feature"), allows also to
provide meaningful default. Generally, enable qmemman by default for given
domain if it's possible. Disable if not supported, or would crash the domain.

Fixes QubesOS/qubes-issues#4135
Fixes QubesOS/qubes-issues#4480 (kind of - make the thing described there intended behavior)