### PR TITLE
Raise VM limit from 254 to 10000

### DIFF
--- a/qubes/config.py
+++ b/qubes/config.py
@@ -75,7 +75,7 @@ defaults = {
     },
 }
 
-max_qid = 254
+max_qid = 10000
 max_dispid = 10000
 
 #: built-in standard labels, if creating new one, allocate them above this

--- a/qubes/tests/vm/mix/net.py
+++ b/qubes/tests/vm/mix/net.py
@@ -27,6 +27,8 @@ import qubes.vm.qubesvm
 
 import qubes.tests
 import qubes.tests.vm.qubesvm
+from qubes.vm.mix.net import vmid_to_ipv4
+
 
 class TC_00_NetVMMixin(
         qubes.tests.vm.qubesvm.QubesVMTestsMixin, qubes.tests.QubesTestCase):
@@ -154,3 +156,23 @@ class TC_00_NetVMMixin(
         self.assertPropertyValue(vm2, 'netvm', None, None, '')
         self.assertPropertyValue(vm2, 'netvm', '', None, '')
         self.assertPropertyValue(vm, 'provides_network', False, False, 'False')
+
+    def test_200_vmid_to_ipv4(self):
+        testcases = (
+            (1,   '0.1'),
+            (2,   '0.2'),
+            (254, '0.254'),
+            (255, '1.1'),
+            (256, '1.2'),
+            (257, '1.3'),
+            (508, '1.254'),
+            (509, '2.1'),
+            (510, '2.2'),
+            (511, '2.3'),
+            (512, '2.4'),
+            (513, '2.5'),
+        )
+        for vmid, ip in testcases:
+            with self.subTest(str(vmid)):
+                self.assertEqual(ipaddress.IPv4Address('1.1.' + ip),
+                                 vmid_to_ipv4('1.1', vmid))


### PR DESCRIPTION
Make max QID equal to max DispID. Technically QID could be up to 64770
(because of how IP addresses are assigned), but set the limit lower to
allow future adjustments to the IP calculation without being forced into
weird corner cases.

Fixes QubesOS/qubes-issues#2519