### PR TITLE
Properly suspend all VMs, not only those with PCI devices

### DIFF
--- a/qubes/api/internal.py
+++ b/qubes/api/internal.py
@@ -175,9 +175,19 @@ class QubesInternalAPI(qubes.api.AbstractQubesAPI):
             except qubes.exc.QubesException as e:
                 vm.log.warning('Failed to run qubes.SuspendPreAll: %s', str(e))
 
-        # FIXME: some timeout?
         if processes:
-            await asyncio.wait([p.wait() for p in processes])
+            done, _ = await asyncio.wait(
+                [asyncio.wait_for(p.wait(), qubes.config.suspend_timeout)
+                 for p in processes])
+            for c in done:
+                try:
+                    c.result()
+                except asyncio.TimeoutError:
+                    self.app.log.warning(
+                        "some qube timed out after %d seconds on %s call",
+                        qubes.config.suspend_timeout,
+                        "qubes.SuspendPreAll"
+                    )
 
         coros = []
         # then suspend/pause VMs
@@ -235,6 +245,16 @@ class QubesInternalAPI(qubes.api.AbstractQubesAPI):
             except qubes.exc.QubesException as e:
                 vm.log.warning('Failed to run qubes.SuspendPostAll: %s', str(e))
 
-        # FIXME: some timeout?
         if processes:
-            await asyncio.wait([p.wait() for p in processes])
+            done, _ = await asyncio.wait(
+                [asyncio.wait_for(p.wait(), qubes.config.suspend_timeout)
+                 for p in processes])
+            for c in done:
+                try:
+                    c.result()
+                except asyncio.TimeoutError:
+                    self.app.log.warning(
+                        "some qube timed out after %d seconds on %s call",
+                        qubes.config.suspend_timeout,
+                        "qubes.SuspendPostAll"
+                    )

--- a/qubes/config.py
+++ b/qubes/config.py
@@ -87,3 +87,5 @@ backup_profile_dir = '/etc/qubes/backup'
 
 #: site-local prefix for all VMs
 qubes_ipv6_prefix = 'fd09:24ef:4179:0000'
+
+suspend_timeout = 60

--- a/qubes/utils.py
+++ b/qubes/utils.py
@@ -289,3 +289,16 @@ def cryptsetup(*args):
         check=True,
         sudo=True,
     )
+
+
+def sanitize_stderr_for_log(untrusted_stderr: bytes) -> str:
+    """Helper function to sanitize qrexec service stderr for logging"""
+    # limit size
+    untrusted_stderr = untrusted_stderr[:4096]
+    # limit to subset of printable ASCII, especially do not allow newlines,
+    # control characters etc
+    allowed = (string.ascii_letters + string.digits + string.punctuation + ' ')
+    allowed_bytes = allowed.encode()
+    stderr = bytes(b if b in allowed_bytes else b'_'[0]
+                   for b in untrusted_stderr)
+    return stderr.decode('ascii')

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -1385,14 +1385,11 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
         if not self.is_running() and not self.is_paused():
             raise qubes.exc.QubesVMNotRunningError(self)
 
-        if list(self.devices['pci'].attached()):
-            if self.features.check_with_template('qrexec', False):
-                await self.run_service_for_stdio('qubes.SuspendPre',
-                                                      user='root')
-            self.libvirt_domain.pMSuspendForDuration(
-                libvirt.VIR_NODE_SUSPEND_TARGET_MEM, 0, 0)
-        else:
-            self.libvirt_domain.suspend()
+        if self.features.check_with_template('qrexec', False):
+            await self.run_service_for_stdio('qubes.SuspendPre',
+                                                  user='root')
+        self.libvirt_domain.pMSuspendForDuration(
+            libvirt.VIR_NODE_SUSPEND_TARGET_MEM, 0, 0)
 
         return self
 


### PR DESCRIPTION
Just pausing a VM for a host suspend breaks 'tsc' clocksource.

QubesOS/qubes-issues#7404
QubesOS/qubes-issues#2044

TODO:

- [x] test with mirage PVH
- [x] suspend (instead of pause) stubdomain too
- [x] Fix QWT to not remove xenstore entry (https://github.com/QubesOS/qubes-issues/issues/7404#issuecomment-1117611495)
- [x] https://github.com/QubesOS/qubes-issues/issues/4657