### PR TITLE
Make encrypted volatile volume optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ ADMIN_API_METHODS_SIMPLE = \
 	admin.pool.volume.ListSnapshots \
 	admin.pool.volume.Resize \
 	admin.pool.volume.Revert \
+	admin.pool.volume.Set.ephemeral \
 	admin.pool.volume.Set.revisions_to_keep \
 	admin.pool.volume.Set.rw \
 	admin.pool.volume.Snapshot \
@@ -106,6 +107,7 @@ ADMIN_API_METHODS_SIMPLE = \
 	admin.vm.volume.ListSnapshots \
 	admin.vm.volume.Resize \
 	admin.vm.volume.Revert \
+	admin.vm.volume.Set.ephemeral \
 	admin.vm.volume.Set.revisions_to_keep \
 	admin.vm.volume.Set.rw \
 	admin.vm.Stats \

--- a/doc/qubes-storage.rst
+++ b/doc/qubes-storage.rst
@@ -66,6 +66,12 @@ properties:
  - :py:attr:`~qubes.storage.Volume.name` - name of the volume inside owning
    domain (like `root`, or `private`)
  - :py:attr:`~qubes.storage.Volume.size` - size of the volume, in bytes
+ - :py:attr:`~qubes.storage.Volume.ephemeral` - whether volume is automatically
+   encrypted with an ephemeral key. This can be set only on volumes that have
+   both :py:attr:`~qubes.storage.Volume.snap_on_start` and
+   :py:attr:`~qubes.storage.Volume.save_on_stop` set to `False` - namely,
+   `volatile` volume. This property for DispVM's volatile volume is inherited
+   from the template (but not for other types of VMs).
 
 Storage pool driver may define additional properties.
 

--- a/qubes/tests/api_admin.py
+++ b/qubes/tests/api_admin.py
@@ -2755,7 +2755,7 @@ netvm default=True type=vm \n'''
         self.vm.volumes.configure_mock(**volumes_conf)
         self.vm.storage = unittest.mock.Mock()
         with self.assertRaises(qubes.api.ProtocolError):
-            self.call_mgmt_func(b'admin.vm.volume.Set.revisions_to_keep',
+            self.call_mgmt_func(b'admin.vm.volume.Set.rw',
                 b'test-vm1', b'private', b'abc')
         self.assertFalse(self.app.save.called)
 

--- a/qubes/tests/api_admin.py
+++ b/qubes/tests/api_admin.py
@@ -43,7 +43,7 @@ import qubes.storage
 # properties defined in API
 volume_properties = [
     'pool', 'vid', 'size', 'usage', 'rw', 'source', 'path',
-    'save_on_stop', 'snap_on_start', 'revisions_to_keep']
+    'save_on_stop', 'snap_on_start', 'revisions_to_keep', 'ephemeral']
 
 
 class AdminAPITestCase(qubes.tests.QubesTestCase):
@@ -2757,6 +2757,34 @@ netvm default=True type=vm \n'''
         with self.assertRaises(qubes.api.ProtocolError):
             self.call_mgmt_func(b'admin.vm.volume.Set.rw',
                 b'test-vm1', b'private', b'abc')
+        self.assertFalse(self.app.save.called)
+
+    def test_685_vm_volume_set_ephemeral(self):
+        self.vm.volumes = unittest.mock.MagicMock()
+        volumes_conf = {
+            'keys.return_value': ['root', 'private', 'volatile', 'kernel'],
+        }
+        self.vm.volumes.configure_mock(**volumes_conf)
+        self.vm.storage = unittest.mock.Mock()
+        value = self.call_mgmt_func(b'admin.vm.volume.Set.ephemeral',
+            b'test-vm1', b'volatile', b'True')
+        self.assertIsNone(value)
+        self.assertEqual(self.vm.volumes.mock_calls,
+            [unittest.mock.call.keys(),
+            ('__getitem__', ('volatile',), {})])
+        self.assertEqual(self.vm.volumes['volatile'].ephemeral, True)
+        self.app.save.assert_called_once_with()
+
+    def test_686_vm_volume_set_ephemeral_invalid(self):
+        self.vm.volumes = unittest.mock.MagicMock()
+        volumes_conf = {
+            'keys.return_value': ['root', 'private', 'volatile', 'kernel'],
+        }
+        self.vm.volumes.configure_mock(**volumes_conf)
+        self.vm.storage = unittest.mock.Mock()
+        with self.assertRaises(qubes.api.ProtocolError):
+            self.call_mgmt_func(b'admin.vm.volume.Set.ephemeral',
+                b'test-vm1', b'volatile', b'abc')
         self.assertFalse(self.app.save.called)
 
     def test_690_vm_console(self):

--- a/qubes/tests/app.py
+++ b/qubes/tests/app.py
@@ -564,6 +564,7 @@ class TC_90_Qubes(qubes.tests.QubesTestCase):
         super(TC_90_Qubes, self).setUp()
         self.app = qubes.Qubes('/tmp/qubestest.xml', load=False,
                                offline_mode=True)
