### PR TITLE
Change interpreter from python2 to python 3 to address issue 3872

### DIFF
--- a/qvm-tools/qvm-sync-clock
+++ b/qvm-tools/qvm-sync-clock
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/python2
 # -*- encoding: utf8 -*-
 #
 # The Qubes OS Project, http://www.qubes-os.org


### PR DESCRIPTION
`qvm-sync-clock` has hard-coded its interpreter to be `/usr/bin/python2`, however it is not compatible with `python2` due to how it uses the `subprocess` module -- `subprocess.DEVNULL` is only available in `python3`'s version of the `subprocess`.
To address issue https://github.com/QubesOS/qubes-issues/issues/3872