### PR TITLE
Fix error message if dynamically attached netvm is stopped

### DIFF
--- a/qubes/vm/mix/net.py
+++ b/qubes/vm/mix/net.py
@@ -457,7 +457,7 @@ class NetVMMixin(qubes.events.Emitter):
             if not self.app.vmm.offline_mode \
                     and self.is_running() and not newvalue.is_running():
                 raise qubes.exc.QubesVMNotStartedError(newvalue,
-                    'Cannot dynamically attach to stopped NetVM: {!r}'.format(
+                    'Cannot dynamically attach to stopped qube {!s}'.format(
                         newvalue))
 
         # don't check oldvalue, because it's missing if it was default


### PR DESCRIPTION
The previous format string used the repr() of the requested netvm. This leads to a lengthy and hard to read error message. Just use the requested netvm's name. While changing this string use the opportunity to use 'qube' instead of (Net)VM.