### PR TITLE
Ensure networking packages are not installed

### DIFF
--- a/rpm_spec/core-dom0.spec.in
+++ b/rpm_spec/core-dom0.spec.in
@@ -115,6 +115,14 @@ Provides:	qubes-core-dom0-doc
 Obsoletes:	preupgrade < 2.0
 Provides:	preupgrade = 2.0
 
+# Ensure that systemd-resolved, systemd-networkd, and NetworkManager are not installed
+Conflicts:      systemd-networkd
+Obsoletes:      systemd-networkd
+Conflicts:      systemd-resolved
+Obsoletes:      systemd-resolved
+Conflicts:      NetworkManager
+Obsoletes:      NetworkManager
+
 Source0: %{name}-%{version}.tar.gz
 
 %description


### PR DESCRIPTION
systemd-resolved, systemd-networkd, and NetworkManager are all worse than useless in dom0 and should not be present there.  Ensure that they do not get installed in dom0, and that if a user's system does have them, they are removed.