### PR TITLE
Better error if template does not exist

### DIFF
--- a/qubes/api/admin.py
+++ b/qubes/api/admin.py
@@ -1062,8 +1062,7 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
         if self.arg:
             if hasattr(vm_class, 'template'):
                 if self.arg not in self.app.domains:
-                    raise qubes.api.PermissionDenied(
-                        'Template {} does not exist'.format(self.arg))
+                    raise qubes.exc.QubesVMNotFoundError(self.arg)
                 kwargs['template'] = self.app.domains[self.arg]
             else:
                 raise qubes.exc.QubesValueError(


### PR DESCRIPTION
PermissionDenied results in an unhelpful "Got empty response from qubesd" error.  This should be backported to R4.1 if applicable.