### PR TITLE
tests: extend zenity bug workaround

### DIFF
--- a/qubes/tests/integ/basic.py
+++ b/qubes/tests/integ/basic.py
@@ -523,7 +523,7 @@ class TC_30_Gui_daemon(qubes.tests.SystemTestCase):
         self.wait_for_window(window_title)
 
         subprocess.check_call(['xdotool', 'key', '--delay', '100',
-                               'ctrl+shift+v', 'ctrl+v', 'alt+o'])
+                               'ctrl+shift+v', 'ctrl+v', 'Return', 'alt+o'])
         self.loop.run_until_complete(p.wait())
 
         # And compare the result


### PR DESCRIPTION
Depending on the version, alt+o may not work (but Return work). Try
both.

Fixes: 231f2b12 "tests: workaround zenity bug"