### PR TITLE
tests/file: run_until_complete(); coro_maybe() for single arg

### DIFF
--- a/qubes/tests/storage_file.py
+++ b/qubes/tests/storage_file.py
@@ -22,7 +22,6 @@
 import os
 import shutil
 
-import asyncio
 import unittest.mock
 
 import subprocess
@@ -592,8 +591,7 @@ class TC_03_FilePool(qubes.tests.QubesTestCase):
                                          'pool': 'test-pool'
                                      }
                                  }, label='red')
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(vm.create_on_disk())
+        self.loop.run_until_complete(vm.create_on_disk())
 
         expected_vmdir = os.path.join(self.APPVMS_DIR, vm.name)
 
@@ -622,8 +620,7 @@ class TC_03_FilePool(qubes.tests.QubesTestCase):
                                          'pool': 'test-pool'
                                      }
                                  }, label='red')
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(vm.create_on_disk())
+        self.loop.run_until_complete(vm.create_on_disk())
 
         expected_vmdir = os.path.join(self.TEMPLATES_DIR, vm.name)
 

--- a/qubes/tests/storage_file.py
+++ b/qubes/tests/storage_file.py
@@ -395,9 +395,11 @@ class TC_01_FileVolumes(qubes.tests.QubesTestCase):
         }
         vm = qubes.tests.storage.TestVM(self)
         volume = self.app.get_pool(self.POOL_NAME).init_volume(vm, config)
-        qubes.utils.void_coros_maybe([volume.create()])
+        self.loop.run_until_complete(
+            qubes.utils.coro_maybe(volume.create()))
         new_size = 64 * 1024 ** 2
-        qubes.utils.void_coros_maybe([volume.resize(new_size)])
+        self.loop.run_until_complete(
+            qubes.utils.coro_maybe(volume.resize(new_size)))
         self.assertEqual(os.path.getsize(volume.path), new_size)
         self.assertEqual(volume.size, new_size)
 
@@ -459,8 +461,8 @@ class TC_01_FileVolumes(qubes.tests.QubesTestCase):
         }
         vm = qubes.tests.storage.TestVM(self)
         volume = self.app.get_pool(self.POOL_NAME).init_volume(vm, config)
-        qubes.utils.void_coros_maybe([volume.create()])
-        qubes.utils.void_coros_maybe([volume.start()])
+        self.loop.run_until_complete(qubes.utils.coro_maybe(volume.create()))
+        self.loop.run_until_complete(qubes.utils.coro_maybe(volume.start()))
         self._setup_loop(volume.path)
         new_size = 64 * 1024 ** 2
         orig_check_call = subprocess.check_call
@@ -468,11 +470,12 @@ class TC_01_FileVolumes(qubes.tests.QubesTestCase):
             sudo = [] if os.getuid() == 0 else ['sudo']
             mock_subprocess.side_effect = (lambda *args, **kwargs:
                 orig_check_call(sudo + args[0], *args[1:], **kwargs))
-            qubes.utils.void_coros_maybe([volume.resize(new_size)])
+            self.loop.run_until_complete(
+                qubes.utils.coro_maybe(volume.resize(new_size)))
         self.assertEqual(os.path.getsize(volume.path), new_size)
         self.assertEqual(self._get_loop_size(volume.path), new_size)
         self.assertEqual(volume.size, new_size)
-        qubes.utils.void_coros_maybe([volume.stop()])
+        self.loop.run_until_complete(qubes.utils.coro_maybe(volume.stop()))
         self.assertEqual(os.path.getsize(volume.path), new_size)
         self.assertEqual(volume.size, new_size)
 


### PR DESCRIPTION
I wonder if there is any way to get a warning for objects from an `@asyncio.coroutine` function that are never yielded from? Like the `RuntimeWarning: coroutine 'foo' was never awaited` for objects from `async def foo()`.