### PR TITLE
qubesd: at startup, stop storage for stopped domains

### DIFF
--- a/qubes/storage/file.py
+++ b/qubes/storage/file.py
@@ -539,9 +539,10 @@ def copy_file(source, destination):
 
 def _remove_if_exists(path):
     ''' Removes a file if it exist, silently succeeds if file does not exist '''
-    if os.path.exists(path):
+    try:
         os.remove(path)
-
+    except FileNotFoundError:
+        pass
 
 def _check_path(path):
     ''' Raise an StoragePoolException if ``path`` does not exist'''

--- a/qubes/storage/lvm.py
+++ b/qubes/storage/lvm.py
@@ -767,6 +767,9 @@ async def qubes_lvm_coro(cmd, log=logging.getLogger('qubes.storage.lvm')):
     ''' Call :program:`lvm` to execute an LVM operation '''
     environ={'LC_ALL': 'C.UTF-8', **os.environ}
     if cmd[0] == "remove":
+        if not os.path.exists('/dev/' + cmd[1]):
+            # ignore errors if the file does not exist
+            return
         pre_cmd = ['blkdiscard', '-p', '1G', '/dev/'+cmd[1]]
         p = await asyncio.create_subprocess_exec(*pre_cmd,
             stdout=subprocess.DEVNULL,

--- a/qubes/storage/lvm.py
+++ b/qubes/storage/lvm.py
@@ -340,7 +340,9 @@ class ThinVolume(qubes.storage.Volume):
             "Not a volatile volume"
         self.log.debug('Resetting volatile %s', self.vid)
         try:
-            cmd = ['remove', self.vid]
+            assert self.path.startswith('/dev/'), \
+                'bad value for self.path: %r' % self.path
+            cmd = ['remove', self.path[5:]]
             await qubes_lvm_coro(cmd, self.log)
         except qubes.storage.StoragePoolException:
             pass
@@ -456,7 +458,9 @@ class ThinVolume(qubes.storage.Volume):
         await self._remove_revisions(self.revisions.keys())
         if not os.path.exists(self.path):
             return
-        cmd = ['remove', self.path]
+        assert self.path.startswith('/dev/'), \
+            'bad value for self.path: %r' % self.path
+        cmd = ['remove', self.path[5:]]
         await qubes_lvm_coro(cmd, self.log)
         await reset_cache_coro()
         # pylint: disable=protected-access
@@ -627,6 +631,8 @@ class ThinVolume(qubes.storage.Volume):
         try:
             cmd = ['remove', self._vid_snap]
             await qubes_lvm_coro(cmd, self.log)
+        except AssertionError:
+            raise
         except:  # pylint: disable=bare-except
             pass
 
@@ -723,6 +729,7 @@ def _get_lvm_cmdline(cmd):
     '''
     action = cmd[0]
     if action == 'remove':
+        assert not cmd[1].startswith('/'), 'absolute path to ‘remove’???'
         lvm_cmd = ['lvremove', '-f', cmd[1]]
     elif action == 'clone':
         lvm_cmd = ['lvcreate', '-kn', '-ay', '-s', cmd[1], '-n', cmd[2]]

--- a/qubes/storage/reflink.py
+++ b/qubes/storage/reflink.py
@@ -222,7 +222,8 @@ class ReflinkVolume(qubes.storage.Volume):
     @_coroutinized
     def stop(self):  # pylint: disable=invalid-overridden-method
         if self.save_on_stop:
-            self._commit(self._path_dirty)
+            if os.path.exists(self._path_dirty):
+                self._commit(self._path_dirty)
         else:
             if not self.snap_on_start:
                 self._size = self.size  # preserve manual resize of image

--- a/qubes/tools/qubesd.py
+++ b/qubes/tools/qubesd.py
@@ -7,6 +7,7 @@ import signal
 import libvirtaio
 
 import qubes
+import qubes.app
 import qubes.api
 import qubes.api.admin
 import qubes.api.internal
@@ -36,6 +37,9 @@ def main(args=None):
         raise
 
     args.app.register_event_handlers()
+
+    # Stop storage for domains not currently running
+    loop.run_until_complete(args.app.stop_storage())
 
     if args.debug:
         qubes.log.enable_debug()

--- a/qubes/utils.py
+++ b/qubes/utils.py
@@ -168,7 +168,20 @@ def systemd_notify():
         nofity_socket = '\0' + nofity_socket[1:]
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
     sock.connect(nofity_socket)
-    sock.sendall(b'READY=1')
+    sock.sendall(b'READY=1\nSTATUS=qubesd online and operational\n')
+    sock.close()
+
+def systemd_extend_timeout():
+    """Extend systemd startup timeout by 60s"""
+    notify_socket = os.getenv('NOTIFY_SOCKET')
+    if not notify_socket:
+        return
+    if notify_socket.startswith('@'):
+        notify_socket = '\0' + notify_socket[1:]
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    sock.connect(notify_socket)
+    sock.sendall(b'EXTEND_TIMEOUT_USEC=60000000\n'
+                 b'STATUS=Cleaning up storage for stopped qubes\n')
     sock.close()
 
 def match_vm_name_with_special(vm, name):


### PR DESCRIPTION
If qubesd is not cleanly shut down, it is possible that storage was also
not properly stopped.  Therefore, we need to stop storage for all
domains that are not currently running.