### PR TITLE
Include default policy for admin.vm.device.{mic,usb}.*

### DIFF
--- a/qubes-rpc-policy/90-admin-default.policy.header
+++ b/qubes-rpc-policy/90-admin-default.policy.header
@@ -20,3 +20,14 @@
 !include-service admin.vm.volume.Import * include/admin-local-rwx
 !include-service admin.vm.volume.ImportWithSize * include/admin-local-rwx
 
+!include-service admin.vm.device.mic.Attach * include/admin-local-rwx
+!include-service admin.vm.device.mic.Available * include/admin-local-ro
+!include-service admin.vm.device.mic.Detach * include/admin-local-rwx
+!include-service admin.vm.device.mic.List * include/admin-local-ro
+!include-service admin.vm.device.mic.Set.persistent * include/admin-local-rwx
+!include-service admin.vm.device.usb.Attach * include/admin-local-rwx
+!include-service admin.vm.device.usb.Available * include/admin-local-ro
+!include-service admin.vm.device.usb.Detach * include/admin-local-rwx
+!include-service admin.vm.device.usb.List * include/admin-local-ro
+!include-service admin.vm.device.usb.Set.persistent * include/admin-local-rwx
+


### PR DESCRIPTION
Those services are delivered by serparate packages (gui-daemon,
app-linux-usb-proxy), so the generator does not see them. But it still
makes sense to include them in the default policy here.

Fixes QubesOS/qubes-issues#7451