### PR TITLE
Disable Hyper-V enlightenments in HVMs

### DIFF
--- a/templates/libvirt/xen.xml
+++ b/templates/libvirt/xen.xml
@@ -64,7 +64,6 @@
                 <pae/>
                 <acpi/>
                 <apic/>
-                <viridian/>
             {% endif %}
 
             {% if vm.devices['pci'].persistent() | list


### PR DESCRIPTION
This reduces hypervisor attack surface.