### PR TITLE
tests: fix extra tests loader

### DIFF
--- a/qubes/tests/extra.py
+++ b/qubes/tests/extra.py
@@ -211,11 +211,11 @@ def load_tests(loader, tests, pattern):
         if entry.name in exclude_list:
             continue
         try:
-            for test_case in entry.load()():
+            for test_case in entry.resolve()():
                 tests.addTests(loader.loadTestsFromNames([
                     '{}.{}'.format(test_case.__module__, test_case.__name__)]))
         except Exception as err:  # pylint: disable=broad-except
-            def runTest(self):
+            def runTest(self, err=err):
                 raise err
             ExtraLoadFailure = type('ExtraLoadFailure',
                 (qubes.tests.QubesTestCase,),
@@ -229,13 +229,13 @@ def load_tests(loader, tests, pattern):
         if entry.name in exclude_list:
             continue
         try:
-            for test_case in entry.load()():
+            for test_case in entry.resolve()():
                 tests.addTests(loader.loadTestsFromNames(
                     qubes.tests.create_testcases_for_templates(
                         test_case.__name__, test_case,
                         module=sys.modules[test_case.__module__])))
         except Exception as err:  # pylint: disable=broad-except
-            def runTest(self):
+            def runTest(self, err=err):
                 raise err
             ExtraForTemplateLoadFailure = type('ExtraForTemplateLoadFailure',
                 (qubes.tests.QubesTestCase,),


### PR DESCRIPTION
Fix load error reporting - make sure 'err' variable is transferred into
'runTest' function scope.
Then, relax test loading requirements - use 'resolve' instead of 'load',
to bypass dependencies check (defined in setup.py of the package). The
required dependencies should be handled by RPM already, and in some
cases may not match those in python package. An example is PDF
converter, where dependencies at python level are set for the actual
converter, which is irrelevant for running tests from dom0 (tests will
interact with PDF converter inside a VM).