### PR TITLE
tests: skip pvgrub tests on Fedora

### DIFF
--- a/qubes/tests/integ/grub.py
+++ b/qubes/tests/integ/grub.py
@@ -157,6 +157,15 @@ class TC_40_PVGrub(GrubBase):
     virt_mode = 'pv'
     kernel = 'pvgrub2'
 
+    def setUp(self):
+        if 'fedora' in self.template:
+            # requires a zstd decompression filter in grub
+            # (see grub_file_filter_id enum in grub sources)
+            self.skipTest('Fedora kernel is compressed with zstd '
+                          'which is not supported by pvgrub2')
+        super().setUp()
+
+
 class TC_41_HVMGrub(GrubBase):
     virt_mode = 'hvm'
     kernel = None


### PR DESCRIPTION
Fedora compresses the kernel with zstd now, which isn't suppported in
grub (as of 2.04). Since we don't care about PV that much anymore,
simply skip the test there.