### PR TITLE
Do not activate unused LVM volumes

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -11,11 +11,15 @@ install_rpm_deps () {
     : # we don’t actually care if this succeeds
 }
 if { command -pv rpm && command -pv dnf; }>/dev/null; then install_rpm_deps; fi
-CLEANUP_LVM=
+
+cleanup_lvm() {
+    sudo --non-interactive $(dirname "$0")/ci/lvm-manage cleanup-lvm "$DEFAULT_LVM_POOL"
+}
+
 name=$(dirname "$0")
 if sudo --non-interactive "$name/ci/lvm-manage" setup-lvm vg$$/pool; then
     export DEFAULT_LVM_POOL=vg$$/pool
-    CLEANUP_LVM=yes
+    trap cleanup_lvm EXIT
 fi
 
 : "${PYTHON:=python3}"
@@ -30,8 +34,3 @@ export PYTHONPATH
 
 "${PYTHON}" setup.py egg_info --egg-base "${TESTPYTHONPATH}"
 "${PYTHON}" -m coverage run --rcfile=ci/coveragerc -m qubes.tests.run "$@"
-retcode=$?
-if [ -n "$CLEANUP_LVM" ]; then
-    sudo --non-interactive $(dirname "$0")/ci/lvm-manage cleanup-lvm "$DEFAULT_LVM_POOL"
-fi
-exit $retcode


### PR DESCRIPTION
This prevents udev from accessing not currently used volumes, and also 
makes LVM snapshot operations faster (less locking to do).

There is at least one unsolved problem here: inactive volumes do not have
size listed on `lvs` output. There is a band-aid by caching the usage from
the last time the volume was active, but it isn't enough for many cases (at
the very least - reporting disk usage of a VM that wasn't started
recently).

There may be also other places that assume existing volumes always have 
relevant /dev/ node present.

Fixes QubesOS/qubes-issues#6184