### PR TITLE
ext/admin: update parameters for policy-related methods

### DIFF
--- a/qubes/ext/admin.py
+++ b/qubes/ext/admin.py
@@ -25,12 +25,12 @@ from qrexec.policy import utils, parser
 
 
 class JustEvaluateAskResolution(parser.AskResolution):
-    async def execute(self, caller_ident):
+    async def execute(self):
         pass
 
 
 class JustEvaluateAllowResolution(parser.AllowResolution):
-    async def execute(self, caller_ident):
+    async def execute(self):
         pass
 
 


### PR DESCRIPTION
Recently qrexec policy engine was separated from qrexec execution, which
changed the signature of execute() method. Update stubs here too.

QubesOS/qubes-issues#6628