### PR TITLE
tests: move traceback cleanup to test method wrappers

### DIFF
--- a/qubes/tests/storage_file.py
+++ b/qubes/tests/storage_file.py
@@ -37,6 +37,7 @@ from qubes.config import defaults
 import qubes.storage.file
 import os.path
 _dir = os.path.dirname(__file__)
+sudo = [] if os.getuid() == 0 else ['sudo']
 
 class TestApp(qubes.Qubes):
     ''' A Mock App object '''
@@ -488,7 +489,6 @@ class TC_01_FileVolumes(qubes.tests.QubesTestCase):
         self.assertEqual(len(volume_data), new_size)
 
     def _get_loop_size(self, path):
-        sudo = [] if os.getuid() == 0 else ['sudo']
         try:
             loop_name = subprocess.check_output(
                 sudo + ['losetup', '--associated', path]).decode().split(':')[0]
@@ -505,7 +505,6 @@ class TC_01_FileVolumes(qubes.tests.QubesTestCase):
             return None
 
     def _setup_loop(self, path):
-        sudo = [] if os.getuid() == 0 else ['sudo']
         loop_name = subprocess.check_output(
             sudo + ['losetup', '--show', '--find', path]).decode().strip()
         self.addCleanup(subprocess.call, sudo + ['losetup', '-d', loop_name])
@@ -528,7 +527,6 @@ class TC_01_FileVolumes(qubes.tests.QubesTestCase):
         orig_check_output = subprocess.check_output
         with unittest.mock.patch('subprocess.check_call') as mock_subprocess, \
                 unittest.mock.patch('subprocess.check_output') as mock_check_output:
-            sudo = [] if os.getuid() == 0 else ['sudo']
             mock_subprocess.side_effect = (lambda *args, **kwargs:
                 orig_check_call(sudo + args[0], *args[1:], **kwargs))
             mock_check_output.side_effect = (lambda *args, **kwargs:

--- a/qubes/tests/storage_file.py
+++ b/qubes/tests/storage_file.py
@@ -228,6 +228,11 @@ class TC_01_FileVolumes(qubes.tests.QubesTestCase):
         self.loop.run_until_complete(qubes.utils.coro_maybe(source.create()))
         self.assertFalse(source.is_dirty())
         self.loop.run_until_complete(qubes.utils.coro_maybe(source.start()))
+        # just starting shouldn't report dirty yet, only when it gets modified
+        p = subprocess.Popen(
+            sudo + ["dd", "of=" + source.block_device().path, "status=none"],
+            stdin=subprocess.PIPE)
+        p.communicate(b"test")
         self.assertTrue(source.is_dirty())
         self.loop.run_until_complete(qubes.utils.coro_maybe(volume.create()))
         self.assertFalse(volume.is_dirty())


### PR DESCRIPTION
Python 3.11 changed internal details that cleanup_traceback() relied on.
Move the functionality to wrappers around actual test functions. This
way, it's contained within test class, and doesn't depend on any
specific implementation of test runner.
Wrap those methods dynamically in QubesTestCase.__init__(), to handle
any overriden methods in subclasses too. This avoids needing to use
explicit decorators for every single test method.

This replaces #507