### PR TITLE
Fix error handling of non-positive/non-zero integers

### DIFF
--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -96,7 +96,9 @@ def _setter_positive_int(self, prop, value):
     # pylint: disable=unused-argument
     value = int(value)
     if value <= 0:
-        raise ValueError('Value must be positive')
+        raise qubes.exc.QubesPropertyValueError(
+            self, prop, value,
+            '{!s} must be positive'.format(prop))
     return value
 
 
@@ -105,7 +107,9 @@ def _setter_non_negative_int(self, prop, value):
     # pylint: disable=unused-argument
     value = int(value)
     if value < 0:
-        raise ValueError('Value must be positive or zero')
+        raise qubes.exc.QubesPropertyValueError(
+            self, prop, value,
+            '{!s} must be positive or zero'.format(prop))
     return value
 
 


### PR DESCRIPTION
The property setter helpers for (non-zero) positive integer values previously raised a ValueError for out of range values, which is interpreted later as internal error. But in such cases the user supplied an invalid value so raise a QubesPropertyValueError. The message will then be displayed by qvm-prefs.

Related to QubesOS/qubes-issues#5005