### PR TITLE
Fixed unexpected error on empty default template and incorrect error handling

### DIFF
--- a/qubes/__init__.py
+++ b/qubes/__init__.py
@@ -727,7 +727,10 @@ class PropertyHolder(qubes.events.Emitter):
         try:
             value = getattr(self, prop)
             if value is None and not allow_none:
-                raise ValueError('Property {!r} cannot be None'.format(prop))
+                msg = 'Property {!r} cannot be None'.format(prop)
+                if hard:
+                    raise ValueError(msg)
+                self.log.fatal(msg)
         except AttributeError:
             # pylint: disable=no-member
             msg = 'Required property {!r} not set on {!r}'.format(prop, self)

--- a/qubes/app.py
+++ b/qubes/app.py
@@ -937,7 +937,7 @@ class Qubes(qubes.PropertyHolder):
         # stage 5: misc fixups
 
         self.property_require('default_netvm', allow_none=True)
-        self.property_require('default_template')
+        self.property_require('default_template', allow_none=True)
         self.property_require('clockvm', allow_none=True)
         self.property_require('updatevm', allow_none=True)
 


### PR DESCRIPTION
qubesd wrongly required default_template global property to be not None.
Furthermore, even without hard failure set, require_property method
raised an exception in case of a property having incorrect None value.
It now logs an error message instead, as designed.

fixes QubesOS/qubes-issues#5326