### PR TITLE
Fix suspend issues with 6.3 kernel in VMs

### DIFF
--- a/qubes/tests/vm/qubesvm.py
+++ b/qubes/tests/vm/qubesvm.py
@@ -830,8 +830,6 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <!-- disable nested HVM -->
             <feature name='vmx' policy='disable'/>
             <feature name='svm' policy='disable'/>
-            <!-- let the guest know the TSC is safe to use (no migration) -->
-            <feature name='invtsc' policy='require'/>
         </cpu>
         <os>
             <type arch="x86_64" machine="xenfv">hvm</type>
@@ -887,8 +885,6 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <!-- disable nested HVM -->
             <feature name='vmx' policy='disable'/>
             <feature name='svm' policy='disable'/>
-            <!-- let the guest know the TSC is safe to use (no migration) -->
-            <feature name='invtsc' policy='require'/>
         </cpu>
         <os>
             <type arch="x86_64" machine="xenfv">hvm</type>
@@ -954,8 +950,6 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <!-- disable nested HVM -->
             <feature name='vmx' policy='disable'/>
             <feature name='svm' policy='disable'/>
-            <!-- let the guest know the TSC is safe to use (no migration) -->
-            <feature name='invtsc' policy='require'/>
         </cpu>
         <os>
             <type arch="x86_64" machine="xenfv">hvm</type>
@@ -1024,8 +1018,6 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <!-- disable nested HVM -->
             <feature name='vmx' policy='disable'/>
             <feature name='svm' policy='disable'/>
-            <!-- let the guest know the TSC is safe to use (no migration) -->
-            <feature name='invtsc' policy='require'/>
         </cpu>
         <os>
             <type arch="x86_64" machine="xenpvh">xenpvh</type>
@@ -1094,8 +1086,6 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <!-- disable nested HVM -->
             <feature name='vmx' policy='disable'/>
             <feature name='svm' policy='disable'/>
-            <!-- let the guest know the TSC is safe to use (no migration) -->
-            <feature name='invtsc' policy='require'/>
         </cpu>
         <os>
             <type arch="x86_64" machine="xenpvh">xenpvh</type>
@@ -1165,8 +1155,6 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <!-- disable nested HVM -->
             <feature name='vmx' policy='disable'/>
             <feature name='svm' policy='disable'/>
-            <!-- let the guest know the TSC is safe to use (no migration) -->
-            <feature name='invtsc' policy='require'/>
         </cpu>
         <os>
             <type arch="x86_64" machine="xenfv">hvm</type>
@@ -1246,8 +1234,6 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <!-- disable nested HVM -->
             <feature name='vmx' policy='disable'/>
             <feature name='svm' policy='disable'/>
-            <!-- let the guest know the TSC is safe to use (no migration) -->
-            <feature name='invtsc' policy='require'/>
         </cpu>
         <os>
             <type arch="x86_64" machine="xenfv">hvm</type>
@@ -1327,8 +1313,6 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <!-- disable nested HVM -->
             <feature name='vmx' policy='disable'/>
             <feature name='svm' policy='disable'/>
-            <!-- let the guest know the TSC is safe to use (no migration) -->
-            <feature name='invtsc' policy='require'/>
         </cpu>
         <os>
             <type arch="x86_64" machine="xenfv">hvm</type>
@@ -1429,8 +1413,6 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <!-- disable nested HVM -->
             <feature name='vmx' policy='disable'/>
             <feature name='svm' policy='disable'/>
-            <!-- let the guest know the TSC is safe to use (no migration) -->
-            <feature name='invtsc' policy='require'/>
         </cpu>
         <os>
             <type arch="x86_64" machine="xenfv">hvm</type>
@@ -1503,8 +1485,6 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             <!-- disable nested HVM -->
             <feature name='vmx' policy='disable'/>
             <feature name='svm' policy='disable'/>
-            <!-- let the guest know the TSC is safe to use (no migration) -->
-            <feature name='invtsc' policy='require'/>
         </cpu>
         <os>
             <type arch="x86_64" machine="xenfv">hvm</type>

--- a/templates/libvirt/xen.xml
+++ b/templates/libvirt/xen.xml
@@ -20,8 +20,6 @@
             {% if vm.app.host.cpu_family_model in [(6, 58), (6, 62)] -%}
                 <feature name='rdrand' policy='disable'/>
             {% endif -%}
-            <!-- let the guest know the TSC is safe to use (no migration) -->
-            <feature name='invtsc' policy='require'/>
         </cpu>
     {% endif %}
     {% endblock %}


### PR DESCRIPTION
Using TSC clocksource requires all VMs (not only those with PCI devices)
to be properly suspended when the system goes to sleep, otherwise the
clock after resume may misbehave. Most of the time, Linux recovers by
detecting TSC is not stable anymore and switching back to clocksource
Xen, but when it doesn't, VM may appear to be frozen.

Kernels before 6.3 chosen clocksource TSC anyway (unless explicit
clocksource=tsc was present on the cmdline), but since 6.3, it prefers
TSC if it's advertised as invariant. Specific Linux commit:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=caea091e48ed9d3951506507abf26e9918d08e35

Qubes OS 4.2 does suspend all VMs properly when the host goes to sleep,
but 4.1 does not, so do not advertise TSC as invariant to avoid
clocksource issues with newer kernels.

This reverts commit 8c8c99c07643c996356f4fc12bbe781a31454f93.