### PR TITLE
Enable SELinux if "selinux" feature is set

### DIFF
--- a/qubes/vm/__init__.py
+++ b/qubes/vm/__init__.py
@@ -368,12 +368,14 @@ class BaseVM(qubes.PropertyHolder):
         '''Create libvirt's XML domain config file
 
         '''
+        def bug(msg, *args):
+            raise AssertionError(msg % args if args else msg)
         domain_config = self.app.env.select_template([
                 'libvirt/xen/by-name/{}.xml'.format(self.name),
                 'libvirt/xen-user.xml',
                 'libvirt/xen-dist.xml',
                 'libvirt/xen.xml',
-            ]).render(vm=self)
+            ]).render(vm=self, bug=bug)
         return domain_config
 
     def watch_qdb_path(self, path):

--- a/templates/libvirt/xen.xml
+++ b/templates/libvirt/xen.xml
@@ -51,6 +51,8 @@
                 <cmdline>{{ vm.kernelopts }}</cmdline>
                 {% elif vm.features.check_with_template('apparmor', '0') == '1' -%}
                 <cmdline>{{ vm.kernelopts_common }}{{ vm.kernelopts }} apparmor=1 security=apparmor</cmdline>
+                {% elif vm.features.check_with_template('selinux', '0') == '1' -%}
+                <cmdline>{{ vm.kernelopts_common }}{{ vm.kernelopts }} selinux=1 security=selinux</cmdline>
                 {% else -%}
                 <cmdline>{{ vm.kernelopts_common }}{{ vm.kernelopts }}</cmdline>
                 {% endif -%}

--- a/templates/libvirt/xen.xml
+++ b/templates/libvirt/xen.xml
@@ -40,9 +40,9 @@
             {% else %}
                 {% if vm.virt_mode == 'pvh' %}
                     <type arch="x86_64" machine="xenpvh">xenpvh</type>
-                {% else %}
+                {% elif vm.virt_mode == 'pv' %}
                     <type arch="x86_64" machine="xenpv">linux</type>
-                {% endif %}
+                {% elif bug("Bad virt mode %r", vm.virt_mode) %}{% endif %}
                 <kernel>{{ vm.storage.kernels_dir }}/vmlinuz</kernel>
                 <initrd>{{ vm.storage.kernels_dir }}/initramfs</initrd>
             {% endif %}


### PR DESCRIPTION
This is necessary for shipping Fedora templates with SELinux by default.