### PR TITLE
Add a timeout to qubes-core.service

### DIFF
--- a/linux/systemd/qubes-core.service
+++ b/linux/systemd/qubes-core.service
@@ -9,6 +9,8 @@ StandardOutput=syslog
 RemainAfterExit=yes
 # Needed to avoid rebooting before all VMs have shut down.
 TimeoutStopSec=180
+# To prevent the system from hanging during startup if there is a bug
+TimeoutStartSec=180
 ExecStart=/usr/lib/qubes/startup-misc.sh
 ExecStop=/usr/bin/qvm-shutdown -q --all --wait
 # QubesDB daemons stop after 60s timeout in worst case; speed it up, since no


### PR DESCRIPTION
This ensures that if there is a bug and the service hangs, the user is still able to use the system eventually, rather than having to edit the kernel command line to recover.