### PR TITLE
Adjust AdminVM.run_service() to use default user

### DIFF
--- a/qubes/tests/integ/qrexec.py
+++ b/qubes/tests/integ/qrexec.py
@@ -836,6 +836,19 @@ class TC_00_QrexecMixin(object):
         self.assertEqual(service_stdout, service_descriptor + b'test1test2',
             'Received data differs from what was expected')
 
+    def test_100_qrexec_service_force_user(self):
+        self.loop.run_until_complete(self.testvm1.start())
+
+        self.create_remote_file(self.testvm1, '/etc/qubes-rpc/test.User',
+            '#!/bin/sh\n/usr/bin/id -u\n')
+        self.create_remote_file(self.testvm1, '/etc/qubes/rpc-config/test.User',
+            'force-user=\'root\'\n')
+
+        stdout, stderr = self.loop.run_until_complete(
+            self.testvm1.run_service_for_stdio('test.User'))
+        self.assertEqual(stdout.strip(), b'0')
+        self.assertEqual(stderr.strip(), b'')
+
 
 def create_testcases_for_templates():
     return qubes.tests.create_testcases_for_templates('TC_00_Qrexec',

--- a/qubes/vm/adminvm.py
+++ b/qubes/vm/adminvm.py
@@ -22,6 +22,7 @@
 
 ''' This module contains the AdminVM implementation '''
 import asyncio
+import grp
 import subprocess
 import libvirt
 
@@ -270,7 +271,12 @@ class AdminVM(BaseVM):
                 'filter_esc=True not supported on calls to dom0')
 
         if user is None:
-            user = 'root'
+            try:
+                qubes_group = grp.getgrnam('qubes')
+                user = qubes_group.gr_mem[0]
+            except KeyError as e:
+                self.log.warning('Default user not found: %s', str(e))
+                user = 'root'
 
         await self.fire_event_async('domain-cmd-pre-run', pre_event=True,
             start_guid=gui)


### PR DESCRIPTION
Be consistent with QubesVM.run_service() and make the default user
normal local user, not root.
This is relevant for appmenus code in desktop-linux-common, which until
now had default user detection open-coded.