### PR TITLE
Allow volume downsize requests

### DIFF
--- a/qubes/storage/__init__.py
+++ b/qubes/storage/__init__.py
@@ -355,10 +355,20 @@ class Volume:
         '''
         raise self._not_implemented("is_outdated")
 
-    async def resize(self, size):
-        ''' Expands volume, throws
+    async def extend(self, size):
+        ''' Extends volume, throws
             :py:class:`qubes.storage.StoragePoolException` if
             given size is less than current_size
+
+            This can be implemented as a coroutine.
+
+            :param int size: new size in bytes
+        '''
+        # pylint: disable=unused-argument
+        raise self._not_implemented("extend")
+
+    async def resize(self, size):
+        ''' Resizes volume
 
             This can be implemented as a coroutine.
 

--- a/qubes/storage/file.py
+++ b/qubes/storage/file.py
@@ -340,13 +340,6 @@ class FileVolume(qubes.storage.Volume):
                   'the template instead'
             raise qubes.storage.StoragePoolException(msg)
 
-        if size < self.size:
-            raise qubes.storage.StoragePoolException(
-                'For your own safety, shrinking of %s is'
-                ' disabled. If you really know what you'
-                ' are doing, use `truncate` on %s manually.' %
-                (self.name, self.vid))
-
         with open(self.path, 'a+b') as fd:
             fd.truncate(size)
 

--- a/qubes/storage/file.py
+++ b/qubes/storage/file.py
@@ -324,10 +324,21 @@ class FileVolume(qubes.storage.Volume):
         # and make it active
         subprocess.check_call(['dmsetup', 'resume', path])
 
-    def resize(self, size):  # pylint: disable=invalid-overridden-method
-        ''' Expands volume, throws
+    def extnd(self, size):  # pylint: disable=invalid-overridden-method
+        ''' Extends volume, throws
             :py:class:`qubst.storage.qubes.storage.StoragePoolException` if
             given size is less than current_size
+        '''  # pylint: disable=no-self-use
+        if size < self.size:
+            raise qubes.storage.StoragePoolException(
+                'For your own safety, shrinking of %s is'
+                ' disabled (%d < %d). If you really know what you'
+                ' are doing, use `lvresize` on %s manually.' %
+                (self.name, size, self.size, self.vid))
+        self.resize(size)
+
+    def resize(self, size):  # pylint: disable=invalid-overridden-method
+        ''' Resizes volume
         '''  # pylint: disable=no-self-use
         if not self.rw:
             msg = 'Can not resize reađonly volume {!s}'.format(self)

--- a/qubes/storage/lvm.py
+++ b/qubes/storage/lvm.py
@@ -598,10 +598,42 @@ class ThinVolume(qubes.storage.Volume):
         return self
 
     @qubes.storage.Volume.locked
-    async def resize(self, size):
-        ''' Expands volume, throws
+    async def extend(self, size):
+        ''' Extends volume, throws
             :py:class:`qubst.storage.qubes.storage.StoragePoolException` if
             given size is less than current_size
