### PR TITLE
tests: fix time.time mock interfering with logging

### DIFF
--- a/qubes/tests/storage_lvm.py
+++ b/qubes/tests/storage_lvm.py
@@ -866,6 +866,8 @@ class TC_00_ThinPool(ThinPoolBase):
         }
         vm = qubes.tests.storage.TestVM(self)
         volume = self.app.get_pool(self.pool.name).init_volume(vm, config)
+        # mock logging, to not interfere with time.time() mock
+        volume.log = unittest.mock.Mock()
         with unittest.mock.patch('time.time') as mock_time:
             mock_time.side_effect = [1521065905]
             self.loop.run_until_complete(volume.create())


### PR DESCRIPTION
Logging something will try to get the current timestamp, and this
interferes with the `time.time()` mock. Most of the tests here disable
logging (by replacing it with a mock), but one was missing this part.