### PR TITLE
Test that quotes and ampersand are XML escaped

### DIFF
--- a/qubes/tests/vm/qubesvm.py
+++ b/qubes/tests/vm/qubesvm.py
@@ -961,7 +961,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <loader type="rom">hvmloader</loader>
             <boot dev="cdrom" />
             <boot dev="hd" />
-            <cmdline>kernel &lt;text&gt; specific options</cmdline>
+            <cmdline>kernel &lt;text&gt;&#39;&#34;&amp; specific options</cmdline>
         </os>
         <features>
             <pae/>
@@ -1000,7 +1000,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             open(os.path.join(kernel_dir, 'initramfs'), 'w').close()
             with open(os.path.join(kernel_dir,
                     'default-kernelopts-common.txt'), 'w') as f:
-                f.write('kernel <text> specific options \n')
+                f.write('kernel <text>\'"& specific options \n')
             self.addCleanup(shutil.rmtree, '/tmp/qubes-test')
             vm.kernel = 'dummy'
             libvirt_xml = vm.create_config_file()


### PR DESCRIPTION
This ensures that we are safe if we interpolate into an XML attribute.