### PR TITLE
Fix libvirt xml syntax for PCI permissive mode

### DIFF
--- a/templates/libvirt/devices/pci.xml
+++ b/templates/libvirt/devices/pci.xml
@@ -2,11 +2,12 @@
 {% if options.get('no-strict-reset', False) %}
  nostrictreset="yes"
 {% endif %}
-{% if options.get('permissive', False) %}
- permissive="yes"
-{% endif %}
 >
-    <source>
+    <source
+{% if options.get('permissive', False) %}
+     writeFiltering="no"
+{% endif %}
+    >
         <address
             bus="0x{{ device.bus }}"
             slot="0x{{ device.device }}"


### PR DESCRIPTION
libvirt since 6.8.0 supports setting permissive flag out of the box
(instead of via qubes local patch), but the attribute name is different.
Adjust XML syntax to match new version.

Fixes QubesOS/qubes-issues#8414