### PR TITLE
Remove CPU usage normalization

### DIFF
--- a/qubes/app.py
+++ b/qubes/app.py
@@ -350,8 +350,7 @@ class QubesHost:
             domid = vm['domid']
             current[domid] = {}
             current[domid]['memory_kb'] = vm['mem_kb']
-            current[domid]['cpu_time'] = int(
-                vm['cpu_time'] / max(vm['online_vcpus'], 1))
+            current[domid]['cpu_time'] = vm['cpu_time']
             if domid in previous:
                 current[domid]['cpu_usage'] = int(
                     (current[domid]['cpu_time'] - previous[domid]['cpu_time'])

--- a/qubes/tests/app.py
+++ b/qubes/tests/app.py
@@ -80,7 +80,7 @@ class TC_20_QubesHost(qubes.tests.QubesTestCase):
         self.assertIsNotNone(info_time)
         expected_info = {
             0: {
-                'cpu_time': 243951379111104//8,
+                'cpu_time': 243951379111104,
                 'cpu_usage': 0,
                 'memory_kb': 3733212,
             },
@@ -90,7 +90,7 @@ class TC_20_QubesHost(qubes.tests.QubesTestCase):
                 'memory_kb': 303916,
             },
             11: {
-                'cpu_time': 249658663079978//8,
+                'cpu_time': 249658663079978,
                 'cpu_usage': 0,
                 'memory_kb': 3782668,
             },
@@ -111,7 +111,7 @@ class TC_20_QubesHost(qubes.tests.QubesTestCase):
         self.assertIsNotNone(info_time)
         expected_info = {
             0: {
-                'cpu_time': 243951379111104//8,
+                'cpu_time': 243951379111104,
                 'cpu_usage': 9,
                 'memory_kb': 3733212,
             },
@@ -121,7 +121,7 @@ class TC_20_QubesHost(qubes.tests.QubesTestCase):
                 'memory_kb': 303916,
             },
             11: {
-                'cpu_time': 249658663079978//8,
+                'cpu_time': 249658663079978,
                 'cpu_usage': 12,
                 'memory_kb': 3782668,
             },


### PR DESCRIPTION
Removes CPU normalization in the domains widget.

For example, a VM with 4 cores assigned (such as dom0 on a quad-core system) can go up to 400%.

* Easier to compare CPU usage (no hidden normalization factors).
* Consistent with xentop.
* Fixes an issue with erroneously high CPU percentages in the domain widget when a VM is shutting down.
