### PR TITLE
Fix error message for non-existing VM passed to a VMProperty

### DIFF
--- a/qubes/vm/__init__.py
+++ b/qubes/vm/__init__.py
@@ -487,7 +487,10 @@ class VMProperty(qubes.property):
         try:
             vm = app.domains[value]
         except KeyError:
-            raise qubes.exc.QubesVMNotFoundError(value)
+            raise qubes.exc.QubesPropertyValueError(instance, self, value,
+                    "Can't set {!s} to non-existing qube {!s}".format(
+                        self,
+                        value))
 
         if not isinstance(vm, self.vmclass):
             raise qubes.exc.QubesPropertyValueError(instance, self, value,


### PR DESCRIPTION
Trying to set a VMProperty (netvm, template, ...) to a non-existing VM previously raised a QubesVMNotFoundError. While this is not wrong qvm-prefs can't distinguish this from other cases (for example see [1]) so instead raise QubesPropertyValueError with a matching error message.

Fixes QubesOS/qubes-issues#6966

[1]: https://github.com/QubesOS/qubes-core-admin-client/blob/e7892560a3a64b924c20dd81bb7f718b5b1c49de/qubesadmin/base.py#L382