### PR TITLE
Refuse to delete an entire volume group

### DIFF
--- a/qubes/storage/lvm.py
+++ b/qubes/storage/lvm.py
@@ -760,6 +760,7 @@ def _get_lvm_cmdline(cmd):
     if action == 'remove':
         assert len(cmd) == 2, 'wrong number of arguments for remove'
         assert not cmd[1].startswith('/'), 'absolute path to ‘remove’???'
+        assert '/' in cmd[1], 'refusing to delete entire volume group'
         lvm_cmd = ['lvremove', '--force', '--', cmd[1]]
     elif action == 'clone':
         assert len(cmd) == 3, 'wrong number of arguments for clone'


### PR DESCRIPTION
LVM will happily delete the entire contents of a volume group if the
command line requests it, even if it is not empty.  There is typically
a prompt for this, but but Qubes OS disables it with --force.

To prevent accidentally wiping user's systems, check (with an assertion)
that the volume to be deleted is not a bare volume group.

Not tested (yet), but should be trivial.