### PR TITLE
Work around Fedora 38 LVM command line parsing bug

### DIFF
--- a/qubes/storage/lvm.py
+++ b/qubes/storage/lvm.py
@@ -769,7 +769,7 @@ def _get_lvm_cmdline(cmd):
     elif action == 'clone':
         assert len(cmd) == 3, 'wrong number of arguments for clone'
         lvm_cmd = ['lvcreate', '--setactivationskip=n', '--activate=y',
-                   '--snapshot', '--type=thin', '--name=' + cmd[2],
+                   '--thin', '--type=thin', '--name=' + cmd[2],
                    '--', cmd[1]]
     elif action == 'create':
         assert len(cmd) == 4, 'wrong number of arguments for create'


### PR DESCRIPTION
Fedora 38's LVM does not accept --snapshot as an argument to vgcreate, but it is possible to have the same effect without --snapshot.

I’m marking this as draft because Qubes OS bundles its own patched version of LVM (which does not have this problem) and I’m not sure I want to make the code harder to understand.