### PR TITLE
tests: make tests more reliable

### DIFF
--- a/qubes/tests/extra.py
+++ b/qubes/tests/extra.py
@@ -80,7 +80,14 @@ class VMWrapper(object):
         return self._loop.run_until_complete(self._vm.shutdown())
 
     def run(self, command, wait=False, user=None, passio_popen=False,
-            passio_stderr=False, **kwargs):
+            passio_stderr=False, gui=False, **kwargs):
+        if gui:
+            try:
+                self._loop.run_until_complete(
+                    self._vm.run_service_for_stdio('qubes.WaitForSession',
+                                                   user=user))
+            except subprocess.CalledProcessError as err:
+                return err.returncode
         if wait:
             try:
                 self._loop.run_until_complete(

--- a/qubes/tests/integ/network_ipv6.py
+++ b/qubes/tests/integ/network_ipv6.py
@@ -43,6 +43,19 @@ class VmIPv6NetworkingMixin(VmNetworkingMixin):
         self.ping6_ip = self.ping6_cmd.format(target=self.test_ip6)
         self.ping6_name = self.ping6_cmd.format(target=self.test_name)
 
+    def tearDown(self):
+        # collect more info on failure (ipv4 info collected in parent)
+        if self._outcome and not self._outcome.success:
+            for vm in (self.testnetvm, self.testvm1, getattr(self, 'proxy', None)):
+                if vm is None:
+                    continue
+                self._run_cmd_and_log_output(vm, 'ip -6 r')
+                self._run_cmd_and_log_output(vm, 'ip6tables -vnL')
+                self._run_cmd_and_log_output(vm, 'ip6tables -vnL -t nat')
+                self._run_cmd_and_log_output(vm, 'nft list table ip6 qubes-firewall')
+
+        super().tearDown()
+
     def configure_netvm(self):
         '''
         :type self: qubes.tests.SystemTestCase | VmIPv6NetworkingMixin

--- a/qubes/tests/integ/qrexec.py
+++ b/qubes/tests/integ/qrexec.py
@@ -201,6 +201,7 @@ class TC_00_QrexecMixin(object):
                     self.testvm1.run_for_stdio('''\
                         /usr/lib/qubes/qrexec-client-vm dom0 test.Abort \
                             /bin/sh -c 'cat /dev/zero; echo $? >/tmp/exit-code';
+                            sleep 1;
                             e=$(cat /tmp/exit-code);
                             test $e -eq 141 -o $e -eq 1'''),
                     timeout=10))

--- a/qubes/tests/integ/vm_qrexec_gui.py
+++ b/qubes/tests/integ/vm_qrexec_gui.py
@@ -399,10 +399,13 @@ class TC_00_AppVMMixin(object):
             self.assertEqual(p.returncode, 0)
             vm_time, _ = self.loop.run_until_complete(
                 self.testvm2.run_for_stdio('date -u +%s'))
-            self.assertAlmostEquals(int(vm_time), int(start_time), delta=30)
+            # get current time
+            current_time, _ = self.loop.run_until_complete(
+                self.testvm1.run_for_stdio('date -u +%s'))
+            self.assertAlmostEquals(int(vm_time), int(current_time), delta=30)
 
             dom0_time = subprocess.check_output(['date', '-u', '+%s'])
-            self.assertAlmostEquals(int(dom0_time), int(start_time), delta=30)
+            self.assertAlmostEquals(int(dom0_time), int(current_time), delta=30)
 
         except:
             # reset time to some approximation of the real time

--- a/qubes/tests/integ/vm_qrexec_gui.py
+++ b/qubes/tests/integ/vm_qrexec_gui.py
@@ -458,7 +458,7 @@ class TC_00_AppVMMixin(object):
                             (rec[:-1] < -threshold))[0]
         np.seterr('raise')
         # compare against sine wave frequency
-        rec_freq = rec_size/np.mean(np.diff(crossings))
+        rec_freq = 44100/np.mean(np.diff(crossings))
         if not sfreq*0.8 < rec_freq < sfreq*1.2:
             self.fail('frequency {} not in specified range'
                     .format(rec_freq))


### PR DESCRIPTION
Compare the time with the "current" time retrieved from ClockVM just
before comparing, not with the test start time. This should work even if
the test machine is quite slow (test taking more than 30s).