### PR TITLE
lvm2 pool: Export immutable snapshot of volume

### DIFF
--- a/qubes/storage/lvm.py
+++ b/qubes/storage/lvm.py
@@ -411,7 +411,6 @@ class ThinVolume(qubes.storage.Volume):
             cmd = ['rename', self.vid,
                    '{}-{}-back'.format(self.vid, int(time.time()))]
             await qubes_lvm_coro(cmd, self.log)
-            await reset_cache_coro()
 
         cmd = ['clone' if keep else 'rename',
                vid_to_commit,

--- a/qubes/storage/lvm.py
+++ b/qubes/storage/lvm.py
@@ -788,9 +788,6 @@ def _get_lvm_cmdline(cmd):
     elif action == 'extend':
         assert len(cmd) == 3, 'wrong number of arguments for extend'
         lvm_cmd = ["lvextend", "--size=" + cmd[2] + 'B', '--', cmd[1]]
-    elif action == 'activate':
-        assert len(cmd) == 2, 'wrong number of arguments for activate'
-        lvm_cmd = ['lvchange', '--activate=y', '--', cmd[1]]
     elif action == 'rename':
         assert len(cmd) == 3, 'wrong number of arguments for rename'
         lvm_cmd = ['lvrename', '--', cmd[1], cmd[2]]


### PR DESCRIPTION
Volumes returned by `export()` must be immutable, since otherwise the
backup will be inconsistent.  Ensure this by exporting a snapshot of the
volume, no the volume itself.

Fixes QubesOS/qubes-issues#7198.

FIXME: tests