### PR TITLE
policy: interpret invalid requested target as @default

### DIFF
--- a/qubespolicy/__init__.py
+++ b/qubespolicy/__init__.py
@@ -24,6 +24,7 @@
 import enum
 import itertools
 import json
+import logging
 import os
 import os.path
 import socket
@@ -656,6 +657,10 @@ class Policy(object):
         list of possible targets for 'ask' action (rule.action == Action.ask)
         '''
         if target == '':
+            target = '@default'
+        # treat non-existing target as @default, to avoid enumerating domains
+        if not target.startswith('@') and target not in system_info['domains']:
+            logging.warning('qrexec: invalid target, intepreting as @default')
             target = '@default'
         rule = self.find_matching_rule(system_info, source, target)
         if rule.action == Action.deny:


### PR DESCRIPTION
If the requested target does not exist, interpret it as it wasn't
provided at all. This prevents the source domain learning if a given
target exists when the policy is set to default `ask` action
(`... @anyvm ask`). In such a case, previous behavior differed based on
target existence: if it did exist, the user get a prompt, otherwise the
request is immediately refused.

Note it is still possible to write a policy that allows the source to
confirm/deny existence of arbitrary domain (for example default `allow`
action, or denying only `@default` target). But such policy would need
to be specifically configured, it does no longer apply to default
(innocently-looking) policy.

Fixes QubesOS/qubes-issues#5955

This is loose backport of similar commit in core-qrexec repository of
Qubes 4.1.