### PR TITLE
Maintain a list of connected machine IPs in qubesdb

### DIFF
--- a/qubes/tests/vm/qubesvm.py
+++ b/qubes/tests/vm/qubesvm.py
@@ -1518,6 +1518,8 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             '/qubes-iptables-header': iptables_header,
             '/qubes-service/qubes-update-check': '0',
             '/qubes-service/meminfo-writer': '1',
+            '/connected-ips': '',
+            '/connected-ips6': '',
         })
 
     @unittest.mock.patch('datetime.datetime')
@@ -1588,6 +1590,8 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             '/qubes-gateway': '10.137.0.2',
             '/qubes-primary-dns': '10.139.1.1',
             '/qubes-secondary-dns': '10.139.1.2',
+            '/connected-ips': '',
+            '/connected-ips6': '',
         }
 
         with self.subTest('ipv4'):
@@ -1642,6 +1646,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             expected['/qubes-firewall/10.137.0.3'] = ''
             expected['/qubes-firewall/10.137.0.3/0000'] = 'action=accept'
             expected['/qubes-firewall/10.137.0.3/policy'] = 'drop'
+            expected['/connected-ips'] = '10.137.0.3'
 
             with unittest.mock.patch('qubes.vm.qubesvm.QubesVM.is_running',
                     lambda _: True):
@@ -1657,6 +1662,8 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             expected['/qubes-firewall/' + ip6] = ''
             expected['/qubes-firewall/' + ip6 + '/0000'] = 'action=accept'
             expected['/qubes-firewall/' + ip6 + '/policy'] = 'drop'
+            expected['/connected-ips6'] = ip6
+
             with unittest.mock.patch('qubes.vm.qubesvm.QubesVM.is_running',
                     lambda _: True):
                 netvm.create_qdb_entries()
@@ -1705,6 +1712,8 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             '/qubes-iptables-header': unittest.mock.ANY,
             '/qubes-service/qubes-update-check': '0',
             '/qubes-service/meminfo-writer': '1',
+            '/connected-ips': '',
+            '/connected-ips6': '',
         })
 
 

--- a/qubes/vm/mix/net.py
+++ b/qubes/vm/mix/net.py
@@ -446,13 +446,14 @@ class NetVMMixin(qubes.events.Emitter):
         '''
         # pylint: disable=unused-argument
 
-        if oldvalue is not None:
+        if oldvalue is not None and oldvalue.is_running():
             oldvalue.reload_connected_ips()
 
         if newvalue is None:
             return
 
-        newvalue.reload_connected_ips()
+        if newvalue.is_running():
+            newvalue.reload_connected_ips()
 
         if self.is_running():
             # refresh IP, DNS etc

--- a/qubes/vm/mix/net.py
+++ b/qubes/vm/mix/net.py
@@ -394,10 +394,17 @@ class NetVMMixin(qubes.events.Emitter):
         Update list of IPs possibly connected to this machine.
         This is used by qubes-firewall to implement anti-spoofing.
         '''
-        connected_ips = [str(vm.visible_ip) for vm in self.connected_vms]
+        connected_ips = [str(vm.visible_ip) for vm in self.connected_vms
+                         if vm.visible_ip is not None]
+        connected_ips6 = [str(vm.visible_ip6) for vm in self.connected_vms
+                          if vm.visible_ip6 is not None]
+
         self.untrusted_qdb.write(
             '/connected-ips',
             ' '.join(connected_ips))
+        self.untrusted_qdb.write(
+            '/connected-ips6',
+            ' '.join(connected_ips6))
 
     @qubes.events.handler('property-pre-del:netvm')
     def on_property_pre_del_netvm(self, event, name, oldvalue=None):

--- a/qubes/vm/mix/net.py
+++ b/qubes/vm/mix/net.py
@@ -479,10 +479,11 @@ class NetVMMixin(qubes.events.Emitter):
     def on_domain_qdb_create(self, event):
         ''' Fills the QubesDB with firewall entries. '''
         # pylint: disable=unused-argument
+
+        # Keep the following in sync with on_firewall_changed.
         self.reload_connected_ips()
         for vm in self.connected_vms:
             if vm.is_running():
-                # keep in sync with on_firewall_changed
                 self.set_mapped_ip_info_for_vm(vm)
                 self.reload_firewall_for_vm(vm)
 
@@ -491,6 +492,7 @@ class NetVMMixin(qubes.events.Emitter):
         ''' Reloads the firewall if vm is running and has a NetVM assigned '''
         # pylint: disable=unused-argument
         if self.is_running() and self.netvm:
+            self.netvm.reload_connected_ips()
             self.netvm.set_mapped_ip_info_for_vm(self)
             self.netvm.reload_firewall_for_vm(self)  # pylint: disable=no-member
 


### PR DESCRIPTION
Necessary for anti-spoofing, see QubesOS/qubes-issues#5540.