+        '''
+        if not self.rw:
+            msg = 'Can not resize reađonly volume {!s}'.format(self)
+            raise qubes.storage.StoragePoolException(msg)
+
+        if size < self.size:
+            raise qubes.storage.StoragePoolException(
+                'For your own safety, shrinking of %s is'
+                ' disabled. If you really know what you'
+                ' are doing, use `truncate` on %s manually.' %
+                (self.name, self.vid))
+
+        if size == self.size:
+            return
+
+        if self.is_dirty() or self.snap_on_start:
+            cmd = ['extend', self._vid_snap, str(size)]
+            await qubes_lvm_coro(cmd, self.log)
+        elif hasattr(self, '_vid_import') and \
+                os.path.exists('/dev/' + self._vid_import):
+            cmd = ['extend', self._vid_import, str(size)]
+            await qubes_lvm_coro(cmd, self.log)
+        elif self.save_on_stop and not self.snap_on_start:
+            cmd = ['extend', self._vid_current, str(size)]
+            await qubes_lvm_coro(cmd, self.log)
+
+        self._size = size
+        await reset_cache_coro()
+
+    @qubes.storage.Volume.locked
+    async def resize(self, size):
+        ''' Resizes volume
         '''
         if not self.rw:
             msg = 'Can not resize reađonly volume {!s}'.format(self)
@@ -757,8 +789,11 @@ def _get_lvm_cmdline(cmd):
         lvm_cmd = ['lvcreate', '--thin', '--setactivationskip=n',
                    '--activate=y', '--name=' + cmd[2],
                    '--virtualsize=' + cmd[3] + 'B', '--', cmd[1]]
-    elif action == 'resize':
+    elif action == 'extend':
         assert len(cmd) == 3, 'wrong number of arguments for extend'
+        lvm_cmd = ["lvextend", "--size=" + cmd[2] + 'B', '--', cmd[1]]
+    elif action == 'resize':
+        assert len(cmd) == 3, 'wrong number of arguments for resize'
         lvm_cmd = ["lvresize", "--force", "--size=" + cmd[2] + 'B', '--', cmd[1]]
     elif action == 'activate':
         assert len(cmd) == 2, 'wrong number of arguments for activate'

--- a/qubes/storage/lvm.py
+++ b/qubes/storage/lvm.py
@@ -607,25 +607,18 @@ class ThinVolume(qubes.storage.Volume):
             msg = 'Can not resize reađonly volume {!s}'.format(self)
             raise qubes.storage.StoragePoolException(msg)
 
-        if size < self.size:
-            raise qubes.storage.StoragePoolException(
-                'For your own safety, shrinking of %s is'
-                ' disabled (%d < %d). If you really know what you'
-                ' are doing, use `lvresize` on %s manually.' %
-                (self.name, size, self.size, self.vid))
-
         if size == self.size:
             return
 
         if self.is_dirty() or self.snap_on_start:
-            cmd = ['extend', self._vid_snap, str(size)]
+            cmd = ['resize', self._vid_snap, str(size)]
             await qubes_lvm_coro(cmd, self.log)
         elif hasattr(self, '_vid_import') and \
                 os.path.exists('/dev/' + self._vid_import):
-            cmd = ['extend', self._vid_import, str(size)]
+            cmd = ['resize', self._vid_import, str(size)]
             await qubes_lvm_coro(cmd, self.log)
         elif self.save_on_stop and not self.snap_on_start:
-            cmd = ['extend', self._vid_current, str(size)]
+            cmd = ['resize', self._vid_current, str(size)]
             await qubes_lvm_coro(cmd, self.log)
 
         self._size = size
@@ -764,9 +757,9 @@ def _get_lvm_cmdline(cmd):
         lvm_cmd = ['lvcreate', '--thin', '--setactivationskip=n',
                    '--activate=y', '--name=' + cmd[2],
                    '--virtualsize=' + cmd[3] + 'B', '--', cmd[1]]
-    elif action == 'extend':
+    elif action == 'resize':
         assert len(cmd) == 3, 'wrong number of arguments for extend'
-        lvm_cmd = ["lvextend", "--size=" + cmd[2] + 'B', '--', cmd[1]]
+        lvm_cmd = ["lvresize", "--force", "--size=" + cmd[2] + 'B', '--', cmd[1]]
     elif action == 'activate':
         assert len(cmd) == 2, 'wrong number of arguments for activate'
         lvm_cmd = ['lvchange', '--activate=y', '--', cmd[1]]


### PR DESCRIPTION
What it does:
- Changes API to introduce volume.extend function that disallows volume downsize
- Removes downsize restrictions from volume.resize
- Adjusts lvm and file backends

What it does not do:
1. Adjusts reflink backend
2. Checks existing callers of volume.resize to use resize or extend call as needed

Once a change in API is conceptually agreed, (1) is hopefully easy to do. Finding 'resize' users across all repositories might be a bit more difficult but doable.