### PR TITLE
api: improve handling destination removed just before the call

### DIFF
--- a/qubes/api/__init__.py
+++ b/qubes/api/__init__.py
@@ -118,20 +118,21 @@ class AbstractQubesAPI:
         #: :py:class:`qubes.Qubes` object
         self.app = app
 
-        #: source qube
-        self.src = self.app.domains[src.decode('ascii')]
-
         try:
+            vm = src.decode('ascii')
+            #: source qube
+            self.src = self.app.domains[vm]
+
+            vm = dest.decode('ascii')
             #: destination qube
-            self.dest = self.app.domains[dest.decode('ascii')]
+            self.dest = self.app.domains[vm]
         except KeyError:
             # normally this should filtered out by qrexec policy, but there are
             # two cases it might not be:
             # 1. The call comes from dom0, which bypasses qrexec policy
             # 2. Domain was removed between checking the policy and here
-            # For uniform handling on the client side, treat this as permission
-            # denied error too
-            raise PermissionDenied
+            # we inform the client accordingly
+            raise qubes.exc.QubesVMNotFoundError(vm)
 
         #: argument
         self.arg = arg.decode('ascii')


### PR DESCRIPTION
If the destination domain doesn't exist anymore when the call gets
to qubesd, inform the client that it may try again later with more
success rather than giving them a generic PermissionDenied error.
This enables client applications to handle such edge cases by e.g.
waiting for a short time before trying again.

Fixes QubesOS/qubes-issues#5105

---------------------------------------

I manually tested this a bit and it seems to work.
Only drawback is that GUI clients would need to explicitly handle this exception (I saw it for one of the widgets so far) or otherwise annoying popups may randomly appear.

If the general approach would be accepted, I'd look deeper into the GUI code.