### PR TITLE
Disallow creating qube named 'Domain-0'

### DIFF
--- a/qubes/vm/__init__.py
+++ b/qubes/vm/__init__.py
@@ -59,6 +59,9 @@ def validate_name(holder, prop, value):
                 '{} value contains illegal characters'.format(prop.__name__))
         raise qubes.exc.QubesValueError(
             'VM name contains illegal characters')
+    if value == 'Domain-0':
+        raise qubes.exc.QubesValueError(
+            "VM name cannot be 'Domain-0'")
     if value in ('none', 'default'):
         raise qubes.exc.QubesValueError(
             'VM name cannot be \'none\' nor \'default\'')


### PR DESCRIPTION
libxl refers to dom0 as 'Domain-0' and refuses to start a VM with that name.  Therefore, a qube named 'Domain-0' is useless.  Forbid creating it.