### PR TITLE
tests: add test success detector during tearDown()

### DIFF
--- a/qubes/tests/__init__.py
+++ b/qubes/tests/__init__.py
@@ -537,6 +537,15 @@ class QubesTestCase(unittest.TestCase):
 
         del self.loop
 
+    def success(self):
+        """Check if test was successful during tearDown """
+
+        result = self.defaultTestResult()
+        self._feedErrorsToResult(result, self._outcome.errors)
+
+        unsuccessful_tests = [test for (test,_) in (result.errors + result.failures)]
+        return self not in unsuccessful_tests
+
     def assertNotRaises(self, excClass, callableObj=None, *args, **kwargs):
         """Fail if an exception of class excClass is raised
            by callableObj when invoked with arguments args and keyword

--- a/qubes/tests/integ/network.py
+++ b/qubes/tests/integ/network.py
@@ -98,7 +98,7 @@ class VmNetworkingMixin(object):
 
     def tearDown(self):
         # collect more info on failure
-        if self._outcome and not self._outcome.success:
+        if not self.success():
             for vm in (self.testnetvm, self.testvm1, getattr(self, 'proxy', None)):
                 if vm is None:
                     continue


### PR DESCRIPTION
**Context:** there are non-easily-reproducible test failures in the network tests (ping failed). This fixes the extra logging that should happen upon failure so hopefully when the issue happens again we can detect it.

---

Previously the test success detection during `tearDown()` didn't work as it depended on self._outcome which had not yet received the correct success state of the test just ran.

See a POC of this solution [in this gist](https://gist.github.com/deeplow/143a5636ba16ea5245314b46bc54793e).

The solution essentially does X things:

  1. Runs the code that would otherwise be run after the tearDown
     see:https://github.com/python/cpython/blob/7e246a3/Lib/unittest/case.py#L601

  2. Interprets the results following the internal structure of
     `unittest.TestResult` and returns the respective success state

Solution inspired by the following exchange:
https://stackoverflow.com/questions/4414234/getting-pythons-unittest-results-in-a-teardown-method#answer-39606065

---

Since this method should only be ran from inside `tearDown` (for fear of the results not being set or already having been erased) I wanted to through an exception when that was the case:

```python
        if "tearDown" != sys._getframe(1).f_code.co_name:
            raise Exception("success() can only be called from tearDown")
```

But I am not satisfied with the above code as it uses some low-level functions that should be only used for internal or specialized purposes... So I did not include it. Instead the method's docstring includes that disclaimer.