### PR TITLE
Remove stale pylint suppressions

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -6,8 +6,6 @@ ignore=tests
 # abstract-class-little-used: see http://www.logilab.org/ticket/111138
 # deprecated-method:
 #   enable again after disabling py-3.4.3 asyncio.ensure_future compat hack
-# not-an-iterable:
-#   a lot of false possitives for asyncio (yield from (some coroutine))
 disable=
   abstract-class-little-used,
   bad-continuation,

--- a/qubes/backup.py
+++ b/qubes/backup.py
@@ -144,7 +144,6 @@ class SendWorker:
             # verified before untaring.
             tar_final_cmd = ["tar", "-cO", "--posix",
                              "-C", self.base_dir, filename]
-            # pylint: disable=not-an-iterable
             final_proc = await asyncio.create_subprocess_exec(
                 *tar_final_cmd,
                 stdout=self.backup_stdout)
@@ -180,7 +179,6 @@ async def launch_proc_with_pty(args, stdin=None, stdout=None,
             termios_p[3] &= ~termios.ECHO
             termios.tcsetattr(ctty_fd, termios.TCSANOW, termios_p)
     (pty_master, pty_slave) = os.openpty()
-    # pylint: disable=not-an-iterable
     p = await asyncio.create_subprocess_exec(*args,
         stdin=stdin,
         stdout=stdout,
@@ -660,7 +658,6 @@ class Backup:
 
                 # Pipe: tar-sparse | scrypt | tar | backup_target
                 # TODO: log handle stderr
-                # pylint: disable=not-an-iterable
                 tar_sparse = await asyncio.create_subprocess_exec(
                     *tar_cmdline, stdout=subprocess.PIPE)
 

--- a/qubes/vm/dispvm.py
+++ b/qubes/vm/dispvm.py
@@ -231,7 +231,6 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
         This method modifies :file:`qubes.xml` file.
         '''
         try:
-            # pylint: disable=not-an-iterable
             await self.kill()
         except qubes.exc.QubesVMNotStartedError:
             pass

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -1413,7 +1413,6 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
         :raises qubes.exc.QubesVMError: when machine is suspended
         """
 
-        # pylint: disable=not-an-iterable
         if self.get_power_state() == "Suspended":
             self.libvirt_domain.pMWakeup()
             if self.features.check_with_template('qrexec', False):


### PR DESCRIPTION
Those were from before `yield from` was replaced by `await`.