### PR TITLE
R4.0: fix killing VMs

### DIFF
--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -1245,7 +1245,7 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
         """Forcefully shutdown (destroy) domain.
 
         This function needs to be called with self.startup_lock held."""
-        self.__waiter = asyncio.get_running_loop().create_future()
+        self.__waiter = asyncio.get_event_loop().create_future()
         try:
             self.libvirt_domain.destroy()
         except libvirt.libvirtError as e:


### PR DESCRIPTION
Use `get_event_loop()` to be compatible with Python 3.5.4 in R4.0 dom0. Killing a VM was broken, e.g.:

```
unhandled exception while calling src=b'dom0' meth=b'admin.vm.Kill' dest=b'disp1234' arg=b'' len(untrusted_payload)=0
Traceback (most recent call last):
  File "/usr/lib/python3.5/site-packages/qubes/api/__init__.py", line 275, in respond
    untrusted_payload=untrusted_payload)
  File "/usr/lib64/python3.5/asyncio/futures.py", line 381, in __iter__
    yield self  # This tells Task to wait for completion.
  File "/usr/lib64/python3.5/asyncio/tasks.py", line 310, in _wakeup
    future.result()
  File "/usr/lib64/python3.5/asyncio/futures.py", line 294, in result
    raise self._exception
  File "/usr/lib64/python3.5/asyncio/tasks.py", line 240, in _step
    result = coro.send(None)
  File "/usr/lib/python3.5/site-packages/qubes/api/admin.py", line 864, in vm_kill
    yield from self.dest.kill()
  File "/usr/lib/python3.5/site-packages/qubes/vm/qubesvm.py", line 1239, in kill
    yield from self._kill_locked()
  File "/usr/lib/python3.5/site-packages/qubes/vm/qubesvm.py", line 1248, in _kill_locked
    self.__waiter = asyncio.get_running_loop().create_future()
AttributeError: module 'asyncio' has no attribute 'get_running_loop'
```