### PR TITLE
qubes-hcl-report: include list of certified hardware

### DIFF
--- a/qvm-tools/qubes-hcl-report
+++ b/qvm-tools/qubes-hcl-report
@@ -137,8 +137,10 @@ function shellquote(s) {
 
 in_system_info == 1 && /^\tManufacturer:/ { brand = $2; }
 in_system_info == 1 && /^\tProduct Name:/ { product = $2; }
+in_system_info == 1 && /^\tVersion:/ { product_version = $2; }
 in_base_board_info == 1 && /^\tManufacturer:/ { alt_brand = $2; }
 in_base_board_info == 1 && /^\tProduct Name:/ { alt_product = $2; }
+in_base_board_info == 1 && /^\tVersion:/ { alt_product_version = $2; }
 in_chassis_info == 1 && /^\tType: / { type = substr($0, 8); }
 in_bios_info == 1 && /^\tVersion: / { bios_version = $2; }
 
@@ -175,9 +177,11 @@ END {
   if (brand == "O.E.M") {
     brand = alt_brand;
     product = alt_product;
+    protuct_version = alt_product_version;
   }
   print("BRAND=" shellquote(brand));
   print("PRODUCT=" shellquote(product));
+  print("PRODUCT_VERSION=" shellquote(product_version));
   print("BIOS=" shellquote(bios_version));
   print("TYPE=" shellquote(type));
 }' "$TEMP_DIR/dmidecode") || exit

--- a/qvm-tools/qubes-hcl-report
+++ b/qvm-tools/qubes-hcl-report
@@ -214,6 +214,25 @@ XL_VTD=$(grep virt_caps "$TEMP_DIR/xl-info"|grep hvm_directio)
 XL_HAP=$(grep "$XL_DMESG_PREFIX_REGEX"'HVM: Hardware Assisted Paging (HAP) detected\( but disabled\)\?$' "$TEMP_DIR/xl-dmesg")
 XL_REMAP=$(grep "$XL_DMESG_PREFIX_REGEX"'\(Intel VT-d Interrupt Remapping enabled\|Interrupt remapping enabled\)' "$TEMP_DIR/xl-dmesg")
 
+CERTIFIED=no
+if [ "$BRAND" = "Micro-Star International Co., Ltd." ] && [ "$PRODUCT" = "MS-7D25" ] && [[ "$BIOS" = "Dasharo"* ]]; then
+    # only intel GPU configuration is certified
+    if ! grep -qv "Intel\|^ *$" <<<"$VGA"; then
+        CERTIFIED=yes
+    fi
+elif [ "$BRAND" = "Notebook" ] && [ "$PRODUCT" = "NV4xPZ" ] && [[ "$BIOS" = "Dasharo"* ]]; then
+    # NovaCustom NV41PZ
+    CERTIFIED=yes
+elif [ "$BRAND" = "LENOVO" ] && [ "$PRODUCT_VERSION" = "ThinkPad X230" ] && [[ "$BIOS" = "Heads"* ]]; then
+    # PrivacyBeast X230
+    CERTIFIED=yes
+elif [ "$BRAND" = "LENOVO" ] && [ "$PRODUCT_VERSION" = "ThinkPad X230" ] && [[ "$BIOS" = "CBET4000"* ]]; then
+    # NitroPad X230
+    CERTIFIED=yes
+elif [ "$BRAND" = "LENOVO" ] && [ "$PRODUCT_VERSION" = "ThinkPad X230" ] && [[ "$BIOS" = "CBET4000"* ]]; then
+    # NitroPad T430
+    CERTIFIED=yes
+fi
 
 FILENAME="Qubes-HCL-${BRAND//[^[:alnum:]]/_}-${PRODUCT//[^[:alnum:]]/_}-$DATE"
 
@@ -305,6 +324,7 @@ I/O MMU:\t$VTD
 HAP/SLAT:\t$HAP_VERBOSE
 TPM:\t\t$TPM
 Remapping:\t$REMAP
+Certified:\t$CERTIFIED
 "
 
 YAML_OUTPUT="---
@@ -348,6 +368,8 @@ scsi: |
 $SCSI
 usb: |
   $USB
+certified:
+  '$CERTIFIED'
 versions:
   - works:
       'FIXME:yes|no|partial'

--- a/qvm-tools/qubes-hcl-report
+++ b/qvm-tools/qubes-hcl-report
@@ -108,7 +108,7 @@ xl info > "$TEMP_DIR/xl-info" || exit
 xl dmesg > "$TEMP_DIR/xl-dmesg" || exit
 unset decoded_dmi
 decoded_dmi=$(awk -- 'BEGIN {
-  FS = " "
+  FS = ":"
   in_system_info = 0;
   in_chassis_info = 0;
   in_base_board_info = 0;
@@ -129,14 +129,16 @@ function check_duplicate(k) {
 }
 
 function shellquote(s) {
+  gsub(/^ */, "", s);
+  gsub(/ *$/, "", s);
   gsub(/'\''/, "&\\\\&&", s);
   return ("'\''" s "'\''");
 }
 
 in_system_info == 1 && /^\tManufacturer:/ { brand = $2; }
-in_system_info == 1 && /^\tProduct Name:/ { product = $3; }
+in_system_info == 1 && /^\tProduct Name:/ { product = $2; }
 in_base_board_info == 1 && /^\tManufacturer:/ { alt_brand = $2; }
-in_base_board_info == 1 && /^\tProduct Name:/ { alt_product = $3; }
+in_base_board_info == 1 && /^\tProduct Name:/ { alt_product = $2; }
 in_chassis_info == 1 && /^\tType: / { type = substr($0, 8); }
 in_bios_info == 1 && /^\tVersion: / { bios_version = $2; }
 


### PR DESCRIPTION
This is used for displaying when user is using certified hardware.
Future versions may extend the check for more detailed configurations.