### PR TITLE
tests: make spoof_ip test work with only nft - IPv6 flavor

### DIFF
--- a/qubes/tests/integ/dispvm.py
+++ b/qubes/tests/integ/dispvm.py
@@ -162,8 +162,8 @@ class TC_20_DispVMMixin(object):
 
     def setUp(self):
         super(TC_20_DispVMMixin, self).setUp()
-        if 'whonix-gw' in self.template:
-            self.skipTest('whonix-gw is not supported as DisposableVM Template')
+        if 'whonix-g' in self.template:
+            self.skipTest('whonix gateway is not supported as DisposableVM Template')
         self.init_default_template(self.template)
         self.disp_base = self.app.add_new_vm(qubes.vm.appvm.AppVM,
             name=self.make_vm_name('dvm'),

--- a/qubes/tests/integ/dom0_update.py
+++ b/qubes/tests/integ/dom0_update.py
@@ -431,7 +431,7 @@ class TC_10_QvmTemplateMixin(object):
         self.loop.run_until_complete(self.updatevm.create_on_disk())
         self.app.updatevm = self.updatevm
         self.app.save()
-        if self.template.startswith('whonix-gw'):
+        if self.template.startswith('whonix-g'):
             self.loop.run_until_complete(
                 self.whonix_gw_setup_async(self.updatevm))
         else:

--- a/qubes/tests/integ/mime.py
+++ b/qubes/tests/integ/mime.py
@@ -44,7 +44,7 @@ import qubes
 class TC_50_MimeHandlers:
     def setUp(self):
         super(TC_50_MimeHandlers, self).setUp()
-        if self.template.startswith('whonix-gw') or 'minimal' in self.template:
+        if self.template.startswith('whonix-g') or 'minimal' in self.template:
             raise unittest.SkipTest(
                 'Template {} not supported by this test'.format(self.template))
 

--- a/qubes/tests/integ/vm_qrexec_gui.py
+++ b/qubes/tests/integ/vm_qrexec_gui.py
@@ -57,7 +57,7 @@ class TC_00_AppVMMixin(object):
             name=self.make_vm_name('vm2'),
             template=self.app.domains[self.template])
         self.loop.run_until_complete(self.testvm2.create_on_disk())
-        if self.template.startswith('whonix-gw'):
+        if self.template.startswith('whonix-g'):
             # Whonix Gateway loudly complains if the VM doesn't provide network,
             # which spams the screen with error messages that interfere with
             # other tests
@@ -87,8 +87,8 @@ class TC_00_AudioMixin(TC_00_AppVMMixin):
         self.loop.run_until_complete(asyncio.sleep(1))
 
     def prepare_audio_vm(self, backend):
-        if 'whonix-gw' in self.template:
-            self.skipTest('whonix-gw have no audio')
+        if 'whonix-g' in self.template:
+            self.skipTest('whonix gateway have no audio')
         self.loop.run_until_complete(self.testvm1.start())
         pulseaudio_units = 'pulseaudio.socket pulseaudio.service'
         pipewire_units = 'pipewire.socket wireplumber.service pipewire.service'


### PR DESCRIPTION
ip6tables is not installed in debian-12 anymore, so make the test working
with just nft.

QubesOS/qubes-issues#5031