### PR TITLE
Update lvm.py

### DIFF
--- a/qubes/storage/lvm.py
+++ b/qubes/storage/lvm.py
@@ -818,7 +818,7 @@ def qubes_lvm_coro(cmd, log=logging.getLogger('qubes.storage.lvm')):
     environ = os.environ.copy()
     environ['LC_ALL'] = 'C.utf8'
     if cmd[0] == "remove":
-        pre_cmd = ['blkdiscard', '/dev/'+cmd[1]]
+        pre_cmd = ['blkdiscard', '-p', '1G', '/dev/'+cmd[1]]
         p = yield from asyncio.create_subprocess_exec(*pre_cmd,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,


### PR DESCRIPTION
Break the ioctl calls from blkdiscard into max 1GB worth of blocks per call. This ensures that the amount of pending discards (both for the virtual lvm thin volume as well as any lower level device recipients) do not dominate the IO streams to the devices. Before this change, IO blocking was leading to both UI and processing freezes in Qubes while very large LVM volumes were being removed. The change will allow other device IOs to be interleaved between the internal ioctl calls from blkdiscard.