### PR TITLE
R4.1: libvirt: adjust domain xml template for upstream PVH format

### DIFF
--- a/qubes/tests/vm/qubesvm.py
+++ b/qubes/tests/vm/qubesvm.py
@@ -882,7 +882,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <feature name='smap' policy='disable'/>
         </cpu>
         <os>
-            <type arch="x86_64" machine="xenfv">pvh</type>
+            <type arch="x86_64" machine="xenpvh">xenpvh</type>
             <kernel>/tmp/kernel/vmlinuz</kernel>
             <initrd>/tmp/kernel/initramfs</initrd>
             <cmdline>root=/dev/mapper/dmroot ro nomodeset console=hvc0 rd_NO_PLYMOUTH rd.plymouth.enable=0 plymouth.enable=0 nopat</cmdline>
@@ -952,7 +952,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <feature name='smap' policy='disable'/>
         </cpu>
         <os>
-            <type arch="x86_64" machine="xenfv">pvh</type>
+            <type arch="x86_64" machine="xenpvh">xenpvh</type>
             <kernel>/tmp/kernel/vmlinuz</kernel>
             <initrd>/tmp/kernel/initramfs</initrd>
             <cmdline>root=/dev/mapper/dmroot ro nomodeset console=hvc0 rd_NO_PLYMOUTH rd.plymouth.enable=0 plymouth.enable=0 nopat</cmdline>

--- a/templates/libvirt/xen.xml
+++ b/templates/libvirt/xen.xml
@@ -36,7 +36,7 @@
                 <boot dev="hd" />
             {% else %}
                 {% if vm.virt_mode == 'pvh' %}
-                    <type arch="x86_64" machine="xenfv">pvh</type>
+                    <type arch="x86_64" machine="xenpvh">xenpvh</type>
                 {% else %}
                     <type arch="x86_64" machine="xenpv">linux</type>
                 {% endif %}


### PR DESCRIPTION
The final PVH support upstream use different machine type name.