### PR TITLE
collections.Callable -> collections.abc.Callable

### DIFF
--- a/qubes/__init__.py
+++ b/qubes/__init__.py
@@ -27,7 +27,7 @@ Qubes OS
 '''
 
 import builtins
-import collections
+import collections.abc
 import os
 import os.path
 import string
@@ -146,11 +146,11 @@ class property:  # pylint: disable=redefined-builtin,invalid-name
     or, when no default, py:class:`exceptions.AttributeError`.
 
     :param str name: name of the property
-    :param collections.Callable setter: if not :py:obj:`None`, this is used to \
-        initialise value; first parameter to the function is holder instance \
-        and the second is value; this is called before ``type``
-    :param collections.Callable saver: function to coerce value to something \
-        readable by setter
+    :param collections.abc.Callable setter: if not :py:obj:`None`, this is \
+        used to initialise value; first parameter to the function is holder \
+        instance and the second is value; this is called before ``type``
+    :param collections.abc.Callable saver: function to coerce value to \
+        something readable by setter
     :param type type: if not :py:obj:`None`, value is coerced to this type
     :param object default: default value; if callable, will be called with \
         holder as first argument
@@ -203,7 +203,7 @@ class property:  # pylint: disable=redefined-builtin,invalid-name
         self.type = type
         self._default = default
         self._default_function = None
-        if isinstance(default, collections.Callable):
+        if isinstance(default, collections.abc.Callable):
             self._default_function = default
 
         self._write_once = write_once

--- a/qubes/app.py
+++ b/qubes/app.py
@@ -20,7 +20,7 @@
 # License along with this library; if not, see <https://www.gnu.org/licenses/>.
 #
 
-import collections
+import collections.abc
 import copy
 import functools
 import grp
@@ -95,7 +95,7 @@ class VirDomainWrapper:
 
     def __getattr__(self, attrname):
         attr = getattr(self._vm, attrname)
-        if not isinstance(attr, collections.Callable):
+        if not isinstance(attr, collections.abc.Callable):
             return attr
 
         @functools.wraps(attr)
@@ -135,7 +135,7 @@ class VirConnectWrapper:
 
     def __getattr__(self, attrname):
         attr = getattr(self._conn, attrname)
-        if not isinstance(attr, collections.Callable):
+        if not isinstance(attr, collections.abc.Callable):
             return attr
         if attrname == 'close':
             return attr

--- a/qubes/events.py
+++ b/qubes/events.py
@@ -116,7 +116,7 @@ class Emitter(metaclass=EmitterMeta):
         This is class method, it is invalid to call it on object instance.
 
         :param str event: event identificator
-        :param collections.Callable handler: handler callable
+        :param collections.abc.Callable handler: handler callable
         '''
 
         # pylint: disable=no-member
@@ -131,7 +131,7 @@ class Emitter(metaclass=EmitterMeta):
         :py:meth:`add_handler` was called to register the handler.
 
         :param str event: event identificator
-        :param collections.Callable handler: handler callable
+        :param collections.abc.Callable handler: handler callable
         '''
 
         # pylint: disable=no-member

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -1072,7 +1072,7 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
         """Start domain
 
         :param bool start_guid: FIXME
-        :param collections.Callable notify_function: FIXME
+        :param collections.abc.Callable notify_function: FIXME
         :param int mem_required: FIXME
         """
 


### PR DESCRIPTION
Old syntax "Deprecated since version 3.3, will be removed in version 3.10"
- https://docs.python.org/3/library/collections.html