### PR TITLE
doc: fix paths of jinja templates for libvirt Xen configuration

### DIFF
--- a/doc/libvirt.rst
+++ b/doc/libvirt.rst
@@ -17,9 +17,9 @@ File paths
 ----------
 
 In order of increasing precedence: the main template, from which the config is
-generated is :file:`/usr/share/templates/libvirt/xen.xml`).
+generated is :file:`/usr/share/qubes/templates/libvirt/xen.xml`).
 The distributor may put a file at
-:file:`/usr/share/qubes/template/xen-dist.xml`) to override this file. 
+:file:`/usr/share/qubes/templates/libvirt/xen-dist.xml`) to override this file.
 User may put a file at either
 :file:`/etc/qubes/templates/libvirt/xen-user.xml` or
 :file:`/etc/qubes/templates/libvirt/xen/by-name/<name>.xml`, where ``<name>`` is


### PR DESCRIPTION
The jinja templates are located in either `/etc/qubes/templates` or `/usr/share/qubes/templates`. `/usr/share/templates` is not used and `/usr/share/qubes/template/` does not exist.

Fix the paths that are documented in https://dev.qubes-os.org/projects/core-admin/en/latest/libvirt.html

NB. I am using Qubes OS 4.0.1 and the git history shows that the location has always been `/usr/share/qubes/templates/libvirt/xen.xml` since the introduction of this file by commit https://github.com/QubesOS/qubes-core-admin/commit/5eaf03c4a2e92bdfd876818d8e1101de432366b6#diff-0a25986a48194c5a407da9a5b40fef7aR316