### PR TITLE
vm/adminvm: adjust exception raised by AdminVM.start()

### DIFF
--- a/qubes/vm/adminvm.py
+++ b/qubes/vm/adminvm.py
@@ -196,7 +196,8 @@ class AdminVM(qubes.vm.BaseVM):
         .. seealso:
            :py:meth:`qubes.vm.qubesvm.QubesVM.start`
         '''  # pylint: disable=unused-argument,arguments-differ
-        raise qubes.exc.QubesVMError(self, 'Cannot start Dom0 fake domain!')
+        raise qubes.exc.QubesVMNotHaltedError(
+            self, 'Cannot start Dom0 fake domain!')
 
     def suspend(self):
         '''Does nothing.


### PR DESCRIPTION
Behave like any other running domain - raise
qubes.exc.QubesVMNotHaltedError instead of generic
qubes.exc.QubesVMError.