### PR TITLE
AdminVM support for Qubes network server (release 4.1).

### DIFF
--- a/qubes/tests/vm/qubesvm.py
+++ b/qubes/tests/vm/qubesvm.py
@@ -1794,6 +1794,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             expected['/qubes-firewall/10.137.0.3/0000'] = 'action=accept'
             expected['/qubes-firewall/10.137.0.3/policy'] = 'drop'
             expected['/connected-ips'] = '10.137.0.3'
+            expected['/qubes-routing-method/10.137.0.3'] = 'masquerade'
 
             with unittest.mock.patch('qubes.vm.qubesvm.QubesVM.is_running',
                     lambda _: True):
@@ -1810,6 +1811,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             expected['/qubes-firewall/' + ip6 + '/0000'] = 'action=accept'
             expected['/qubes-firewall/' + ip6 + '/policy'] = 'drop'
             expected['/connected-ips6'] = ip6
+            expected['/qubes-routing-method/fd09:24ef:4179::a89:3'] = 'masquerade'
 
             with unittest.mock.patch('qubes.vm.qubesvm.QubesVM.is_running',
                     lambda _: True):

--- a/qubes/vm/mix/net.py
+++ b/qubes/vm/mix/net.py
@@ -378,7 +378,7 @@ class NetVMMixin(qubes.events.Emitter):
             if ip is None:
                 continue
             # report routing method
-            self.setup_non_masquerade_forwarding_for_vm(vm, ip, remove=shutdown)
+            self.setup_forwarding_for_vm(vm, ip, remove=shutdown)
 
     def reload_firewall_for_vm(self, vm):
         ''' Reload the firewall rules for the vm '''
@@ -400,7 +400,7 @@ class NetVMMixin(qubes.events.Emitter):
             # signal its done
             self.untrusted_qdb.write(base_dir[:-1], '')
 
-    def setup_non_masquerade_forwarding_for_vm(self, vm, ip, remove=False):
+    def setup_forwarding_for_vm(self, vm, ip, remove=False):
         '''
         Record in Qubes DB that the passed VM may be meant to have traffic
         forwarded to and from it, rather than masqueraded from it and blocked
@@ -420,7 +420,9 @@ class NetVMMixin(qubes.events.Emitter):
         '''
         if ip is None:
             return
-        routing_method = vm.features.check_with_template('routing-method', 'masquerade')
+        routing_method = vm.features.check_with_template(
+            'routing-method', 'masquerade'
+        )
         base_file = '/qubes-routing-method/{}'.format(ip)
         if remove:
             self.untrusted_qdb.rm(base_file)


### PR DESCRIPTION
These modifications create a new feature `routing-method` which defaults to the normal Qubes OS behavior of masquerading outgoing traffic from AppVMs.  When the `routing-method` feature is set on a VM, its value is written to a `/qubes-routing-method/<IP>` Qubes DB entry within its NetVM.

NetVMs can thus use that information to switch from masquerading to normal IP forwarding for VMs designated with `routing-method=forward` by the administrator.

Other than creating the necessary `/qubes-routing-method/<IP>` hierarchy in Qubes DB, this code does nothing else.

This feature does not yet support chains of NetVMs -- only the NetVM directly attached to the AppVM is affected.

To see the companion agent that uses this new Qubes DB information, please refer to branch `r4.0` of https://github.com/Rudd-O/qubes-network-server/tree/r4.0 .  The agent in that branch supports reading from the `/qubes-routing-method` tree to configure the NetVM appropriately.

I am working, in parallel, on a Qubes OS >= 4.1.compatible implementation.