### PR TITLE
Partial fix for https://github.com/QubesOS/qubes-issues/issues/6587

### DIFF
--- a/qubes/devices.py
+++ b/qubes/devices.py
@@ -341,8 +341,8 @@ class DeviceCollection:
         :file:`qubes.xml`) or not. Device can also be in :file:`qubes.xml`,
         but be temporarily detached.
 
-        :param Optional[bool] persistent: only include devices which are or are not
-        attached persistently.
+        :param Optional[bool] persistent: only include devices which are or are
+        not attached persistently.
         '''
 
         try:

--- a/qubes/devices.py
+++ b/qubes/devices.py
@@ -333,7 +333,7 @@ class DeviceCollection:
         '''
         return [a.device for a in self._set]
 
-    def assignments(self, persistent=None):
+    def assignments(self, persistent: Optional[bool]=None):
         '''List assignments for devices which are (or may be) attached to the
            vm.
 


### PR DESCRIPTION
This is forward ported version of https://github.com/QubesOS/qubes-core-admin/pull/407

Original description by @v6ak :

Partial fix for https://github.com/QubesOS/qubes-issues/issues/6587

- Persistently assigned block devices no longer reorder. (This does not matter much on its own, as their order in qubes.xml is mostly irelevant, but it is much easier to test, as I can increase the reproduction rate to nearly 100 % by assigning plenty of block devices.)
- PCI devices seem to reorder less frequently. I'd like to investigate this deeper, but this is all I know ATM.
- They are rather conservative – I haven't touched the original method assignments, but rather copied and created a new one. It doesn't seem to be hard to change other occurrences, but I am not sure about testing.
- Tests: works on my machine. I see, it deserves to be better, but I am not sure how to do it properly.
- I believe I have simplified the for cycle of DeviceCollection.assignments_list a bit. If the evolution is not clear, there is some intermediate step: https://gist.github.com/v6ak/23c6b5f84238e314a8a751c8ac6de48d

