### PR TITLE
tests: do not expect GUI error message anymore

### DIFF
--- a/qubes/tests/integ/basic.py
+++ b/qubes/tests/integ/basic.py
@@ -501,6 +501,8 @@ class TC_30_Gui_daemon(qubes.tests.SystemTestCase):
                                'key', 'ctrl+a', 'ctrl+c', 'ctrl+shift+c',
                                'Escape'])
 
+        self.wait_for_window(window_title, show=False)
+
         clipboard_content = \
             open('/var/run/qubes/qubes-clipboard.bin', 'r').read().strip()
         self.assertEqual(clipboard_content, test_string,

--- a/qubes/tests/integ/dispvm.py
+++ b/qubes/tests/integ/dispvm.py
@@ -460,6 +460,9 @@ class TC_20_DispVMMixin(object):
         if winid is None:
             self.fail('Timeout waiting for editor window')
 
+        self.loop.run_until_complete(
+            self.wait_for_window_hide_coro("editor", winid))
+
         with open('/var/run/qubes/qubes-clipboard.bin', 'rb') as f:
             test_txt_content = f.read()
         self.assertEqual(test_txt_content.strip(), b"test1")

--- a/qubes/tests/integ/vm_qrexec_gui.py
+++ b/qubes/tests/integ/vm_qrexec_gui.py
@@ -347,11 +347,6 @@ class TC_00_AppVMMixin(object):
                 'qvm-move-to-vm {} /tmp/testfile'.format(
                     self.testvm2.name)))
 
-            # Close GUI error message
-            try:
-                self.enter_keys_in_window('Error', ['Return'])
-            except subprocess.CalledProcessError:
-                pass
             self.loop.run_until_complete(p.wait())
             self.assertNotEqual(p.returncode, 0)
 


### PR DESCRIPTION
QubesOS/qubes-core-agent-linux#363 removes GUI error messages if the
toll was called from command line. Adjust tests.