### PR TITLE
Do not try reading "old" property value when loading them from XML

### DIFF
--- a/qubes/__init__.py
+++ b/qubes/__init__.py
@@ -245,8 +245,11 @@ class property:  # pylint: disable=redefined-builtin,invalid-name
             return
 
         try:
-            oldvalue = getattr(instance, self.__name__)
-            has_oldvalue = True
+            if instance.events_enabled:
+                oldvalue = getattr(instance, self.__name__)
+                has_oldvalue = True
+            else:
+                has_oldvalue = False
         except AttributeError:
             has_oldvalue = False
 

--- a/qubes/tests/vm/adminvm.py
+++ b/qubes/tests/vm/adminvm.py
@@ -180,3 +180,6 @@ class TC_00_AdminVM(qubes.tests.QubesTestCase):
             self.assertEqual(exc.exception.returncode, 1)
             self.assertEqual(exc.exception.output, b'stdout')
             self.assertEqual(exc.exception.stderr, b'stderr')
+
+    def test_711_adminvm_ordering(self):
+        assert(self.vm < qubes.vm.qubesvm.QubesVM(self.app, None, qid=1, name="dom0"))

--- a/qubes/tests/vm/qubesvm.py
+++ b/qubes/tests/vm/qubesvm.py
@@ -2284,3 +2284,6 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
 
         property_change(test_vm, "template_for_dispvms", False)
         property_change(test_vm, "template_for_dispvms", True)
+
+    def test_801_ordering(self):
+        assert qubes.vm.qubesvm.QubesVM(self.app, None, qid=1, name="bogus") > qubes.vm.adminvm.AdminVM(self.app, None)

--- a/qubes/vm/adminvm.py
+++ b/qubes/vm/adminvm.py
@@ -29,9 +29,10 @@ import qubes
 import qubes.exc
 import qubes.vm
 from qubes.vm.qubesvm import _setter_kbd_layout
+from qubes.vm import BaseVM
 
 
-class AdminVM(qubes.vm.BaseVM):
+class AdminVM(BaseVM):
     '''Dom0'''
 
     dir_path = None
@@ -82,16 +83,21 @@ class AdminVM(qubes.vm.BaseVM):
     def __str__(self):
         return self.name
 
-    def __lt__(self, other):
+    def __lt__(self, other: object):
+        if not isinstance(other, BaseVM):
+            return NotImplemented
         # order dom0 before anything
-        return self.name != other.name
+        if not isinstance(other, AdminVM):
+            return True
+        assert self is other, "multiple instances of AdminVM?"
+        return False
 
     @property
     def attached_volumes(self):
         return []
 
     @property
-    def xid(self):
+    def xid(self) -> int:
         '''Always ``0``.
 
         .. seealso:

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -40,6 +40,7 @@ import qubes.exc
 import qubes.storage
 import qubes.utils
 import qubes.vm
+import qubes.vm.adminvm
 import qubes.vm.mix.net
 
 qmemman_present = False
@@ -959,6 +960,10 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
         return self.qid
 
     def __lt__(self, other):
+        if not isinstance(other, qubes.vm.BaseVM):
+            return NotImplemented
+        if isinstance(other, qubes.vm.adminvm.AdminVM):
+            return False
         return self.name < other.name
 
     def __xml__(self):


### PR DESCRIPTION
When loading properties from XML, events are disabled. Do not try to 
retrieve old property value that would be used only for sending an event.
Due to dependencies between properties, it may not be possible yet.

Theoretically, some of such issues could be solved by shuffling properties
between load stages, but there are many layers of inter VM dependencies
(TemplateVM->AppVM, netvm, guivm, default_dispvm etc) and solving them all
at once might not be possible in some configurations.

Fixes QubesOS/qubes-issues#6998