### PR TITLE
qubes-hcl-report: run lspci as root

### DIFF
--- a/qvm-tools/qubes-hcl-report
+++ b/qvm-tools/qubes-hcl-report
@@ -71,7 +71,7 @@ DATE=`date +%Y%m%d-%H%M%S`
 TEMP_DIR=`mktemp --tmpdir -d HCL.XXXXXXXXXX`
 cat /etc/qubes-release > $TEMP_DIR/qubes-release
 cat /proc/cpuinfo > $TEMP_DIR/cpuinfo
-lspci -nnvk > $TEMP_DIR/lspci
+sudo lspci -nnvk > $TEMP_DIR/lspci
 cat /proc/scsi/scsi > $TEMP_DIR/scsi
 sudo dmidecode > $TEMP_DIR/dmidecode
 xl info > $TEMP_DIR/xl-info


### PR DESCRIPTION
This allows the "Capabilities" field to be shown.

I thought this might be useful, but I don't know if you care; if not, feel free to reject the pull request.  Since `sudo` is used on `dmidecode`, I assumed it would be appropriate to use on `lspci` as well.  I haven't actually tested the modified `qubes-hcl-report`, but I ran `sudo lspci -nnvk` manually in dom0 and it worked as expected.