### PR TITLE
Always snapshot in the FILE pool

### DIFF
--- a/qubes/storage/file.py
+++ b/qubes/storage/file.py
@@ -265,9 +265,7 @@ class FileVolume(qubes.storage.Volume):
         return self
 
     def export(self):
-        # FIXME: this should rather return snapshot(self.path, self.path_cow)
-        #  if domain is running
-        return self.path
+        return snapshot(self.path, self.path_cow)
 
     @asyncio.coroutine
     def import_volume(self, src_volume):

--- a/qubes/storage/file.py
+++ b/qubes/storage/file.py
@@ -326,6 +326,8 @@ class FileVolume(qubes.storage.Volume):
             assert self._locked is FileVolume._marker_exported, \
                 'nested calls to start()'
             self._not_implemented('starting a VM with an exported volume')
+        if self.is_dirty():
+            self._not_implemented('exporting a dirty volume')
         self._locked = FileVolume._marker_running
         if not self.save_on_stop and not self.snap_on_start:
             self.reset()

--- a/qubes/storage/file.py
+++ b/qubes/storage/file.py
@@ -265,7 +265,9 @@ class FileVolume(qubes.storage.Volume):
         return self
 
     def export(self):
-        return snapshot(self.path, self.path_cow)
+        if self.is_dirty():
+            self._not_implemented('exporting a dirty volume')
+        return self.path
 
     @asyncio.coroutine
     def import_volume(self, src_volume):

--- a/qubes/storage/file.py
+++ b/qubes/storage/file.py
@@ -176,11 +176,14 @@ class FilePool(qubes.storage.Pool):
 class FileVolume(qubes.storage.Volume):
     ''' Parent class for the xen volumes implementation which expects a
         `target_dir` param on initialization.  '''
+    _marker_running = object()
+    _marker_exported = object()
 
     def __init__(self, dir_path, **kwargs):
         self.dir_path = dir_path
         assert self.dir_path, "dir_path not specified"
         self._revisions_to_keep = 0
+        self._locked = None
         super().__init__(**kwargs)
 
         if self.snap_on_start:
@@ -265,9 +268,17 @@ class FileVolume(qubes.storage.Volume):
         return self
 
     def export(self):
-        if self.is_dirty():
+        if self._locked is not None:
+            assert self._locked is FileVolume._marker_running, \
+                'nested calls to export()'
             self._not_implemented('exporting a dirty volume')
+        self._locked = FileVolume._marker_exported
         return self.path
+
+    def export_end(self, path):
+        assert self._locked is FileVolume._marker_exported, \
+            'cannot end an export that never began'
+        self._locked = None
 
     @asyncio.coroutine
     def import_volume(self, src_volume):
@@ -311,6 +322,11 @@ class FileVolume(qubes.storage.Volume):
         return self
 
     def start(self):
+        if self._locked is not None:
+            assert self._locked is FileVolume._marker_exported, \
+                'nested calls to start()'
+            self._not_implemented('starting a VM with an exported volume')
+        self._locked = FileVolume._marker_running
         if not self.save_on_stop and not self.snap_on_start:
             self.reset()
         else:
@@ -328,12 +344,15 @@ class FileVolume(qubes.storage.Volume):
         return self
 
     def stop(self):
+        assert self._locked is FileVolume._marker_running, \
+            'cannot stop a volume that has not been started'
         if self.save_on_stop:
             self.commit()
         elif self.snap_on_start:
             _remove_if_exists(self.path_cow)
         else:
             _remove_if_exists(self.path)
+        self._locked = None
         return self
 
     @property

--- a/qubes/storage/file.py
+++ b/qubes/storage/file.py
@@ -271,9 +271,9 @@ class FileVolume(qubes.storage.Volume):
         if self._export_lock is not None:
             assert self._export_lock is FileVolume._marker_running, \
                 'nested calls to export()'
-            self._not_implemented('exporting a starting volume')
+            raise qubes.storage.StoragePoolException('file pool cannot export running volumes')
         if self.is_dirty():
-            self._not_implemented('exporting a dirty volume')
+            raise qubes.storage.StoragePoolException('file pool cannot export dirty volumes')
         self._export_lock = FileVolume._marker_exported
         return self.path
 
@@ -327,7 +327,7 @@ class FileVolume(qubes.storage.Volume):
         if self._export_lock is not None:
             assert self._export_lock is FileVolume._marker_exported, \
                 'nested calls to start()'
-            self._not_implemented('starting a VM with an exported volume')
+            raise qubes.storage.StoragePoolException('file pool cannot start a VM with an exported volume')
         self._export_lock = FileVolume._marker_running
         if not self.save_on_stop and not self.snap_on_start:
             self.reset()

--- a/qubes/storage/file.py
+++ b/qubes/storage/file.py
@@ -271,9 +271,11 @@ class FileVolume(qubes.storage.Volume):
         if self._export_lock is not None:
             assert self._export_lock is FileVolume._marker_running, \
                 'nested calls to export()'
-            raise qubes.storage.StoragePoolException('file pool cannot export running volumes')
+            raise qubes.storage.StoragePoolException(
+                'file pool cannot export running volumes')
         if self.is_dirty():
-            raise qubes.storage.StoragePoolException('file pool cannot export dirty volumes')
+            raise qubes.storage.StoragePoolException(
+                'file pool cannot export dirty volumes')
         self._export_lock = FileVolume._marker_exported
         return self.path
 
@@ -327,7 +329,8 @@ class FileVolume(qubes.storage.Volume):
         if self._export_lock is not None:
             assert self._export_lock is FileVolume._marker_exported, \
                 'nested calls to start()'
-            raise qubes.storage.StoragePoolException('file pool cannot start a VM with an exported volume')
+            raise qubes.storage.StoragePoolException(
+                'file pool cannot start a VM with an exported volume')
         self._export_lock = FileVolume._marker_running
         if not self.save_on_stop and not self.snap_on_start:
             self.reset()

--- a/qubes/storage/file.py
+++ b/qubes/storage/file.py
@@ -271,6 +271,8 @@ class FileVolume(qubes.storage.Volume):
         if self._export_lock is not None:
             assert self._export_lock is FileVolume._marker_running, \
                 'nested calls to export()'
+            self._not_implemented('exporting a starting volume')
+        if self.is_dirty():
             self._not_implemented('exporting a dirty volume')
         self._export_lock = FileVolume._marker_exported
         return self.path
@@ -326,8 +328,6 @@ class FileVolume(qubes.storage.Volume):
             assert self._export_lock is FileVolume._marker_exported, \
                 'nested calls to start()'
             self._not_implemented('starting a VM with an exported volume')
-        if self.is_dirty():
-            self._not_implemented('exporting a dirty volume')
         self._export_lock = FileVolume._marker_running
         if not self.save_on_stop and not self.snap_on_start:
             self.reset()


### PR DESCRIPTION
We must snapshot a VM’s disk before exporting it.  Otherwise, we will
likely corrupt the VM’s filesystem.

Fixes https://github.com/QubesOS/qubes-issues/issues/4324