### PR TITLE
Adjust vm.icon value for DispVM-related qubes

### DIFF
--- a/qubes/vm/appvm.py
+++ b/qubes/vm/appvm.py
@@ -102,6 +102,14 @@ class AppVM(qubes.vm.mix.dvmtemplate.DVMTemplateMixin,
 
         super().__init__(app, xml, **kwargs)
 
+    @qubes.stateless_property
+    def icon(self):
+        if self.template_for_dispvms:
+            return 'templatevm-' + self.label.name
+        # multi-inheritance and properties confuses pylint here
+        # pylint: disable=no-member
+        return super().icon
+
     @qubes.events.handler('domain-load')
     def on_domain_loaded(self, event):
         ''' When domain is loaded assert that this vm has a template.

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -2134,10 +2134,10 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
         raw_icon_name = self.label.name
         if self.klass == 'TemplateVM':
             return 'templatevm-' + raw_icon_name
-        if self.klass == 'DispVM':
-            return 'dispvm-' + raw_icon_name
         if self.features.get('servicevm', False):
             return 'servicevm-' + raw_icon_name
+        if self.klass == 'DispVM':
+            return 'dispvm-' + raw_icon_name
         return 'appvm-' + raw_icon_name
 
     @property


### PR DESCRIPTION
An AppVM with template_for_dispvms is a "disposable template", so let it
have "template" icon.
For a disposable service qube it's more important it's "service" than
"disposable", so let it have "service" icon.

QubesOS/qubes-issues#6709