### PR TITLE
Translate 'ich6' audio model into "hda" libvirt sound model

### DIFF
--- a/templates/libvirt/xen.xml
+++ b/templates/libvirt/xen.xml
@@ -192,7 +192,9 @@
                     {% endif %}
                     />
                 <input type="tablet" bus="usb"/>
-                {% if vm.features.check_with_template('audio-model', False) %}
+                {% if vm.features.check_with_template('audio-model', False) == 'ich6' %}
+                    <sound model="hda"/>
+                {% elif vm.features.check_with_template('audio-model', False) %}
                     <sound model="{{ vm.features.check_with_template('audio-model', False) }}"/>
                 {% endif %}
                 {% if vm.features.check_with_template('video-model', 'vga') != 'none' %}


### PR DESCRIPTION
Since libxl migrated from -soundhw option to -device, it changed names
used there. Automatically translate settings of existing qubes.

Fixes QubesOS/qubes-issues#7946