### PR TITLE
tests: show full traceback on failure

### DIFF
--- a/qubes/tests/run.py
+++ b/qubes/tests/run.py
@@ -229,6 +229,13 @@ class QubesTestResult(unittest.TestResult):
             self.stream.writeln(self.separator2)
             self.stream.writeln('%s' % err)
 
+    def _is_relevant_tb_level(self, *args, **kwargs):
+        # Don't let unittest.TestResult attempt to omit irrelevant
+        # traceback levels on test failure - the patched in decorator
+        # detect_never_awaited() would confuse it.
+
+        return False  # method decides the opposite of what its name says
+
 
 def demo(verbosity=2):
     class TC_00_Demo(qubes.tests.QubesTestCase):

--- a/qubes/tests/selftest.py
+++ b/qubes/tests/selftest.py
@@ -31,6 +31,10 @@ class TC_00_SelfTest(qubes.tests.QubesTestCase):
     def test_001_raise_never_awaited_by_default(self):
         intentionally_never_awaited()
 
+    def test_002_full_traceback_on_failure(self):
+        self.assertTrue(callable(
+            getattr(unittest.TestResult, '_is_relevant_tb_level', None)))
+
 
 async def intentionally_never_awaited():
     pass


### PR DESCRIPTION
Before #418:

    ======================================================================
    EXPECTED: qubes.tests.firewall/TC_02_DstHost/test_007_ipv4_invalid_network
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/home/user/devel/github/qubes-core-admin/qubes/tests/firewall.py", line 153, in test_007_ipv4_invalid_network
        qubes.firewall.DstHost('127.0.0.1/32')
    AssertionError: ValueError not raised


After #418:

    ======================================================================
    EXPECTED: qubes.tests.firewall/TC_02_DstHost/test_007_ipv4_invalid_network
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/usr/lib64/python3.9/contextlib.py", line 79, in inner
        return func(*args, **kwds)
    AssertionError: ValueError not raised


Full traceback with this PR:

    ======================================================================
    EXPECTED: qubes.tests.firewall/TC_02_DstHost/test_007_ipv4_invalid_network
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/usr/lib64/python3.9/unittest/case.py", line 59, in testPartExecutor
        yield
      File "/usr/lib64/python3.9/unittest/case.py", line 593, in run
        self._callTestMethod(testMethod)
      File "/usr/lib64/python3.9/contextlib.py", line 79, in inner
        return func(*args, **kwds)
      File "/usr/lib64/python3.9/unittest/case.py", line 550, in _callTestMethod
        method()
      File "/home/user/devel/github/qubes-core-admin/qubes/tests/firewall.py", line 153, in test_007_ipv4_invalid_network
        qubes.firewall.DstHost('127.0.0.1/32')
      File "/usr/lib64/python3.9/unittest/case.py", line 226, in __exit__
        self._raiseFailure("{} not raised".format(exc_name))
      File "/usr/lib64/python3.9/unittest/case.py", line 163, in _raiseFailure
        raise self.test_case.failureException(msg)
    AssertionError: ValueError not raised