### PR TITLE
storage: more (re)size fixes

### DIFF
--- a/qubes/api/admin.py
+++ b/qubes/api/admin.py
@@ -457,8 +457,10 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
 
         self.fire_event_for_permission(size=size)
 
-        yield from self.dest.storage.resize(self.arg, size)
-        self.app.save()
+        try:
+            yield from self.dest.storage.resize(self.arg, size)
+        finally:  # even if calling qubes.ResizeDisk inside the VM failed
+            self.app.save()
 
     @qubes.api.method('admin.vm.volume.Import', no_payload=True,
         scope='local', write=True)

--- a/qubes/storage/reflink.py
+++ b/qubes/storage/reflink.py
@@ -140,13 +140,6 @@ class ReflinkVolume(qubes.storage.Volume):
         self._path_import = self._path_vid + '-import.img'
         self.path = self._path_dirty
 
-        # In case the volume was previously resized, but then a crash
-        # prevented qubesd from serializing the new size to qubes.xml:
-        for path in (self._path_dirty, self._path_clean):
-            with suppress(FileNotFoundError):
-                self.size = os.path.getsize(path)
-                break
-
     @_unblock
     def create(self):
         if self.save_on_stop and not self.snap_on_start:

--- a/qubes/storage/reflink.py
+++ b/qubes/storage/reflink.py
@@ -204,7 +204,6 @@ class ReflinkVolume(qubes.storage.Volume):
         if self.snap_on_start:
             # pylint: disable=protected-access
             _copy_file(self.source._path_clean, self._path_clean)
-            self.size = os.path.getsize(self._path_clean)
         if self.snap_on_start or self.save_on_stop:
             _copy_file(self._path_clean, self._path_dirty)
         else:

--- a/qubes/storage/reflink.py
+++ b/qubes/storage/reflink.py
@@ -158,7 +158,6 @@ class ReflinkVolume(qubes.storage.Volume):
         return self
 
     @_coroutinized
-    @_locked
     def verify(self):
         if self.snap_on_start:
             img = self.source._path_clean  # pylint: disable=protected-access


### PR DESCRIPTION
- A minor one for `admin.vm.volume.Resize`
- Rejig reflink to dynamically get the volume size from the actual image file size; revert two ad-hoc size update commits from #266


----------

BTW, https://github.com/QubesOS/qubes-core-admin/commit/b6f77eb ("tests: do not use lazy unmount") breaks on my system. Without lazy unmount, reflink _integration_ tests that do the loopback dance (i.e. `StorageReflinkOnBtrfs` if /var/tmp is ext4, or `StorageReflinkOnExt4` if /var/tmp is btrfs) fail at cleanup.

I tried:

- with the `fuser -vm` invocation moved to immediately before the failing `umount` (in case it's a short timing window) and capturing stdout+stderr -> nothing listed, WTF
- with `lsof +D` instead of `fuser -vm` -> still nothing
- with added `sync` before `umount` (thinking it could be similar to `dmsetup remove` failure due to pending I/O) -> didn't fix it
- with `detach_loopdev(dev)` omitted from `mkdir_fs`, letting `umount` handle it instead -> no
- with the loopback image file moved to a different directory that's not shadowed by the mounted filesystem -> no
- with the mountpoint moved outside of /var/tmp (suspecting some systemd magic) -> no

Only lazy unmount seems to work here. Are you sure it doesn't on your system, even with https://github.com/QubesOS/qubes-core-admin/commit/4234fe5 ("tests: fix cleanup after reflink tests") applied? Theoretically, `rmdir()` on the empty former mountpoint should always succeed after successful `MNT_DETACH` by `umount -l`, no?