### PR TITLE
Fix for no such file error starting sys-gui

### DIFF
--- a/qubes/ext/gui.py
+++ b/qubes/ext/gui.py
@@ -119,7 +119,7 @@ class GUI(qubes.ext.Extension):
                                             str(vm.xid))
         if vm.features.get('input-dom0-proxy', None):
             await asyncio.create_subprocess_exec(
-                '/usr/bin/qubes-input-trigger --all --dom0')
+                '/usr/bin/qubes-input-trigger', '--all', '--dom0')
 
     @qubes.ext.handler('property-reset:keyboard_layout')
     def on_keyboard_reset(self, vm, event, name, oldvalue=None):


### PR DESCRIPTION
`sys-gui` and `sys-gui-gpu` both fail to boot with the error:  `no such file or directory /usr/bin/qubes-input-trigger --all --dom0 failed with erno2`

Reported here https://forum.qubes-os.org/t/how-to-enable-the-new-gui-vm/2631/7?u=face

`asyncio`  seems to be treating the args as part of the path.   Breaking it up fixes and the `sys-gui` will boot normally.