### PR TITLE
Use fsync and nocreat during import

### DIFF
--- a/qubes/storage/lvm.py
+++ b/qubes/storage/lvm.py
@@ -510,7 +510,7 @@ class ThinVolume(qubes.storage.Volume):
             src_path = await qubes.utils.coro_maybe(src_volume.export())
             try:
                 cmd = [_dd, 'if=' + src_path, 'of=/dev/' + self._vid_import,
-                    'conv=sparse', 'status=none', 'bs=128K']
+                       'conv=sparse,nocreat,fsync', 'status=none', 'bs=128K']
                 if not os.access('/dev/' + self._vid_import, os.W_OK) or \
                         not os.access(src_path, os.R_OK):
                     cmd.insert(0, _sudo)


### PR DESCRIPTION
It is critical that dd properly flush data to disk, so that imported data will not be lost in the event of an unclean shutdown.  It is also critical that dd not try to create the destination file if it does not exist, as this would try to write a huge amount of data to a tmpfs and could easily cause out-of-memory if it succeeded.

Fixes QubesOS/qubes-issues#7870.