### PR TITLE
tests/never_awaited: be compatible with traceback pruning

### DIFF
--- a/qubes/storage/reflink.py
+++ b/qubes/storage/reflink.py
@@ -201,7 +201,6 @@ class ReflinkVolume(qubes.storage.Volume):
     def is_dirty(self):
         return self.save_on_stop and os.path.exists(self._path_dirty)
 
-    # pylint: disable=invalid-overridden-method
     @qubes.storage.Volume.locked
     @_coroutinized
     def start(self):  # pylint: disable=invalid-overridden-method
@@ -219,7 +218,6 @@ class ReflinkVolume(qubes.storage.Volume):
                 _create_sparse_file(self._path_dirty, self.size)
         return self
 
-    # pylint: disable=invalid-overridden-method
     @qubes.storage.Volume.locked
     @_coroutinized
     def stop(self):  # pylint: disable=invalid-overridden-method

--- a/qubes/tests/__init__.py
+++ b/qubes/tests/__init__.py
@@ -44,8 +44,6 @@ import tempfile
 import time
 import traceback
 import unittest
-import warnings
-from contextlib import contextmanager
 from distutils import spawn
 
 import gc
@@ -63,6 +61,7 @@ import qubes.devices
 import qubes.events
 import qubes.exc
 import qubes.ext.pci
+import qubes.tests.never_awaited
 import qubes.vm.standalonevm
 import qubes.vm.templatevm
 
@@ -385,45 +384,14 @@ class substitute_entry_points(object):
         self._orig_iter_entry_points = None
 
 
-@contextmanager
-def detect_never_awaited(ignore=False, gc_before=False, gc_after=False):
-    detected = []
-    showwarning_orig = warnings.showwarning
-
-    def showwarning(message, category, filename, lineno, file=None, line=None):
-        if issubclass(category, RuntimeWarning) \
-           and str.endswith(str(message), ' was never awaited'):
-            detected.append(warnings.WarningMessage(
-                message, category, filename, lineno, file, line))
-        else:
-            showwarning_orig(message, category, filename, lineno, file, line)
-
-    if gc_before:
-        gc.collect()
-    warnings.showwarning = showwarning
-
-    try:
-        yield
-    finally:
-        if gc_after:
-            gc.collect()
-        warnings.showwarning = showwarning_orig
-        if detected and not ignore:
-            raise RuntimeError('\n' + ';\n'.join(map(str, detected)))
-
-
-ignore_never_awaited = functools.partial(
-        detect_never_awaited, ignore=True, gc_before=True, gc_after=True)
-
-
 class QubesTestCase(unittest.TestCase):
     """Base class for Qubes unit tests.
     """
 
-    _callSetUp      = detect_never_awaited()(unittest.TestCase._callSetUp)
-    _callTestMethod = detect_never_awaited()(unittest.TestCase._callTestMethod)
-    _callTearDown   = detect_never_awaited()(unittest.TestCase._callTearDown)
-    _callCleanup    = detect_never_awaited()(unittest.TestCase._callCleanup)
+    _callSetUp      = never_awaited.detect()(unittest.TestCase._callSetUp)
+    _callTestMethod = never_awaited.detect()(unittest.TestCase._callTestMethod)
+    _callTearDown   = never_awaited.detect()(unittest.TestCase._callTearDown)
+    _callCleanup    = never_awaited.detect()(unittest.TestCase._callCleanup)
 
     def __init__(self, *args, **kwargs):
         super(QubesTestCase, self).__init__(*args, **kwargs)

--- a/qubes/tests/never_awaited.py
+++ b/qubes/tests/never_awaited.py
@@ -1,0 +1,64 @@
+#
+# The Qubes OS Project, https://www.qubes-os.org/
+#
+# Copyright (C) 2021 Rusty Bird <rustybird@net-c.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, see <https://www.gnu.org/licenses/>.
+#
+
+import functools
+import gc
+import warnings
+
+
+# For unittest.TestResult._is_relevant_tb_level()
+__unittest = True
+
+
+def detect(handle=True, gc_before=False, gc_after=False):
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            detected = []
+            showwarning_orig = warnings.showwarning
+
+            def showwarning(message, category, filename, lineno,
+                            file=None, line=None):
+                if issubclass(category, RuntimeWarning) \
+                   and str.endswith(str(message), ' was never awaited'):
+                    detected.append(warnings.WarningMessage(
+                        message, category, filename, lineno, file, line))
+                else:
+                    showwarning_orig(
+                        message, category, filename, lineno, file, line)
+
+            if gc_before:
+                gc.collect()
+            warnings.showwarning = showwarning
+
+            try:
+                func(*args, **kwargs)
+            finally:
+                if gc_after:
+                    gc.collect()
+                warnings.showwarning = showwarning_orig
+                if detected and handle:
+                    raise RuntimeError('\n' + ';\n'.join(map(str, detected)))
+
+        return wrapper
+
+    return decorator
+
+
+ignore = functools.partial(detect, False, gc_before=True, gc_after=True)

--- a/qubes/tests/run.py
+++ b/qubes/tests/run.py
@@ -229,13 +229,6 @@ class QubesTestResult(unittest.TestResult):
             self.stream.writeln(self.separator2)
             self.stream.writeln('%s' % err)
 
-    def _is_relevant_tb_level(self, *args, **kwargs):
-        # Don't let unittest.TestResult attempt to omit irrelevant
-        # traceback levels on test failure - the patched in decorator
-        # detect_never_awaited() would confuse it.
-
-        return False  # method decides the opposite of what its name says
-
 
 def demo(verbosity=2):
     class TC_00_Demo(qubes.tests.QubesTestCase):

--- a/qubes/tests/selftest.py
+++ b/qubes/tests/selftest.py
@@ -23,9 +23,9 @@ import qubes.tests
 
 
 class TC_00_SelfTest(qubes.tests.QubesTestCase):
+    @qubes.tests.never_awaited.ignore()
     def test_000_ignore_never_awaited(self):
-        with qubes.tests.ignore_never_awaited():
-            intentionally_never_awaited()
+        intentionally_never_awaited()
 
     @unittest.expectedFailure
     def test_001_raise_never_awaited_by_default(self):

--- a/qubes/tests/selftest.py
+++ b/qubes/tests/selftest.py
@@ -31,10 +31,6 @@ class TC_00_SelfTest(qubes.tests.QubesTestCase):
     def test_001_raise_never_awaited_by_default(self):
         intentionally_never_awaited()
 
-    def test_002_full_traceback_on_failure(self):
-        self.assertTrue(callable(
-            getattr(unittest.TestResult, '_is_relevant_tb_level', None)))
-
 
 async def intentionally_never_awaited():
     pass

--- a/rpm_spec/core-dom0.spec.in
+++ b/rpm_spec/core-dom0.spec.in
@@ -449,6 +449,7 @@ done
 %{python3_sitelib}/qubes/tests/ext.py
 %{python3_sitelib}/qubes/tests/firewall.py
 %{python3_sitelib}/qubes/tests/init.py
+%{python3_sitelib}/qubes/tests/never_awaited.py
 %{python3_sitelib}/qubes/tests/rpc_import.py
 %{python3_sitelib}/qubes/tests/selftest.py
 %{python3_sitelib}/qubes/tests/storage.py


### PR DESCRIPTION
Note that if the `qubes.tests.never_awaited.detect()` decorator itself somehow raises an unintended exception, it will occur in an "irrelevant" level and hence the traceback will be empty. I hope that's unlikely though.