### PR TITLE
libvirt xen: Add gfx_passthru and device_video

### DIFF
--- a/qubes/tests/vm/qubesvm.py
+++ b/qubes/tests/vm/qubesvm.py
@@ -751,6 +751,8 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <cmdline>root=/dev/mapper/dmroot ro nomodeset console=hvc0 rd_NO_PLYMOUTH rd.plymouth.enable=0 plymouth.enable=0 nopat</cmdline>
         </os>
         <features>
+            <xen>
+            </xen>
         </features>
         <clock offset='utc' adjustment='reset'>
             <timer name="tsc" mode="native"/>
@@ -826,6 +828,8 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <acpi/>
             <apic/>
             <viridian/>
+            <xen>
+            </xen>
         </features>
         <clock offset="variable" adjustment="0" basis="localtime" />
         <on_poweroff>destroy</on_poweroff>
@@ -884,6 +888,8 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <acpi/>
             <apic/>
             <viridian/>
+            <xen>
+            </xen>
         </features>
         <clock offset="variable" adjustment="0" basis="localtime" />
         <on_poweroff>destroy</on_poweroff>
@@ -951,6 +957,8 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <acpi/>
             <apic/>
             <viridian/>
+            <xen>
+            </xen>
         </features>
         <clock offset="variable" adjustment="0" basis="localtime" />
         <on_poweroff>destroy</on_poweroff>
@@ -1015,6 +1023,8 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <acpi/>
             <apic/>
             <viridian/>
+            <xen>
+            </xen>
         </features>
         <clock offset='utc' adjustment='reset'>
             <timer name="tsc" mode="native"/>
@@ -1085,6 +1095,8 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <acpi/>
             <apic/>
             <viridian/>
+            <xen>
+            </xen>
         </features>
         <clock offset='utc' adjustment='reset'>
             <timer name="tsc" mode="native"/>
@@ -1242,6 +1254,8 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <acpi/>
             <apic/>
             <viridian/>
+            <xen>
+            </xen>
         </features>
         <clock offset="variable" adjustment="0" basis="localtime" />
         <on_poweroff>destroy</on_poweroff>
@@ -1324,6 +1338,8 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <acpi/>
             <apic/>
             <viridian/>
+            <xen>
+            </xen>
         </features>
         <clock offset="variable" adjustment="0" basis="localtime" />
         <on_poweroff>destroy</on_poweroff>
@@ -1425,6 +1441,8 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <acpi/>
             <apic/>
             <viridian/>
+            <xen>
+            </xen>
         </features>
         <clock offset="variable" adjustment="0" basis="localtime" />
         <on_poweroff>destroy</on_poweroff>
@@ -1499,6 +1517,8 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <acpi/>
             <apic/>
             <viridian/>
+            <xen>
+            </xen>
         </features>
         <clock offset="variable" adjustment="0" basis="localtime" />
         <on_poweroff>destroy</on_poweroff>

--- a/templates/libvirt/xen.xml
+++ b/templates/libvirt/xen.xml
@@ -61,13 +61,15 @@
                 <apic/>
                 <viridian/>
             {% endif %}
-
-            {% if vm.devices['pci'].persistent() | list
-                    and vm.features.get('pci-e820-host', True) %}
                 <xen>
+                {% if vm.devices['pci'].persistent() | list
+                      and vm.features.get('pci-e820-host', True) %}
                     <e820_host state="on"/>
+                {% endif %}
+                {% if vm.features.check_with_template('gfx-passthru', False) %}
+                    <gfx_passthru state="on"/>
+                {% endif %}
                 </xen>
-            {% endif %}
         {% endblock %}
     </features>
 
@@ -186,12 +188,14 @@
                     {% endif %}
                     />
                 <input type="tablet" bus="usb"/>
-                <video>
-                    <model type="{{ vm.features.check_with_template('video-model', 'vga') }}"/>
-                </video>
-                {% if vm.features.check_with_template('linux-stubdom', True) %}
-                    {# TODO only add qubes gui if gui-agent is not installed in HVM #}
-                    <graphics type="qubes"/>
+                {% if vm.features.check_with_template('video-model', 'vga') != 'none' %}
+                    <video>
+                        <model type="{{ vm.features.check_with_template('video-model', 'vga') }}"/>
+                    </video>
+                    {% if vm.features.check_with_template('linux-stubdom', True) %}
+                        {# TODO only add qubes gui if gui-agent is not installed in HVM #}
+                        <graphics type="qubes"/>
+                    {% endif %}
                 {% endif %}
             {% endif %}
                 <console type="pty">


### PR DESCRIPTION
Add gfx_passthru and device_video options to libvirt Xen domain template.

By default gfx_passthrou is disabled and video device is enabled as before this change. When we want to pass a GPU device settings gfx_passthru is required and device_video can be disabled as it is not usefull.

Depends on: https://github.com/QubesOS/qubes-core-libvirt/pull/23

Part of: QubesOS/qubes-issues#2618