### PR TITLE
Remove `logrotate` configuration for no longer present `qmemman.log`

### DIFF
--- a/linux/system-config/Makefile
+++ b/linux/system-config/Makefile
@@ -6,6 +6,3 @@ install:
 	cp vif-route-qubes $(DESTDIR)/etc/xen/scripts
 	install -m 0755 create-snapshot destroy-snapshot $(DESTDIR)/usr/lib/qubes
 	install -m 0644 -D tmpfiles-qubes.conf $(DESTDIR)/usr/lib/tmpfiles.d/qubes.conf
-	install -d $(DESTDIR)/etc/logrotate.d
-	install -m 0644 logrotate-qubes \
-		$(DESTDIR)/etc/logrotate.d/qubes

--- a/linux/system-config/logrotate-qubes
+++ b/linux/system-config/logrotate-qubes
@@ -1,7 +1,0 @@
-/var/log/qubes/qmemman.log {
-    create 0640 root qubes
-    su root qubes
-    postrotate
-        /bin/systemctl restart qubes-qmemman.service >/dev/null 2>/dev/null || true
-    endscript
-}

--- a/rpm_spec/core-dom0.spec.in
+++ b/rpm_spec/core-dom0.spec.in
@@ -339,7 +339,6 @@ done
 %files
 %defattr(-,root,root,-)
 %config(noreplace) %attr(0664,root,qubes) %{_sysconfdir}/qubes/qmemman.conf
-%config(noreplace) /etc/logrotate.d/qubes
 %attr(770,root,qubes) %dir /etc/qubes/backup
 /usr/bin/qvm-*
 /usr/bin/qubes-*


### PR DESCRIPTION
This PR fixes https://github.com/QubesOS/qubes-issues/issues/7132.

`logrotate` tried to access the `qmemman.log` file although it is no longer present. Hence it failed to start on boot.

Since `qmemman.log` is no longer in use, the configuration for it should be removed as well.