### PR TITLE
tests: handle both whonix-ws and whonix-workstation names

### DIFF
--- a/linux/aux-tools/startup-misc.sh
+++ b/linux/aux-tools/startup-misc.sh
@@ -11,5 +11,9 @@ cp /var/lib/qubes/qubes.xml /var/lib/qubes/backup/qubes-$(date +%F-%T).xml
 
 /usr/lib/qubes/cleanup-dispvms
 
+if [ -e /sys/module/grant_table/parameters/free_per_iteration ]; then
+    echo 1000 > /sys/module/grant_table/parameters/free_per_iteration
+fi
+
 # Hide mounted devices from qubes-block list (at first udev run, only / is mounted)
 udevadm trigger --action=change --subsystem-match=block

--- a/qubes/tests/__init__.py
+++ b/qubes/tests/__init__.py
@@ -833,7 +833,7 @@ class SystemTestCase(QubesTestCase):
             self.skipTest('Default template required for testing networking')
         default_netvm = self.host_app.default_netvm
         # if testing Whonix Workstation based VMs, try to use sys-whonix instead
-        if self.app.default_template.name.startswith('whonix-ws'):
+        if self.app.default_template.name.startswith('whonix-w'):
             if 'sys-whonix' in self.host_app.domains:
                 default_netvm = self.host_app.domains['sys-whonix']
         if default_netvm is None:
@@ -1341,7 +1341,7 @@ class SystemTestCase(QubesTestCase):
 
     async def wait_for_session(self, vm):
         timeout = vm.qrexec_timeout
-        if getattr(vm, 'template', None) and 'whonix-ws' in vm.template.name:
+        if getattr(vm, 'template', None) and 'whonix-w' in vm.template.name:
             # first boot of whonix-ws takes more time because of /home
             # initialization, including Tor Browser copying
             timeout = 120

--- a/qubes/tests/integ/dom0_update.py
+++ b/qubes/tests/integ/dom0_update.py
@@ -419,7 +419,7 @@ class TC_10_QvmTemplateMixin(object):
             self.skipTest(
                 'Template \'{}\' is already installed, '
                 'choose a different one with QUBES_INSTALL_TEST_TEMPLATE variable')
-        if self.template.startswith('whonix-ws'):
+        if self.template.startswith('whonix-w'):
             self.skipTest('Test not supported for this template')
         self.tmpdir = tempfile.mkdtemp()
         self.init_default_template(self.template)


### PR DESCRIPTION
Whonix 17 templates use full whonix-workstation name. Match them both by
whonix-w pattern.

QubesOS/qubes-issues#1778