### PR TITLE
Removed unused vm.icon_path property

### DIFF
--- a/qubes/tests/integ/backupcompatibility.py
+++ b/qubes/tests/integ/backupcompatibility.py
@@ -184,16 +184,12 @@ class TC_00_BackupCompatibility(
         os.mkdir(self.fullpath("appvms/test-work"))
         self.create_whitelisted_appmenus(self.fullpath(
             "appvms/test-work/whitelisted-appmenus.list"))
-        os.symlink("/usr/share/qubes/icons/green.png",
-                   self.fullpath("appvms/test-work/icon.png"))
         self.create_private_img(self.fullpath("appvms/test-work/private.img"))
 
         # StandaloneVM
         os.mkdir(self.fullpath("appvms/test-standalonevm"))
         self.create_whitelisted_appmenus(self.fullpath(
             "appvms/test-standalonevm/whitelisted-appmenus.list"))
-        os.symlink("/usr/share/qubes/icons/blue.png",
-                   self.fullpath("appvms/test-standalonevm/icon.png"))
         self.create_private_img(self.fullpath(
             "appvms/test-standalonevm/private.img"))
         self.create_sparse(
@@ -254,8 +250,6 @@ class TC_00_BackupCompatibility(
             self.create_whitelisted_appmenus(self.fullpath(
                 "vm-templates/test-template-clone/netvm-whitelisted-appmenus"
                 ".list"))
-        os.symlink("/usr/share/qubes/icons/green.png",
-                   self.fullpath("vm-templates/test-template-clone/icon.png"))
         os.mkdir(
             self.fullpath("vm-templates/test-template-clone/apps.templates"))
         self.create_appmenus(

--- a/qubes/tests/vm/dispvm.py
+++ b/qubes/tests/vm/dispvm.py
@@ -94,9 +94,7 @@ class TC_00_DispVM(qubes.tests.QubesTestCase):
         self.assertEqual(dispvm.auto_cleanup, True)
         mock_makedirs.assert_called_once_with(
             '/var/lib/qubes/appvms/' + dispvm.name, mode=0o775, exist_ok=True)
-        mock_symlink.assert_called_once_with(
-            '/usr/share/icons/hicolor/128x128/devices/appvm-red.png',
-            '/var/lib/qubes/appvms/{}/icon.png'.format(dispvm.name))
+        mock_symlink.assert_not_called()
 
     def test_001_from_appvm_reject_not_allowed(self):
         with self.assertRaises(qubes.exc.QubesException):

--- a/qubes/vm/adminvm.py
+++ b/qubes/vm/adminvm.py
@@ -214,10 +214,6 @@ class AdminVM(qubes.vm.BaseVM):
         raise qubes.exc.QubesVMError(self, 'Cannot kill Dom0 fake domain!')
 
     @property
-    def icon_path(self):
-        pass
-
-    @property
     def untrusted_qdb(self):
         '''QubesDB handle for this domain.'''
         if self._qdb_connection is None:


### PR DESCRIPTION
The property was not used for anything, but caused numerous
problems due to symlinks.

fixes QubesOS/qubes-issues#5934