### PR TITLE
Enable apparmor if template supports it

### DIFF
--- a/qubes/ext/services.py
+++ b/qubes/ext/services.py
@@ -174,7 +174,13 @@ class ServicesExtension(qubes.ext.Extension):
         for feature in new_supported_services.difference(
                 old_supported_services):
             vm.features[feature] = True
+            if feature == 'supported-service.apparmor' and \
+               not 'apparmor' in vm.features:
+                vm.features['apparmor'] = True
 
         for feature in old_supported_services.difference(
                 new_supported_services):
             del vm.features[feature]
+            if feature == 'supported-service.apparmor' and \
+               'apparmor' in vm.features and vm.features['apparmor'] == '1':
+                del vm.features['apparmor']

--- a/templates/libvirt/xen.xml
+++ b/templates/libvirt/xen.xml
@@ -49,6 +49,8 @@
             {% if vm.kernel %}
                 {% if vm.features.check_with_template('no-default-kernelopts', False) -%}
                 <cmdline>{{ vm.kernelopts }}</cmdline>
+                {% elif vm.features.check_with_template('apparmor', '0') == '1' -%}
+                <cmdline>{{ vm.kernelopts_common }}{{ vm.kernelopts }} apparmor=1 security=apparmor</cmdline>
                 {% else -%}
                 <cmdline>{{ vm.kernelopts_common }}{{ vm.kernelopts }}</cmdline>
                 {% endif -%}


### PR DESCRIPTION
When the feature supported-service.apparmor is set for the first time, the feature apparmor is also set and when the template drops support, the feature apparmor is unset if the user didn't manually disable it.
Depends on https://github.com/QubesOS/qubes-core-agent-linux/pull/246, Closes https://github.com/QubesOS/qubes-issues/issues/4088