### PR TITLE
tests: ensure proper cleanup of auxiliary process

### DIFF
--- a/qubes/tests/integ/vm_qrexec_gui.py
+++ b/qubes/tests/integ/vm_qrexec_gui.py
@@ -943,11 +943,13 @@ class TC_00_AppVMMixin(object):
             self.testvm1.start(),
             self.testvm2.start()]))
 
+        self.loop.run_until_complete(self.testvm1.run_for_stdio(
+            'cp /etc/passwd /tmp/passwd'))
         with self.qrexec_policy('qubes.Filecopy', self.testvm1, self.testvm2):
             try:
                 self.loop.run_until_complete(
                     self.testvm1.run_for_stdio(
-                        'qvm-copy-to-vm {} /etc/passwd'.format(
+                        'qvm-copy-to-vm {} /tmp/passwd'.format(
                             self.testvm2.name)))
             except subprocess.CalledProcessError as e:
                 self.fail('qvm-copy-to-vm failed: {}'.format(e.stderr))
@@ -961,7 +963,7 @@ class TC_00_AppVMMixin(object):
 
         try:
             self.loop.run_until_complete(self.testvm1.run_for_stdio(
-                'test -f /etc/passwd'))
+                'test -f /tmp/passwd'))
         except subprocess.CalledProcessError:
             self.fail('source file got removed')
 


### PR DESCRIPTION
Various qrexec tests create auxiliary process (service_proc) as a local
variable. In case of test failure, process cleanup isn't called and may
lead to FD leaks and breaking subsequent tests.

Fix this by always saving such process instance in self.service_proc and
cleaning it up in self.tearDown() (this code is already there).