### PR TITLE
Require features to start with an ASCII letter

### DIFF
--- a/qubes/api/misc.py
+++ b/qubes/api/misc.py
@@ -58,6 +58,8 @@ class QubesMiscAPI(qubes.api.AbstractQubesAPI):
         safe_set = string.ascii_letters + string.digits + '-._'
         for untrusted_key in untrusted_features:
             untrusted_value = untrusted_features[untrusted_key]
+            self.enforce(untrusted_value)
+            self.enforce(untrusted_value[0] in string.ascii_letters)
             self.enforce(all((c in safe_set) for c in untrusted_value))
 
         await self.src.fire_event_async('features-request',


### PR DESCRIPTION
This prevents any option injection naughtiness.