### PR TITLE
tests: avoid object leaks in usb extension

### DIFF
--- a/qubes/app.py
+++ b/qubes/app.py
@@ -724,6 +724,17 @@ class Qubes(qubes.PropertyHolder):
             :param event: Event name (``'pool-delete'``)
             :param pool: Pool object
 
+        .. event:: qubes-close (subject, event)
+
+            Fired when this Qubes() object instance is going to be closed
+            and destroyed. In practice it is called only during tests, to
+            cleanup objects from one test, before another.
+            It is _not_ called when qubesd daemon is stopped.
+
+            :param subject: Event emitter
+            :param event: Event name (``'qubes-close'``)
+
+
     Methods and attributes:
     """
     default_guivm = qubes.VMProperty(
@@ -1085,6 +1096,9 @@ class Qubes(qubes.PropertyHolder):
         for frame in traceback.extract_stack():
             self.log.debug('%s', frame)
 
+        # let all the extension cleanup things
+        self.fire_event('qubes-close')
+
         super().close()
 
         if self._domain_event_callback_id is not None:
@@ -1094,6 +1108,9 @@ class Qubes(qubes.PropertyHolder):
 
         # Only our Lord, The God Almighty, knows what references
         # are kept in extensions.
+        # NOTE: this doesn't really delete extension objects - Extension class
+        # saves reference to instance, and also various registered (class level)
+        # event handlers do that too
         del self._extensions
 
         for vm in self.domains:

--- a/qubes/ext/pci.py
+++ b/qubes/ext/pci.py
@@ -313,6 +313,12 @@ class PCIDeviceExtension(qubes.ext.Extension):
             else:
                 raise
 
+    @qubes.ext.handler('qubes-close', system=True)
+    def on_app_close(self, app, event):
+        # pylint: disable=unused-argument,no-self-use
+        _cache_get.cache_clear()
+
+
 @functools.lru_cache(maxsize=None)
 def _cache_get(vm, ident):
     ''' Caching wrapper around `PCIDevice(vm, ident)`. '''

--- a/qubes/tests/__init__.py
+++ b/qubes/tests/__init__.py
@@ -410,7 +410,6 @@ class QubesTestCase(unittest.TestCase):
         self.loop = asyncio.get_event_loop()
         self.addCleanup(self.cleanup_loop)
         self.addCleanup(self.cleanup_traceback)
-        self.addCleanup(qubes.ext.pci._cache_get.cache_clear)
 
     def cleanup_traceback(self):
         '''Remove local variables reference from tracebacks to allow garbage

--- a/qubes/tests/vm/qubesvm.py
+++ b/qubes/tests/vm/qubesvm.py
@@ -273,6 +273,9 @@ class QubesVMTestsMixin(object):
 
     def tearDown(self):
         try:
+            # self.app is not a real events emiter, so make the call manually
+            for handler in qubes.Qubes.__handlers__.get('qubes-close'):
+                handler(self.app, 'qubes-close')
             self.app.domains.close()
         except AttributeError:
             pass


### PR DESCRIPTION
Extension objects are singletons and normally do not require any special
cleanup. But in case of tests, we try to remove all the qubes objects
between tests and the cache in usb extension makes it hard.
Instead of polluting actual extension code with hacks useful only during
tests, put it into a common place - in SystemTestCase class.