### PR TITLE
Allow volume shrinking

### DIFF
--- a/qubes/storage/__init__.py
+++ b/qubes/storage/__init__.py
@@ -355,14 +355,17 @@ class Volume:
         '''
         raise self._not_implemented("is_outdated")
 
-    async def resize(self, size):
-        ''' Expands volume, throws
+    async def resize(self, size, allow_shrink=False):
+        ''' Resizes volume, throws
             :py:class:`qubes.storage.StoragePoolException` if
-            given size is less than current_size
+            given size is less than current_size and allow_shrink
+            is not True
 
             This can be implemented as a coroutine.
 
             :param int size: new size in bytes
+            :param bool allow_shrink: if shrinking volume is allowed. \
+                False by default.
         '''
         # pylint: disable=unused-argument
         raise self._not_implemented("resize")

--- a/qubes/storage/callback.py
+++ b/qubes/storage/callback.py
@@ -454,10 +454,10 @@ class CallbackVolume(qubes.storage.Volume):
         await self._callback('post_volume_remove')
         return ret
 
-    async def resize(self, size):
+    async def resize(self, size, allow_shrink=False):
         await self._assert_initialized()
         await self._callback('pre_volume_resize', cb_args=[size])
-        return await coro_maybe(self._cb_impl.resize(size))
+        return await coro_maybe(self._cb_impl.resize(size, allow_shrink))
 
     async def start(self):
         await self._assert_initialized()

--- a/qubes/storage/file.py
+++ b/qubes/storage/file.py
@@ -324,10 +324,11 @@ class FileVolume(qubes.storage.Volume):
         # and make it active
         subprocess.check_call(['dmsetup', 'resume', path])
 
-    def resize(self, size):  # pylint: disable=invalid-overridden-method
-        ''' Expands volume, throws
+    def resize(self, size, allow_shrink=False):  \
+        # pylint: disable=invalid-overridden-method
+        ''' Resizes volume, throws
             :py:class:`qubst.storage.qubes.storage.StoragePoolException` if
-            given size is less than current_size
+            given size is less than current size and allow_shrink is not True
         '''  # pylint: disable=no-self-use
         if not self.rw:
             msg = 'Can not resize reađonly volume {!s}'.format(self)
@@ -340,7 +341,7 @@ class FileVolume(qubes.storage.Volume):
                   'the template instead'
             raise qubes.storage.StoragePoolException(msg)
 
-        if size < self.size:
+        if size < self.size and not allow_shrink:
             raise qubes.storage.StoragePoolException(
                 'For your own safety, shrinking of %s is'
                 ' disabled. If you really know what you'

--- a/qubes/storage/lvm.py
+++ b/qubes/storage/lvm.py
@@ -598,34 +598,39 @@ class ThinVolume(qubes.storage.Volume):
         return self
 
     @qubes.storage.Volume.locked
-    async def resize(self, size):
-        ''' Expands volume, throws
+    async def resize(self, size, allow_shrink=False):
+        ''' Resizes volume, throws
             :py:class:`qubst.storage.qubes.storage.StoragePoolException` if
-            given size is less than current_size
+            given size is less than current size and allow_shrink is not True
         '''
+        lvm_command = 'extend'
+
         if not self.rw:
             msg = 'Can not resize reađonly volume {!s}'.format(self)
             raise qubes.storage.StoragePoolException(msg)
 
         if size < self.size:
-            raise qubes.storage.StoragePoolException(
-                'For your own safety, shrinking of %s is'
-                ' disabled (%d < %d). If you really know what you'
-                ' are doing, use `lvresize` on %s manually.' %
-                (self.name, size, self.size, self.vid))
+            if allow_shrink:
+                lvm_command = 'resize'
+            else:
+                raise qubes.storage.StoragePoolException(
+                    'For your own safety, shrinking of %s is'
+                    ' disabled (%d < %d). If you really know what you'
+                    ' are doing, use `lvresize` on %s manually.' %
+                    (self.name, size, self.size, self.vid))
 
         if size == self.size:
             return
 
         if self.is_dirty() or self.snap_on_start:
-            cmd = ['extend', self._vid_snap, str(size)]
+            cmd = [lvm_command, self._vid_snap, str(size)]
             await qubes_lvm_coro(cmd, self.log)
         elif hasattr(self, '_vid_import') and \
                 os.path.exists('/dev/' + self._vid_import):
-            cmd = ['extend', self._vid_import, str(size)]
+            cmd = [lvm_command, self._vid_import, str(size)]
             await qubes_lvm_coro(cmd, self.log)
         elif self.save_on_stop and not self.snap_on_start:
