### PR TITLE
Fix various doc typos

### DIFF
--- a/doc/qubes.rst
+++ b/doc/qubes.rst
@@ -41,12 +41,12 @@ default NetVM for all AppVMs. All of those *configurable* parameters are called
 Definition
 ^^^^^^^^^^
 Properties are defined on global :py:class:`qubes.Qubes` application object and
-on every domain. Those classess inherit from :py:class:`PropertyHolder` class,
+on every domain. Those classes inherit from :py:class:`PropertyHolder` class,
 which is responsible for operation of properties.
 
 Each Qubes property is actually a *data descriptor* (a Python term), which means
-they are attributes of their classess, but when trying to access it from
-*instance*, they return it's underlying value instead. They can be thought of as
+they are attributes of their classes, but when trying to access it from
+*instance*, they return its underlying value instead. They can be thought of as
 Python's builtin :py:class:`property`, but greatly enhanced. They are defined in
 definition of their class::
 
@@ -123,7 +123,7 @@ similar to `type`, but is always executed (not only when types don't agree) and
 accepts more parameters: `self`, `prop` and `value` being respectively: owners'
 instance, property's instance and the value being set. There is also `saver`,
 which does reverse: given value of the property it should return a string that
-can be parsed by `saver`.
+can be parsed by `setter`.
 
 
 Unset properties and default values
@@ -176,13 +176,13 @@ property::
 Setting netvm on particular domain of course does not affect global default, but
 only this instance. But there are two problems:
 
-- You don't know if the value of the property you just accessed was it's
+- You don't know if the value of the property you just accessed was its
   true or default value.
 - After ``del``'ing a property, you still will get a value on access. You
   cannot count on `AttributeError` raised from them.
 
 Therefore Qubes support alternative semantics. You can (and probably should,
-wherever applicable) use no ``del``, but assignment of special magic object
+wherever applicable) use not ``del``, but assignment of special magic object
 :py:obj:`qubes.property.DEFAULT`. There is also method
 :py:meth:`qubes.PropertyHolder.property_is_default`, which can be used to
 distinguish unset from set properties::
@@ -205,7 +205,7 @@ distinguish unset from set properties::
 
 Inheritance
 ^^^^^^^^^^^
-Properties in subclassess overload properties from their parents, like
+Properties in subclasses overload properties from their parents, like
 expected::
 
    >>> import qubes

--- a/qubes/devices.py
+++ b/qubes/devices.py
@@ -31,23 +31,23 @@ Devices are identified by pair of (backend domain, `ident`), where `ident` is
 
 Such extension should:
  - provide `qubes.devices` endpoint - a class descendant from
-   :py:class:`qubes.devices.DeviceInfo`, designed to hold device description (
-   including bus-specific properties)
+   :py:class:`qubes.devices.DeviceInfo`, designed to hold device description
+   (including bus-specific properties)
  - handle `device-attach:bus` and `device-detach:bus` events for
    performing the attach/detach action; events are fired even when domain isn't
    running and extension should be prepared for this; handlers for those events
    can be coroutines
  - handle `device-list:bus` event - list devices exposed by particular
-   domain; it should return list of appropriate DeviceInfo objects
+   domain; it should return a list of appropriate DeviceInfo objects
  - handle `device-get:bus` event - get one device object exposed by this
    domain of given identifier
- - handle `device-list-attached:class` event - list currently attached
-   devices to this domain
- - fire `device-list-change:class` event when device list change is detected
+ - handle `device-list-attached:class` event - list devices currently attached
+   to this domain
+ - fire `device-list-change:class` event when a device list change is detected
    (new/removed device)
 
-Note that device-listing event handlers can not be asynchronous. This for
-example means you can not call qrexec service there. This is intentional to
+Note that device-listing event handlers cannot be asynchronous. This for
+example means you cannot call qrexec service there. This is intentional to
 keep device listing operation cheap. You need to design the extension to take
 this into account (for example by using QubesDB).
 

--- a/qubes/devices.py
+++ b/qubes/devices.py
@@ -29,22 +29,22 @@ bus is implemented by an extension.
 Devices are identified by pair of (backend domain, `ident`), where `ident` is
 :py:class:`str` and can contain only characters from `[a-zA-Z0-9._-]` set.
 
-Such extension should provide:
- - `qubes.devices` endpoint - a class descendant from
- :py:class:`qubes.devices.DeviceInfo`, designed to hold device description (
- including bus-specific properties)
+Such extension should:
+ - provide `qubes.devices` endpoint - a class descendant from
+   :py:class:`qubes.devices.DeviceInfo`, designed to hold device description (
+   including bus-specific properties)
  - handle `device-attach:bus` and `device-detach:bus` events for
- performing the attach/detach action; events are fired even when domain isn't
- running and extension should be prepared for this; handlers for those events
- can be coroutines
+   performing the attach/detach action; events are fired even when domain isn't
+   running and extension should be prepared for this; handlers for those events
+   can be coroutines
  - handle `device-list:bus` event - list devices exposed by particular
- domain; it should return list of appropriate DeviceInfo objects
+   domain; it should return list of appropriate DeviceInfo objects
  - handle `device-get:bus` event - get one device object exposed by this
- domain of given identifier
+   domain of given identifier
  - handle `device-list-attached:class` event - list currently attached
- devices to this domain
+   devices to this domain
  - fire `device-list-change:class` event when device list change is detected
- (new/removed device)
+   (new/removed device)
 
 Note that device-listing event handlers can not be asynchronous. This for
 example means you can not call qrexec service there. This is intentional to

--- a/qubes/devices.py
+++ b/qubes/devices.py
@@ -21,7 +21,7 @@
 
 '''API for various types of devices.
 
-Main concept is that some domain main
+Main concept is that some domain may
 expose (potentially multiple) devices, which can be attached to other domains.
 Devices can be of different buses (like 'pci', 'usb', etc). Each device
 bus is implemented by an extension.
@@ -401,7 +401,7 @@ class DeviceCollection:
 
 
 class DeviceManager(dict):
-    '''Device manager that hold all devices by their classess.
+    '''Device manager that hold all devices by their classes.
 
     :param vm: VM for which we manage devices
     '''


### PR DESCRIPTION
These are some doc fixes noticed while answering [my own question](https://forum.qubes-os.org/t/understanding-the-code-path-for-admin-vm-device-pci-attach/6694), though I only covered the obvious/trivial problems, not the deeper ones of the doc not matching the API, described in this post.