### PR TITLE
Added handling for 'force' option in vm shutdown

### DIFF
--- a/qubes/api/admin.py
+++ b/qubes/api/admin.py
@@ -899,9 +899,9 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
         scope='local', execute=True)
     @asyncio.coroutine
     def vm_shutdown(self):
-        self.enforce(not self.arg)
-        self.fire_event_for_permission()
-        yield from self.dest.shutdown()
+        force = (self.arg == 'force')
+        self.fire_event_for_permission(force=force)
+        yield from self.dest.shutdown(force=force)
 
     @qubes.api.method('admin.vm.Pause', no_payload=True,
         scope='local', execute=True)

--- a/qubes/tests/api_admin.py
+++ b/qubes/tests/api_admin.py
@@ -1004,7 +1004,18 @@ netvm default=True type=vm
         self.vm.shutdown = coroutine_mock
         value = self.call_mgmt_func(b'admin.vm.Shutdown', b'test-vm1')
         self.assertIsNone(value)
-        func_mock.assert_called_once_with()
+        func_mock.assert_called_once_with(force=False)
+
+    def test_231_shutdown_force(self):
+        func_mock = unittest.mock.Mock()
+
+        @asyncio.coroutine
+        def coroutine_mock(*args, **kwargs):
+            return func_mock(*args, **kwargs)
+        self.vm.shutdown = coroutine_mock
+        value = self.call_mgmt_func(b'admin.vm.Shutdown', b'test-vm1', b'force')
+        self.assertIsNone(value)
+        func_mock.assert_called_once_with(force=True)
 
     def test_240_pause(self):
         func_mock = unittest.mock.Mock()
@@ -2699,7 +2710,6 @@ netvm default=True type=vm
             b'admin.vm.firewall.Reload',
             b'admin.vm.volume.List',
             b'admin.vm.Start',
-            b'admin.vm.Shutdown',
             b'admin.vm.Pause',
             b'admin.vm.Unpause',
             b'admin.vm.Kill',


### PR DESCRIPTION
To be more precise: just allowed using it, as the option was
actually implemented previously.

references QubesOS/qubes-issues#5591