### PR TITLE
Extension to store features starting with vm-config in qubesdb

### DIFF
--- a/doc/qubes-ext.rst
+++ b/doc/qubes-ext.rst
@@ -18,5 +18,6 @@ Extensions defined here
 .. autoclass:: qubes.ext.pci.PCIDeviceExtension
 .. autoclass:: qubes.ext.r3compatibility.R3Compatibility
 .. autoclass:: qubes.ext.services.ServicesExtension
+.. autoclass:: qubes.ext.vm_config.VMConfig
 
 .. vim: ts=3 sw=3 et

--- a/doc/qubes-features.rst
+++ b/doc/qubes-features.rst
@@ -183,11 +183,24 @@ Services and features can be then inspected from dom0 using
    $ qvm-features my-qube
    supported-service.my-service  1
 
+VM config and passing configuration values to VMs
+-------------------------------------------------
+
+Features that are prefixed with ``vm-config.`` are accessible via qubes-db
+from inside the qube. This is an easy way to pass certain information from
+dom0/gui domain tools to the inside of the qube.
+To read a ``vm-config.feature_name`` feature, use:
+
+.. code-block:: shell
+
+   $ qubesdb-read /vm-config/feature_name
+   value
+
 
 Announcing supported features
 ------------------------------
 
-For non-service features, there is similar announce mechanis to the above, but
+For non-service features, there is similar announce mechanism to the above, but
 uses ``supported-feature.`` prefix. It works like this:
 
 1. The TemplateVM (or StandaloneVM) announces

--- a/qubes/ext/vm_config.py
+++ b/qubes/ext/vm_config.py
@@ -1,0 +1,85 @@
+# -*- encoding: utf-8 -*-
+#
+# The Qubes OS Project, http://www.qubes-os.org
+#
+# Copyright (C) 2017 Marek Marczykowski-Górecki
+#                               <marmarek@invisiblethingslab.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, see <https://www.gnu.org/licenses/>.
+
+"""Extension exposing vm-config features to QubesDB"""
+
+import qubes.ext
+import qubes.config
+
+PREFIX = 'vm-config.'
+
+
+class VMConfig(qubes.ext.Extension):
+    """This extension export features with 'vm-config.' prefix to QubesDB in
+    /vm-config/ tree.
+    """
+
+    @qubes.ext.handler('domain-qdb-create')
+    def on_domain_qdb_create(self, vm, event):
+        """Actually export features"""
+        # pylint: disable=unused-argument
+        for feature, value in vm.features.items():
+            if not feature.startswith(PREFIX):
+                continue
+            config = feature[len(PREFIX):]
+
+            vm.untrusted_qdb.write('/vm-config/{}'.format(config),
+                                   str(value))
+
+    @qubes.ext.handler('domain-feature-set:*')
+    def on_domain_feature_set(self, vm, event, feature, value, oldvalue=None):
+        """Update /vm-config/ QubesDB tree in runtime"""
+        # pylint: disable=unused-argument
+
+        if not feature.startswith(PREFIX):
+            return
+        config = feature[len(PREFIX):]
+        # qubesdb keys are limited to 63 bytes, and "/vm-config/" is
+        # 11 bytes.  That leaves 52 for the config name.
+        if len(config) > 52:
+            raise qubes.exc.QubesValueError(
+                    'VM config name must not exceed 46 bytes')
+        # The empty string is not a valid file name.
+        if not config:
+            raise qubes.exc.QubesValueError('Empty config name not allowed')
+        # Require config names to start with an ASCII letter.  This implicitly
+        # rejects names which start with '-' (which could be interpreted as an
+        # option) or are '.' or '..'.
+        if not (('a' <= config[0] <= 'z') or ('A' <= config[0] <= 'Z')):
+            raise qubes.exc.QubesValueError(
+                    'Config name must start with an ASCII letter')
+
+        if not vm.is_running():
+            return
+
+        vm.untrusted_qdb.write('/vm-config/' + config,
+                               str(value))
+
+    @qubes.ext.handler('domain-feature-delete:*')
+    def on_domain_feature_delete(self, vm, event, feature):
+        """Update /vm-config/ QubesDB tree in runtime"""
+        # pylint: disable=unused-argument
+        if not vm.is_running():
+            return
+        if not feature.startswith(PREFIX):
+            return
+        config = feature[len(PREFIX):]
+
+        vm.untrusted_qdb.rm('/vm-config/{}'.format(config))

--- a/rpm_spec/core-dom0.spec.in
+++ b/rpm_spec/core-dom0.spec.in
@@ -439,6 +439,7 @@ done
 %{python3_sitelib}/qubes/ext/services.py
 %{python3_sitelib}/qubes/ext/supported_features.py
 %{python3_sitelib}/qubes/ext/windows.py
+%{python3_sitelib}/qubes/ext/vm_config.py
 
 %dir %{python3_sitelib}/qubes/tests
 %dir %{python3_sitelib}/qubes/tests/__pycache__

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ if __name__ == '__main__':
                 'qubes.ext.services = qubes.ext.services:ServicesExtension',
                 'qubes.ext.supported_features = qubes.ext.supported_features:SupportedFeaturesExtension',
                 'qubes.ext.windows = qubes.ext.windows:WindowsFeatures',
+                'qubes.ext.vm_config = qubes.ext.vm_config:VMConfig',
             ],
             'qubes.devices': [
                 'pci = qubes.ext.pci:PCIDevice',


### PR DESCRIPTION
Idea: to have a simple way of transmitting certain external (qubes-level) settings to inside a vm.


references https://github.com/QubesOS/qubes-issues/issues/8138