### PR TITLE
Allow StandaloneVM to be a DVM template

### DIFF
--- a/qubes/tests/vm/__init__.py
+++ b/qubes/tests/vm/__init__.py
@@ -48,6 +48,9 @@ class TestVMsCollection(dict):
     def close(self):
         self.clear()
 
+    def __iter__(self):
+        return iter(self.values())
+
 class TestVolume(object):
     def __init__(self, pool):
         self.pool = pool

--- a/qubes/vm/dispvm.py
+++ b/qubes/vm/dispvm.py
@@ -26,12 +26,18 @@ import qubes.vm.qubesvm
 import qubes.vm.appvm
 import qubes.config
 
+def _setter_template(self, prop, value):
+    if not getattr(value, 'template_for_dispvms', False):
+        raise qubes.exc.QubesPropertyValueError(self, prop, value,
+            'template for DispVM must have template_for_dispvms=True')
+    return value
+
 class DispVM(qubes.vm.qubesvm.QubesVM):
     '''Disposable VM'''
 
     template = qubes.VMProperty('template',
                                 load_stage=4,
-                                vmclass=qubes.vm.appvm.AppVM,
+                                setter=_setter_template,
                                 doc='AppVM, on which this DispVM is based.')
 
     dispid = qubes.property('dispid', type=int, write_once=True,

--- a/qubes/vm/mix/dvmtemplate.py
+++ b/qubes/vm/mix/dvmtemplate.py
@@ -1,0 +1,47 @@
+# -*- encoding: utf-8 -*-
+#
+# The Qubes OS Project, http://www.qubes-os.org
+#
+# Copyright (C) 2017 Marek Marczykowski-Górecki
+#                               <marmarek@invisiblethingslab.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+import qubes.events
+
+class DVMTemplateMixin(qubes.events.Emitter):
+    '''VM class capable of being DVM template'''
+
+    template_for_dispvms = qubes.property('template_for_dispvms',
+        type=bool,
+        default=False,
+        doc='Should this VM be allowed to start as Disposable VM')
+
+    @qubes.events.handler('property-pre-set:template')
+    def __on_property_pre_set_template(self, event, name, newvalue,
+            oldvalue=None):
+        # pylint: disable=unused-argument
+        if any(self.dispvms):
+            raise qubes.exc.QubesVMInUseError(self,
+                'Cannot change template '
+                'while there are DispVMs based on this qube')
+
+    @property
+    def dispvms(self):
+        ''' Returns a generator containing all Disposable VMs based on the
+        current AppVM.
+        '''
+        for vm in self.app.domains:
+            if getattr(vm, 'template', None) == self:
+                yield vm

--- a/qubes/vm/mix/dvmtemplate.py
+++ b/qubes/vm/mix/dvmtemplate.py
@@ -28,6 +28,23 @@ class DVMTemplateMixin(qubes.events.Emitter):
         default=False,
         doc='Should this VM be allowed to start as Disposable VM')
 
+    @qubes.events.handler('property-pre-set:template_for_dispvms')
+    def __on_pre_set_dvmtemplate(self, event, name,
+            newvalue, oldvalue=None):
+        # pylint: disable=unused-argument
+        if newvalue:
+            return
+        if any(self.dispvms):
+            raise qubes.exc.QubesVMInUseError(self,
+                'Cannot change template_for_dispvms to False while there are '
+                'some DispVMs based on this DVM template')
+
+    @qubes.events.handler('property-pre-del:template_for_dispvms')
+    def __on_pre_del_dvmtemplate(self, event, name,
+            oldvalue=None):
+        self.__on_pre_set_dvmtemplate(
+            event, name, False, oldvalue)
+
     @qubes.events.handler('property-pre-set:template')
     def __on_property_pre_set_template(self, event, name, newvalue,
             oldvalue=None):

--- a/qubes/vm/standalonevm.py
+++ b/qubes/vm/standalonevm.py
@@ -19,10 +19,12 @@
 #
 
 import qubes.events
+import qubes.vm.mix.dvmtemplate
 import qubes.vm.qubesvm
 import qubes.config
 
-class StandaloneVM(qubes.vm.qubesvm.QubesVM):
+class StandaloneVM(qubes.vm.mix.dvmtemplate.DVMTemplateMixin,
+        qubes.vm.qubesvm.QubesVM):
     '''Standalone Application VM'''
 
     def __init__(self, *args, **kwargs):

--- a/rpm_spec/core-dom0.spec.in
+++ b/rpm_spec/core-dom0.spec.in
@@ -249,6 +249,7 @@ fi
 %dir %{python3_sitelib}/qubes/vm/mix/__pycache__
 %{python3_sitelib}/qubes/vm/mix/__pycache__/*
 %{python3_sitelib}/qubes/vm/mix/__init__.py
+%{python3_sitelib}/qubes/vm/mix/dvmtemplate.py
 %{python3_sitelib}/qubes/vm/mix/net.py
 
 %dir %{python3_sitelib}/qubes/storage


### PR DESCRIPTION
To do so, split DVM template into a mixin, so it's trivial to add it to
specific classes.

Fixes QubesOS/qubes-issues#4670