### PR TITLE
Fixed a doctest in qubes-backup and a typo

### DIFF
--- a/doc/qubes.rst
+++ b/doc/qubes.rst
@@ -16,7 +16,7 @@ loading from XML file.
 
 The loading from XML is done in stages, because Qubes domains are dependent on
 each other in what can be even a circular dependency. Therefore some properties
-(especcialy those that refer to another domains) are loaded later.
+(especialy those that refer to another domains) are loaded later.
 
 .. image:: loading.svg
 

--- a/qubes/backup.py
+++ b/qubes/backup.py
@@ -233,7 +233,6 @@ class Backup:
     >>> vms = [app.domains[name] for name in ['my-vm1', 'my-vm2', 'my-vm3']]
     >>> exclude_vms = []
     >>> options = {
-    >>>     'encrypted': True,
     >>>     'compressed': True,
     >>>     'passphrase': 'This is very weak backup passphrase',
     >>>     'target_vm': app.domains['sys-usb'],


### PR DESCRIPTION
The edit in `qubes/backup.py` was made after I tried the code block in the docstring on my R4.0 machine and suddenly struggled with an `AttributeError` (line 356), since `encrypted` is no attribute of class `Backup`.

Be aware that I'm on R4.0 and have only "verified" that it's still accurate by examining the current code.

Side note: is directly opening such a PR here fine or is an issue in Qubes-Issues recommended beforehand (I thought this could be discussed here, since it's quite a small change)?