### PR TITLE
Storage resize related fixes (file, lvm)

### DIFF
--- a/qubes/storage/file.py
+++ b/qubes/storage/file.py
@@ -272,6 +272,13 @@ class FileVolume(qubes.storage.Volume):
             msg = 'Can not resize reađonly volume {!s}'.format(self)
             raise qubes.storage.StoragePoolException(msg)
 
+        if self.snap_on_start:
+            # this theoretically could be supported, but it's unusual
+            # enough to not worth the effort
+            msg = 'Cannot resize volume based on a template - resize' \
+                  'the template instead'
+            raise qubes.storage.StoragePoolException(msg)
+
         if size < self.size:
             raise qubes.storage.StoragePoolException(
                 'For your own safety, shrinking of %s is'

--- a/qubes/storage/lvm.py
+++ b/qubes/storage/lvm.py
@@ -613,7 +613,7 @@ class ThinVolume(qubes.storage.Volume):
         if size == self.size:
             return
 
-        if self.is_dirty():
+        if self.is_dirty() or self.snap_on_start:
             cmd = ['extend', self._vid_snap, str(size)]
             await qubes_lvm_coro(cmd, self.log)
         elif hasattr(self, '_vid_import') and \


### PR DESCRIPTION
With more thorough tests for all the storage pools, the tests complains about
not working online resize of private volumes in the 'file' pool driver. It
turned out, adding this feature is a bit easier than skipping the test for this
one pool driver (and keep the results meaningful).

While at it, fix online resize of DispVM's private volume (QubesOS/qubes-issues#6705)