### PR TITLE
Test fixes

### DIFF
--- a/qubes/tests/integ/vm_qrexec_gui.py
+++ b/qubes/tests/integ/vm_qrexec_gui.py
@@ -490,8 +490,6 @@ class TC_00_AppVMMixin(object):
             # wait for possible parecord buffering
             self.loop.run_until_complete(asyncio.sleep(1))
             p.terminate()
-            # for some reason sudo do not relay SIGTERM sent above
-            subprocess.check_call(['pkill', 'parecord'])
             p.wait()
             self.check_audio_sample(recorded_audio.file.read(), sfreq)
 


### PR DESCRIPTION
tests: remove workaround for sudo not forwarding signals

It's fixed in sudo 1.9.13.