### PR TITLE
Disallow persistent attachment of block devices

### DIFF
--- a/qubes/api/admin.py
+++ b/qubes/api/admin.py
@@ -1308,6 +1308,9 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
         # may raise KeyError, either on domain or ident
         dev = self.app.domains[backend_domain].devices[devclass][ident]
 
+        if devclass == 'block' and persistent:
+            raise qubes.exc.QubesException('Block devices cannot be persistently attached')
+
         self.fire_event_for_permission(device=dev,
             devclass=devclass, persistent=persistent,
             options=options)


### PR DESCRIPTION
It is very fragile.

Marking as draft because this is not yet tested.