### PR TITLE
reflink: implement `usage_details()`, handle absent pool

### DIFF
--- a/qubes/storage/reflink.py
+++ b/qubes/storage/reflink.py
@@ -125,14 +125,22 @@ class ReflinkPool(qubes.storage.Pool):
         }
 
     @property
+    def usage_details(self):
+        with suppress(FileNotFoundError):
+            stat = os.statvfs(self.dir_path)
+            return {
+                'data_size': stat.f_frsize * stat.f_blocks,
+                'data_usage': stat.f_frsize * (stat.f_blocks - stat.f_bfree),
+            }
+        return {}
+
+    @property
     def size(self):
-        statvfs = os.statvfs(self.dir_path)
-        return statvfs.f_frsize * statvfs.f_blocks
+        return self.usage_details.get('data_size')
 
     @property
     def usage(self):
-        statvfs = os.statvfs(self.dir_path)
-        return statvfs.f_frsize * (statvfs.f_blocks - statvfs.f_bfree)
+        return self.usage_details.get('data_usage')
 
     def included_in(self, app):
         ''' Check if there is pool containing this one - either as a


### PR DESCRIPTION
Not sure if this would completely f*x QubesOS/qubes-issues#8187 and QubesOS/qubes-issues#8188 because I don't have an R4.2 installation at hand to test, and maybe the other storage drivers need to be tweaked as well