### PR TITLE
tests/network: avoid race conditions with NetworkManager

### DIFF
--- a/qubes/tests/integ/network.py
+++ b/qubes/tests/integ/network.py
@@ -78,6 +78,9 @@ class VmNetworkingMixin(object):
         self.loop.run_until_complete(self.testnetvm.create_on_disk())
         self.testnetvm.provides_network = True
         self.testnetvm.netvm = None
+        # avoid races with NetworkManager, self.configure_netvm() configures
+        # everything directly
+        self.testnetvm.features['service.network-manager'] = False
         self.testvm1 = self.app.add_new_vm(qubes.vm.appvm.AppVM,
             name=self.make_vm_name('vm1'),
             label='red')


### PR DESCRIPTION
The "netvm" in the tests is configured manually, using "ip" command, and
by manually writing to /etc/resolv.conf. Do not let NetworkManager
interfere - simply disable it.