### PR TITLE
api/admin: (ext/admin) limit listing VMs based on qrexec policy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,10 @@ install:
   - sudo apt-get -y install python3-gi gir1.2-gtk-3.0
   - pip install --quiet -r ci/requirements.txt
   - git clone https://github.com/"${TRAVIS_REPO_SLUG%%/*}"/qubes-builder ~/qubes-builder
+  - git clone https://github.com/"${TRAVIS_REPO_SLUG%%/*}"/qubes-core-qrexec ~/qubes-core-qrexec
 script:
-  - PYTHONPATH=test-packages pylint qubes
-  - ./run-tests
+  - PYTHONPATH=test-packages:~/qubes-core-qrexec pylint qubes
+  - PYTHONPATH=test-packages:~/qubes-core-qrexec ./run-tests
   - ~/qubes-builder/scripts/travis-build
 env:
  - DIST_DOM0=fc31 USE_QUBES_REPO_VERSION=4.1 USE_QUBES_REPO_TESTING=1

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -8,3 +8,4 @@ lxml
 pylint
 sphinx
 PyYAML
+pyinotify

--- a/qubes/api/internal.py
+++ b/qubes/api/internal.py
@@ -30,6 +30,23 @@ import qubes.vm.adminvm
 import qubes.vm.dispvm
 
 
+def get_system_info(app):
+    system_info = {'domains': {
+        domain.name: {
+            'tags': list(domain.tags),
+            'type': domain.__class__.__name__,
+            'template_for_dispvms':
+                getattr(domain, 'template_for_dispvms', False),
+            'default_dispvm': (domain.default_dispvm.name if
+                getattr(domain, 'default_dispvm', None) else None),
+            'icon': str(domain.label.icon),
+            'guivm': (domain.guivm.name if getattr(domain, 'guivm', None)
+                      else None),
+        } for domain in app.domains
+    }}
+    return system_info
+
+
 class QubesInternalAPI(qubes.api.AbstractQubesAPI):
     ''' Communication interface for dom0 components,
     by design the input here is trusted.'''
@@ -42,19 +59,7 @@ class QubesInternalAPI(qubes.api.AbstractQubesAPI):
         self.enforce(self.dest.name == 'dom0')
         self.enforce(not self.arg)
 
-        system_info = {'domains': {
-            domain.name: {
-                'tags': list(domain.tags),
-                'type': domain.__class__.__name__,
-                'template_for_dispvms':
-                    getattr(domain, 'template_for_dispvms', False),
-                'default_dispvm': (domain.default_dispvm.name if
-                    getattr(domain, 'default_dispvm', None) else None),
-                'icon': str(domain.label.icon),
-                'guivm': (domain.guivm.name if getattr(domain, 'guivm', None)
-                          else None),
-            } for domain in self.app.domains
-        }}
+        system_info = get_system_info(self.app)
 
         return json.dumps(system_info)
 

--- a/qubes/ext/admin.py
+++ b/qubes/ext/admin.py
@@ -18,10 +18,28 @@
 # License along with this library; if not, see <https://www.gnu.org/licenses/>.
 
 import qubes.api
+import qubes.api.internal
 import qubes.ext
 import qubes.vm.adminvm
+from qrexec.policy import utils, parser
+
+
+class JustEvaluateAskResolution(parser.AskResolution):
+    def execute(self, caller_ident):
+        pass
+
+
+class JustEvaluateAllowResolution(parser.AllowResolution):
+    def execute(self, caller_ident):
+        pass
+
 
 class AdminExtension(qubes.ext.Extension):
+    def __init__(self):
+        super(AdminExtension, self).__init__()
+        self.policy_cache = utils.PolicyCache(lazy_load=True)
+        self.policy_cache.initialize_watcher()
+
     # pylint: disable=too-few-public-methods
     @qubes.ext.handler(
         'admin-permission:admin.vm.tag.Set',
@@ -36,3 +54,86 @@ class AdminExtension(qubes.ext.Extension):
                     __name__, type(self).__name__))
 
     # TODO create that tag here (need to figure out how to pass mgmtvm name)
+
+    @qubes.ext.handler('admin-permission:admin.vm.List')
+    def admin_vm_list(self, vm, event, arg, **kwargs):
+        '''When called with target 'dom0' (aka "get full list"), exclude domains
+           that the caller don't have permission to list
+        '''
+        # pylint: disable=unused-argument
+
+        if vm.klass == 'AdminVM':
+            # dom0 can always list everything
+            return None
+
+        policy = self.policy_cache.get_policy()
+        system_info = qubes.api.internal.get_system_info(vm.app)
+
+        def filter_vms(dest_vm):
+            request = parser.Request(
+                'admin.vm.List',
+                '+' + arg,
+                vm.name,
+                dest_vm.name,
+                system_info=system_info,
+                ask_resolution_type=JustEvaluateAskResolution,
+                allow_resolution_type=JustEvaluateAllowResolution)
+            try:
+                resolution = policy.evaluate(request)
+                # do not consider 'ask' as allow here,
+                # this needs to be not interactive
+                return isinstance(resolution, parser.AllowResolution)
+            except parser.AccessDenied:
+                return False
+
+        return (filter_vms,)
+
+    @qubes.ext.handler('admin-permission:admin.Events')
+    def admin_events(self, vm, event, arg, **kwargs):
+        '''When called with target 'dom0' (aka "get all events"),
+           exclude domains that the caller don't have permission to receive
+           events about
+        '''
+        # pylint: disable=unused-argument
+
+        if vm.klass == 'AdminVM':
+            # dom0 can always list everything
+            return None
+
+        def filter_events(event):
+            subject, event, kwargs = event
+            try:
+                dest = subject.name
+            except AttributeError:
+                # domain-add and similar events fired on the Qubes() object
+                if 'vm' in kwargs:
+                    dest = kwargs['vm'].name
+                else:
+                    dest = '@adminvm'
+
+            policy = self.policy_cache.get_policy()
+            # TODO: cache system_info (based on last qubes.xml write time?)
+            system_info = qubes.api.internal.get_system_info(vm.app)
+            request = parser.Request(
+                'admin.Events',
+                '+' + event.replace(':', '_'),
+                vm.name,
+                dest,
+                system_info=system_info,
+                ask_resolution_type=JustEvaluateAskResolution,
+                allow_resolution_type=JustEvaluateAllowResolution)
+            try:
+                resolution = policy.evaluate(request)
+                # do not consider 'ask' as allow here,
+                # this needs to be not interactive
+                return isinstance(resolution, parser.AllowResolution)
+            except parser.AccessDenied:
+                return False
+
+        return (filter_events,)
+
+    @qubes.ext.handler('qubes-close', system=True)
+    def on_qubes_close(self, app, event, **kwargs):
+        """Unregister policy file watches on app.close()."""
+        # pylint: disable=unused-argument
+        self.policy_cache.cleanup()

