### PR TITLE
Fix QubesOS/qubes-issues#4556

### DIFF
--- a/qubes/vm/dispvm.py
+++ b/qubes/vm/dispvm.py
@@ -116,7 +116,10 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
             # by default inherit properties from the DispVM template
             proplist = [prop.__name__ for prop in template.property_list()
                 if prop.clone and prop.__name__ not in ['template']]
-            self_props = [prop.__name__ for prop in self.property_list()]
+            # Do not overwrite properties that have already been set to a
+            # non-default value.
+            self_props = [prop.__name__ for prop in self.property_list()
+                if self.property_is_default(prop)]
             self.clone_properties(template, set(proplist).intersection(
                 self_props))
 


### PR DESCRIPTION
The initializer of the class DispVM first calls the initializer of the
QubesVM class, which among other things sets properties as specified in
kwargs, and then copies over the properties of the template. This can
lead to properties passed explicitly by the caller through kwargs being
overwritten.

Hence only clone properties of the template that are still set to
default in the DispVM.

Fixes QubesOS/qubes-issues#4556