### PR TITLE
tests: clone properties too when cloning a template

### DIFF
--- a/qubes/tests/integ/backup.py
+++ b/qubes/tests/integ/backup.py
@@ -324,15 +324,16 @@ class BackupTestsMixin(object):
             restored_vm = self.app.domains[vm_name]
             for prop in vm_info['properties']:
                 self.assertEqual(
-                    vm_info['properties'][prop],
-                    str(getattr(restored_vm, prop)),
-                    "VM {} - property {} not properly restored".format(
-                        vm_name, prop))
-                self.assertEqual(
                     vm_info['default'][prop],
                     restored_vm.property_is_default(prop),
                     "VM {} - property {} differs in being default".format(
                         vm_name, prop))
+                if not vm_info['default'][prop]:
+                    self.assertEqual(
+                        vm_info['properties'][prop],
+                        str(getattr(restored_vm, prop)),
+                        "VM {} - property {} not properly restored".format(
+                            vm_name, prop))
             for dev_class in vm_info['devices']:
                 for dev in vm_info['devices'][dev_class]:
                     found = False

--- a/qubes/tests/integ/grub.py
+++ b/qubes/tests/integ/grub.py
@@ -97,6 +97,7 @@ class GrubBase(object):
             label='red')
         self.testvm1.virt_mode = self.virt_mode
         self.testvm1.features.update(self.app.domains[self.template].features)
+        self.testvm1.clone_properties(self.app.domains[self.template])
         self.loop.run_until_complete(
             self.testvm1.clone_disk_files(self.app.domains[self.template]))
         self.loop.run_until_complete(self.testvm1.start())
@@ -117,6 +118,7 @@ class GrubBase(object):
             name=self.make_vm_name('template'), label='red')
         self.test_template.virt_mode = self.virt_mode
         self.test_template.features.update(self.app.domains[self.template].features)
+        self.test_template.clone_properties(self.app.domains[self.template])
         self.loop.run_until_complete(
             self.test_template.clone_disk_files(self.app.domains[self.template]))
 


### PR DESCRIPTION
This is especially relevant if extra kernel options are necessary - for
example for SELinux, otherwise full relabel will be started (and will
timeout the VM start). But there may be other cases too.