--- a/qubes/ext/admin.py
+++ b/qubes/ext/admin.py
@@ -37,8 +37,11 @@ class JustEvaluateAllowResolution(parser.AllowResolution):
 class AdminExtension(qubes.ext.Extension):
     def __init__(self):
         super(AdminExtension, self).__init__()
-        self.policy_cache = utils.PolicyCache(lazy_load=True)
-        self.policy_cache.initialize_watcher()
+        # during tests, __init__() of the extension can be called multiple
+        # times, because there are multiple Qubes() object instances
+        if not hasattr(self, 'policy_cache'):
+            self.policy_cache = utils.PolicyCache(lazy_load=True)
+            self.policy_cache.initialize_watcher()
 
     # pylint: disable=too-few-public-methods
     @qubes.ext.handler(
@@ -136,4 +139,6 @@ class AdminExtension(qubes.ext.Extension):
     def on_qubes_close(self, app, event, **kwargs):
         """Unregister policy file watches on app.close()."""
         # pylint: disable=unused-argument
-        self.policy_cache.cleanup()
+        if hasattr(self, 'policy_cache'):
+            self.policy_cache.cleanup()
+            del self.policy_cache

--- a/qubes/tests/api.py
+++ b/qubes/tests/api.py
@@ -109,8 +109,12 @@ class TC_00_QubesDaemonProtocol(qubes.tests.QubesTestCase):
             connect_coro)
 
     def tearDown(self):
-        self.sock_server.close()
-        self.sock_client.close()
+        self.writer.close()
+        try:
+            self.loop.run_until_complete(self.writer.wait_closed())
+        except AttributeError:  # old python in travis
+            pass
+        self.transport.close()
         super(TC_00_QubesDaemonProtocol, self).tearDown()
 
     def test_000_message_ok(self):

--- a/qubes/tests/app.py
+++ b/qubes/tests/app.py
@@ -480,6 +480,9 @@ class TC_89_QubesEmpty(qubes.tests.QubesTestCase):
             with self.assertRaises(AttributeError):
                 self.app.default_fw_netvm
 
+            self.app.close()
+            del self.app
+
         with self.subTest('loop'):
             with open('/tmp/qubestest.xml', 'w') as xml_file:
                 xml_file.write(xml_template.format(
@@ -501,6 +504,9 @@ class TC_89_QubesEmpty(qubes.tests.QubesTestCase):
                 self.app.domains['sys-firewall'])
             with self.assertRaises(AttributeError):
                 self.app.default_fw_netvm
+
+            self.app.close()
+            del self.app
 
 
 class TC_90_Qubes(qubes.tests.QubesTestCase):

--- a/qubes/tests/storage_lvm.py
+++ b/qubes/tests/storage_lvm.py
@@ -131,6 +131,7 @@ class TC_00_ThinPool(ThinPoolBase):
     def tearDown(self):
         super(TC_00_ThinPool, self).tearDown()
         os.unlink(self.app.store)
+        self.app.close()
         del self.app
         for attr in dir(self):
             if isinstance(getattr(self, attr), qubes.vm.BaseVM):
@@ -1141,6 +1142,7 @@ class TC_02_StorageHelpers(ThinPoolBase):
         self.thin_dir.cleanup()
         super(TC_02_StorageHelpers, self).tearDown()
         os.unlink(self.app.store)
+        self.app.close()
         del self.app
         for attr in dir(self):
             if isinstance(getattr(self, attr), qubes.vm.BaseVM):


### PR DESCRIPTION
Various Admin API calls, when directed at dom0, retrieve global system view
instead of a specific VM. This applies to admin.vm.List (called at dom0
retrieve full VM list) and admin.Events (called at dom0 listen for events
of all the VMs). This makes it tricky to configure a management VM with
access to limited set of VMs only, because many tools require ability to
list VMs, and that would return full list.

Fix this issue by adding a filter to admin.vm.List and admin.Events calls
(using event handlers in AdminExtension) that filters the output using
qrexec policy. This version evaluates policy for each VM or event
(but loads only once). If the performance will be an issue, it can be 
optimized later.

Fixes QubesOS/qubes-issues#5509