### PR TITLE
reduce default SWIOTLB size when no PCI devs are used

### DIFF
--- a/qubes/config.py
+++ b/qubes/config.py
@@ -52,7 +52,7 @@ defaults = {
     'libvirt_uri': 'xen:///',
     'memory': 400,
     'hvm_memory': 400,
-    'kernelopts': "",
+    'kernelopts': "swiotlb=2048",
     'kernelopts_pcidevs': "",
     'kernelopts_common': ('root=/dev/mapper/dmroot ro nomodeset console=hvc0 '
              'rd_NO_PLYMOUTH rd.plymouth.enable=0 plymouth.enable=0 '),

--- a/qubes/tests/vm/qubesvm.py
+++ b/qubes/tests/vm/qubesvm.py
@@ -1710,6 +1710,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
         # pretend the VM is running...
         vm._qubesprop_xid = 3
         netvm.kernel = None
+        netvm._qubesprop_xid = 4
         test_qubesdb = TestQubesDB()
         mock_qubesdb.write.side_effect = test_qubesdb.write
         mock_qubesdb.rm.side_effect = test_qubesdb.rm
@@ -1855,6 +1856,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
         vm.netvm = None
         vm.guivm = guivm
         vm.is_running = lambda: True
+        vm._qubesprop_xid = 2
         guivm.keyboard_layout = 'fr++'
         guivm.is_running = lambda: True
         guivm._libvirt_domain = unittest.mock.Mock(**{'ID.return_value': 2})
@@ -1905,6 +1907,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
         vm.netvm = None
         vm.audiovm = audiovm
         vm.is_running = lambda: True
+        vm._qubesprop_xid = 2
         audiovm.is_running = lambda: True
         audiovm._libvirt_domain = unittest.mock.Mock(**{'ID.return_value': 2})
         vm.events_enabled = True
@@ -1978,6 +1981,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
         vm.netvm = None
         vm.guivm = guivm
         vm.is_running = lambda: True
+        vm._qubesprop_xid = 2
         guivm.keyboard_layout = 'fr++'
         guivm.is_running = lambda: True
         guivm._libvirt_domain = unittest.mock.Mock(**{'ID.return_value': 2})

--- a/qubes/tests/vm/qubesvm.py
+++ b/qubes/tests/vm/qubesvm.py
@@ -771,7 +771,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <type arch="x86_64" machine="xenpv">linux</type>
             <kernel>/tmp/kernel/vmlinuz</kernel>
             <initrd>/tmp/kernel/initramfs</initrd>
-            <cmdline>root=/dev/mapper/dmroot ro nomodeset console=hvc0 rd_NO_PLYMOUTH rd.plymouth.enable=0 plymouth.enable=0</cmdline>
+            <cmdline>root=/dev/mapper/dmroot ro nomodeset console=hvc0 rd_NO_PLYMOUTH rd.plymouth.enable=0 plymouth.enable=0 swiotlb=2048</cmdline>
         </os>
         <features>
         </features>
@@ -900,7 +900,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <loader type="rom">hvmloader</loader>
             <boot dev="cdrom" />
             <boot dev="hd" />
-            <cmdline>root=/dev/mapper/dmroot ro nomodeset console=hvc0 rd_NO_PLYMOUTH rd.plymouth.enable=0 plymouth.enable=0</cmdline>
+            <cmdline>root=/dev/mapper/dmroot ro nomodeset console=hvc0 rd_NO_PLYMOUTH rd.plymouth.enable=0 plymouth.enable=0 swiotlb=2048</cmdline>
         </os>
         <features>
             <pae/>
@@ -967,7 +967,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <loader type="rom">hvmloader</loader>
             <boot dev="cdrom" />
             <boot dev="hd" />
-            <cmdline>kernel &lt;text&gt;&#39;&#34;&amp; specific options</cmdline>
+            <cmdline>kernel &lt;text&gt;&#39;&#34;&amp; specific options swiotlb=2048</cmdline>
         </os>
         <features>
             <pae/>
@@ -1031,7 +1031,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <type arch="x86_64" machine="xenpvh">xenpvh</type>
             <kernel>/tmp/kernel/vmlinuz</kernel>
             <initrd>/tmp/kernel/initramfs</initrd>
-            <cmdline>root=/dev/mapper/dmroot ro nomodeset console=hvc0 rd_NO_PLYMOUTH rd.plymouth.enable=0 plymouth.enable=0</cmdline>
+            <cmdline>root=/dev/mapper/dmroot ro nomodeset console=hvc0 rd_NO_PLYMOUTH rd.plymouth.enable=0 plymouth.enable=0 swiotlb=2048</cmdline>
         </os>
         <features>
             <pae/>
@@ -1101,7 +1101,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <type arch="x86_64" machine="xenpvh">xenpvh</type>
             <kernel>/tmp/kernel/vmlinuz</kernel>
             <initrd>/tmp/kernel/initramfs</initrd>
-            <cmdline>root=/dev/mapper/dmroot ro nomodeset console=hvc0 rd_NO_PLYMOUTH rd.plymouth.enable=0 plymouth.enable=0</cmdline>
+            <cmdline>root=/dev/mapper/dmroot ro nomodeset console=hvc0 rd_NO_PLYMOUTH rd.plymouth.enable=0 plymouth.enable=0 swiotlb=2048</cmdline>
         </os>
         <features>
             <pae/>
@@ -1340,7 +1340,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <loader type="rom">hvmloader</loader>
             <boot dev="cdrom" />
             <boot dev="hd" />
-            <cmdline>root=/dev/mapper/dmroot ro nomodeset console=hvc0 rd_NO_PLYMOUTH rd.plymouth.enable=0 plymouth.enable=0</cmdline>
+            <cmdline>root=/dev/mapper/dmroot ro nomodeset console=hvc0 rd_NO_PLYMOUTH rd.plymouth.enable=0 plymouth.enable=0 swiotlb=2048</cmdline>
         </os>
         <features>
             <pae/>

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -2270,10 +2270,12 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
 
         # TODO: Currently the whole qmemman is quite Xen-specific, so stay with
         # xenstore for it until decided otherwise
-        if qmemman_present:
+        if qmemman_present and self.maxmem:
+            xs_basedir = f"/local/domain/{self.xid}"
+            self.app.vmm.xs.write('',
+                                  f"{xs_basedir}/memory/meminfo", "")
             self.app.vmm.xs.set_permissions('',
-                                            '/local/domain/{}/memory'.format(
-                                                self.xid),
+                                            f"{xs_basedir}/memory/meminfo",
                                             [{'dom': self.xid}])
 
         self.fire_event('domain-qdb-create')


### PR DESCRIPTION
Linux inside HVM will allocate 64MB for bouncing DMA (SWIOTLB) by default.
If no real PCI device is assigned, that's way too much, and wastes over 15%
of VM's initial memory. With real PCI devices, it's usually too much too,
but it's very device specific, so don't risk breaking it. In other cases,
reduce default to 4MB.

Note PVH domain will not allocate SWIOTLB anyway, as no PCI devices are 
there at all. This difference contributes to the VM start time, so reducing
SWIOTLB should also improve that part.

QubesOS/qubes-issues#6174

Also, include few fixes from #506, to have them merged independently