### PR TITLE
add ability to setup multiply layouts in features

### DIFF
--- a/qubes/ext/gui.py
+++ b/qubes/ext/gui.py
@@ -132,10 +132,11 @@ class GUI(qubes.ext.Extension):
         untrusted_variant = untrusted_xkb_layout[1]
         untrusted_options = untrusted_xkb_layout[2]
 
+        re_layout = r'^[a-zA-Z,]*$'
         re_variant = r'^[a-zA-Z0-9-_]*$'
         re_options = r'^[a-zA-Z0-9-_:,]*$'
 
-        if not untrusted_layout.isalpha():
+        if not re.match(re_layout, untrusted_layout):
             raise qubes.exc.QubesValueError("Invalid layout provided")
         if not re.match(re_variant, untrusted_variant):
             raise qubes.exc.QubesValueError("Invalid variant provided")


### PR DESCRIPTION
Add comma as correct symbol on sanitize. According to setxkbmap manual:               
    Specifies  the  name of the layout used to determine the components which make  up  the  keyboard  description.  The  -layout option may only be used once. Multiple layouts can be specified as a comma-separated list.