### PR TITLE
Fix timezone handling in HVMs

### DIFF
--- a/qubes/tests/vm/qubesvm.py
+++ b/qubes/tests/vm/qubesvm.py
@@ -848,7 +848,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <apic/>
             <viridian/>
         </features>
-        <clock offset="variable" adjustment="0" basis="localtime" />
+        <clock offset="variable" adjustment="0" basis="utc" />
         <on_poweroff>destroy</on_poweroff>
         <on_reboot>destroy</on_reboot>
         <on_crash>destroy</on_crash>
@@ -904,7 +904,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <apic/>
             <viridian/>
         </features>
-        <clock offset="variable" adjustment="0" basis="localtime" />
+        <clock offset="variable" adjustment="0" basis="utc" />
         <on_poweroff>destroy</on_poweroff>
         <on_reboot>destroy</on_reboot>
         <on_crash>destroy</on_crash>
@@ -969,7 +969,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <apic/>
             <viridian/>
         </features>
-        <clock offset="variable" adjustment="0" basis="localtime" />
+        <clock offset="variable" adjustment="0" basis="utc" />
         <on_poweroff>destroy</on_poweroff>
         <on_reboot>destroy</on_reboot>
         <on_crash>destroy</on_crash>
@@ -1176,7 +1176,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
                 <e820_host state="on"/>
             </xen>
         </features>
-        <clock offset="variable" adjustment="0" basis="localtime" />
+        <clock offset="variable" adjustment="0" basis="utc" />
         <on_poweroff>destroy</on_poweroff>
         <on_reboot>destroy</on_reboot>
         <on_crash>destroy</on_crash>
@@ -1252,7 +1252,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <apic/>
             <viridian/>
         </features>
-        <clock offset="variable" adjustment="0" basis="localtime" />
+        <clock offset="variable" adjustment="0" basis="utc" />
         <on_poweroff>destroy</on_poweroff>
         <on_reboot>destroy</on_reboot>
         <on_crash>destroy</on_crash>
@@ -1332,7 +1332,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <apic/>
             <viridian/>
         </features>
-        <clock offset="variable" adjustment="0" basis="localtime" />
+        <clock offset="variable" adjustment="0" basis="utc" />
         <on_poweroff>destroy</on_poweroff>
         <on_reboot>destroy</on_reboot>
         <on_crash>destroy</on_crash>
@@ -1431,7 +1431,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <apic/>
             <viridian/>
         </features>
-        <clock offset="variable" adjustment="0" basis="localtime" />
+        <clock offset="variable" adjustment="0" basis="utc" />
         <on_poweroff>destroy</on_poweroff>
         <on_reboot>destroy</on_reboot>
         <on_crash>destroy</on_crash>
@@ -1503,7 +1503,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <apic/>
             <viridian/>
         </features>
-        <clock offset="variable" adjustment="0" basis="localtime" />
+        <clock offset="variable" adjustment="0" basis="utc" />
         <on_poweroff>destroy</on_poweroff>
         <on_reboot>destroy</on_reboot>
         <on_crash>destroy</on_crash>

--- a/templates/libvirt/xen.xml
+++ b/templates/libvirt/xen.xml
@@ -76,7 +76,7 @@
 
     {% block clock %}
         {% if vm.virt_mode == 'hvm' %}
-            {% set timezone = vm.features.check_with_template('timezone', 'localtime').lower() %}
+            {% set timezone = vm.features.check_with_template('timezone', '').lower() %}
             {% if timezone == 'localtime' %}
                 <clock offset="variable" adjustment="0" basis="localtime" />
             {% elif timezone.isdigit() %}


### PR DESCRIPTION
Non-Windows HVMs always want the “hardware” (emulated) clock to be UTC,
and Windows HVMs can be made to expect this by a registry change.

Tested by setting the `timezone` feature to the empty string in the template of `sys-net`, which has the same effect as this change.