-            cmd = ['extend', self._vid_current, str(size)]
+            cmd = [lvm_command, self._vid_current, str(size)]
             await qubes_lvm_coro(cmd, self.log)
 
         self._size = size
@@ -767,6 +772,10 @@ def _get_lvm_cmdline(cmd):
     elif action == 'extend':
         assert len(cmd) == 3, 'wrong number of arguments for extend'
         lvm_cmd = ["lvextend", "--size=" + cmd[2] + 'B', '--', cmd[1]]
+    elif action == 'resize':
+        assert len(cmd) == 3, 'wrong number of arguments for resize'
+        lvm_cmd = ["lvresize", "--force", "--size=" + cmd[2] + 'B',
+                   '--', cmd[1]]
     elif action == 'activate':
         assert len(cmd) == 2, 'wrong number of arguments for activate'
         lvm_cmd = ['lvchange', '--activate=y', '--', cmd[1]]

--- a/qubes/storage/reflink.py
+++ b/qubes/storage/reflink.py
@@ -296,10 +296,20 @@ class ReflinkVolume(qubes.storage.Volume):
 
     @qubes.storage.Volume.locked
     @_coroutinized
-    def resize(self, size):  # pylint: disable=invalid-overridden-method
+    def resize(self, size, allow_shrink=False):  \
+        # pylint: disable=invalid-overridden-method
         ''' Resize a read-write volume; notify any corresponding loop
-            devices of the size change.
+            devices of the size change; throw
+            :py:class:`qubst.storage.qubes.storage.StoragePoolException` if
+            given size is less than current size and allow_shrink is not True
         '''
+        if size < self._size and not allow_shrink:
+            raise qubes.storage.StoragePoolException(
+                'For your own safety, shrinking of %s is'
+                ' disabled. If you really know what you'
+                ' are doing, use `truncate` on %s manually.' %
+                (self.name, self.vid))
+
         if not self.rw:
             raise qubes.storage.StoragePoolException(
                 'Cannot resize: {} is read-only'.format(self.vid))

--- a/qubes/tests/storage_file.py
+++ b/qubes/tests/storage_file.py
@@ -462,6 +462,14 @@ class TC_01_FileVolumes(qubes.tests.QubesTestCase):
             qubes.utils.coro_maybe(volume.resize(new_size)))
         self.assertEqual(os.path.getsize(volume.path), new_size)
         self.assertEqual(volume.size, new_size)
+        self.loop.run_until_complete(
+            qubes.utils.coro_maybe(volume.resize(new_size)))
+        self.assertEqual(os.path.getsize(volume.path), new_size/4)
+        self.assertEqual(volume.size, new_size)
+        self.loop.run_until_complete(
+            qubes.utils.coro_maybe(volume.resize(new_size/4, True)))
+        self.assertEqual(os.path.getsize(volume.path), new_size/4)
+        self.assertEqual(volume.size, new_size)
 
     def test_024_import_data_with_new_size(self):
         config = {

--- a/qubes/tests/storage_lvm.py
+++ b/qubes/tests/storage_lvm.py
@@ -258,7 +258,7 @@ class TC_00_ThinPool(ThinPoolBase):
         self.loop.run_until_complete(volume.resize(new_size/4))
         self.assertEqual(self._get_size(path), new_size)
         self.assertEqual(volume.size, new_size)
-        self.loop.run_until_complete(volume.resize(new_size/4), True)
+        self.loop.run_until_complete(volume.resize(new_size/4, True))
         self.assertEqual(self._get_size(path), new_size/4)
         self.assertEqual(volume.size, new_size/4)
 

--- a/qubes/tests/storage_lvm.py
+++ b/qubes/tests/storage_lvm.py
@@ -255,6 +255,12 @@ class TC_00_ThinPool(ThinPoolBase):
         self.loop.run_until_complete(volume.resize(new_size))
         self.assertEqual(self._get_size(path), new_size)
         self.assertEqual(volume.size, new_size)
+        self.loop.run_until_complete(volume.resize(new_size/4))
+        self.assertEqual(self._get_size(path), new_size)
+        self.assertEqual(volume.size, new_size)
+        self.loop.run_until_complete(volume.resize(new_size/4), True)
+        self.assertEqual(self._get_size(path), new_size/4)
+        self.assertEqual(volume.size, new_size/4)
 
     def test_007_resize_running(self):
         old_size = 32 * 1024**2


### PR DESCRIPTION
Change Volume.resize call to allow volume shrinking.
Bypass size check for file and lvm if shrinking is allowed.
Implement size check for reflink as it wasn't there.