### PR TITLE
Correct comments in to match current code behavior

### DIFF
--- a/qubes/backup.py
+++ b/qubes/backup.py
@@ -294,7 +294,7 @@ class Backup:
 
     def __init__(self, app, vms_list=None, exclude_list=None, **kwargs):
         """
-        If vms = None, include all (sensible) VMs;
+        If vms = None, use default list based on vm.include_in_backups property;
         exclude_list is always applied
         """
         super(Backup, self).__init__()


### PR DESCRIPTION
The implementation in https://github.com/QubesOS/qubes-core-admin/blob/master/qubes/backup.py interprets a "None" list of VMs to backup as asking for the default list of VMs. See line 347 for the implementation code:

```
if vms_list is None:
            vms_list = [vm for vm in app.domains if vm.include_in_backups]
```

However, the in-code comments differ. At the class declaration on line 231 the comment reflects the as-implemented behavior:

```
class Backup:
    '''Backup operation manager. Usage:
    >>> app = qubes.Qubes()
    >>> # optional - you can use 'None' to use default list (based on
    >>> #  vm.include_in_backups property)
    >>> vms = [app.domains[name] for name in ['my-vm1', 'my-vm2', 'my-vm3']]
```

later however, at the __init__ method on line 295, there is a different in-code comment:

```
   def __init__(self, app, vms_list=None, exclude_list=None, **kwargs):
        """
        If vms = None, include all (sensible) VMs;
        exclude_list is always applied
        """
```

This pull request updates the second comment to reflect the actual code behavior on line 347 of using `vm.include_in_backups` to determine which VMs to include when a "None" list is passed.


