### PR TITLE
Fix TypeError during reset of `provides_network`

### DIFF
--- a/qubes/ext/core_features.py
+++ b/qubes/ext/core_features.py
@@ -85,7 +85,7 @@ class CoreFeatures(qubes.ext.Extension):
         self.set_servicevm_feature(subject)
 
     @qubes.ext.handler('property-reset:provides_network')
-    def on_property_reset(self, subject, event, name):
+    def on_property_reset(self, subject, event, name, oldvalue=None):
         # pylint: disable=unused-argument
         self.set_servicevm_feature(subject)
 


### PR DESCRIPTION
Handlers for `property-reset:*` can receive `oldvalue`, which is the case for `provides_network`.

Fixes: https://github.com/QubesOS/qubes-issues/issues/8653