+        self.app.default_kernel = 'dummy'
         self.addCleanup(self.cleanup_qubes)
         self.app.load_initial_values()
         self.template = self.app.add_new_vm('TemplateVM', name='test-template',

--- a/qubes/tests/storage_file.py
+++ b/qubes/tests/storage_file.py
@@ -279,6 +279,24 @@ class TC_01_FileVolumes(qubes.tests.QubesTestCase):
         self.assertFalse(volume.snap_on_start)
         self.assertFalse(volume.save_on_stop)
         self.assertTrue(volume.rw)
+        self.assertFalse(volume.ephemeral)
+
+    def test_004_volatile_volume_encrypted(self):
+        config = {
+            'name': 'root',
+            'pool': self.POOL_NAME,
+            'size': defaults['root_img_size'],
+            'rw': True,
+            'ephemeral': True,
+        }
+        vm = qubes.tests.storage.TestVM(self)
+        volume = self.app.get_pool(self.POOL_NAME).init_volume(vm, config)
+        self.assertEqual(volume.name, 'root')
+        self.assertEqual(volume.pool, self.POOL_NAME)
+        self.assertEqual(volume.size, defaults['root_img_size'])
+        self.assertFalse(volume.snap_on_start)
+        self.assertFalse(volume.save_on_stop)
+        self.assertTrue(volume.rw)
         self.assertTrue(volume.ephemeral)
 
     def test_005_appvm_volumes(self):

--- a/qubes/tests/vm/__init__.py
+++ b/qubes/tests/vm/__init__.py
@@ -59,14 +59,16 @@ class TestVMsCollection(dict):
         return iter(set(self.values()))
 
 class TestVolume(object):
-    def __init__(self, pool):
+    def __init__(self, pool, **kwargs):
         self.pool = pool
-        self.size = 0
-        self.source = None
+        self.size = int(kwargs.get('size', 0))
+        self.source = kwargs.get('source')
+        self.config = kwargs
 
 class TestPool(object):
     def init_volume(self, *args, **kwargs):
-        return TestVolume(self)
+        kwargs['pool'] = self
+        return TestVolume(**kwargs)
 
 class TestApp(qubes.tests.TestEmitter):
     labels = {1: qubes.Label(1, '0xcc0000', 'red'),

--- a/qubes/tests/vm/dispvm.py
+++ b/qubes/tests/vm/dispvm.py
@@ -49,8 +49,8 @@ class TC_00_DispVM(qubes.tests.QubesTestCase):
         self.app = TestApp()
         self.app.save = mock.Mock()
         self.app.pools['default'] = qubes.tests.vm.appvm.TestPool(name='default')
-        self.app.pools['linux-kernel'] = mock.Mock(**{
-            'init_volume.return_value.pool': 'linux-kernel'})
+        self.app.pools['linux-kernel'] = \
+            qubes.tests.vm.appvm.TestPool(name='linux-kernel')
         self.app.vmm.offline_mode = True
         self.template = self.app.add_new_vm(qubes.vm.templatevm.TemplateVM,
             name='test-template', label='red')

--- a/qubes/tests/vm/dispvm.py
+++ b/qubes/tests/vm/dispvm.py
@@ -236,6 +236,7 @@ class TC_00_DispVM(qubes.tests.QubesTestCase):
                          self.appvm.volumes['root'].pool)
         self.assertIs(dispvm.volumes['volatile'].pool,
                          self.appvm.volumes['volatile'].pool)
+        self.assertFalse(dispvm.volumes['volatile'].ephemeral)
 
     def test_021_storage_template_change(self):
         self.appvm.template_for_dispvms = True

--- a/qubes/vm/dispvm.py
+++ b/qubes/vm/dispvm.py
@@ -116,12 +116,25 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
                     self.volume_config[name] = config.copy()
                     if 'vid' in self.volume_config[name]:
                         del self.volume_config[name]['vid']
-                # copy pool setting from base AppVM; root and private would be
-                # in the same pool anyway (because of snap_on_start),
-                # but not volatile, which could be surprising
-                elif 'pool' not in self.volume_config[name] \
-                        and 'pool' in config:
-                    self.volume_config[name]['pool'] = config['pool']
+                else:
+                    # if volume exists, use its live config, since some settings
+                    # can be changed and volume_config isn't updated
+                    config = template.volumes[name].config
+                    # copy pool setting from base AppVM; root and private would
+                    # be in the same pool anyway (because of snap_on_start),
+                    # but not volatile, which could be surprising
+                    if 'pool' not in self.volume_config[name] \
+                            and 'pool' in config:
+                        self.volume_config[name]['pool'] = config['pool']
+                    # copy rw setting from the base AppVM too
+                    if 'rw' in config:
+                        self.volume_config[name]['rw'] = config['rw']
+                    # copy ephemeral setting from the base AppVM too, but only
+                    # if non-default value is used
+                    if 'ephemeral' not in self.volume_config[name] \
+                            and 'ephemeral' in config:
+                        self.volume_config[name]['ephemeral'] = \
+                            config['ephemeral']
 
         super().__init__(app, xml, *args, **kwargs)
 


### PR DESCRIPTION
Make 'ephemeral' volume property accessible read-write via Admin API, and set
the default value to False. This allows the feature to be enabled for specific
VMs where it is needed. This can be changed via `qvm-volume` tool.
Furthermore, volumes of a new DispVM gets the value from its template's
matching volumes. Do the same for 'rw' property.

QubesOS/qubes-issues#904