### PR TITLE
Added icon property to AdminVM

### DIFF
--- a/qubes/tests/vm/adminvm.py
+++ b/qubes/tests/vm/adminvm.py
@@ -73,6 +73,9 @@ class TC_00_AdminVM(qubes.tests.QubesTestCase):
     def test_000_init(self):
         pass
 
+    def test_001_property_icon(self):
+        self.assertEqual(self.vm.icon, 'adminvm-black')
+
     def test_100_xid(self):
         self.assertEqual(self.vm.xid, 0)
 

--- a/qubes/vm/adminvm.py
+++ b/qubes/vm/adminvm.py
@@ -99,6 +99,12 @@ class AdminVM(qubes.vm.BaseVM):
         '''
         return 0
 
+    @qubes.stateless_property
+    def icon(self): # pylint: disable=no-self-use
+        """freedesktop icon name, suitable for use in
+        :py:meth:`PyQt4.QtGui.QIcon.fromTheme`"""
+        return 'adminvm-black'
+
     @property
     def libvirt_domain(self):
         '''Libvirt object for dom0.


### PR DESCRIPTION
To provide greater visual distinctiveness to AdminVMs, now they will
have their own icons.

requires https://github.com/QubesOS/qubes-artwork/pull/20
fixes QubesOS/qubes-issues#3853