### PR TITLE
Do not require all the autostart VMs to run before user login

### DIFF
--- a/linux/systemd/qubes-vm@.service
+++ b/linux/systemd/qubes-vm@.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Start Qubes VM %i
-Before=systemd-user-sessions.service
 After=qubesd.service qubes-meminfo-writer-dom0.service
 ConditionKernelCommandLine=!qubes.skip_autostart
 


### PR DESCRIPTION
Allow user login while some VMs are still starting. This improves UX of
the system startup, since user can start using the system earlier.

Fixes QubesOS/qubes-issues#3149