### PR TITLE
Remove qvm-* symlinks from core-admin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,13 +179,6 @@ ifeq ($(OS),Linux)
 	$(MAKE) install -C linux/system-config
 endif
 	$(PYTHON) setup.py install -O1 --skip-build --root $(DESTDIR)
-	ln -sf qvm-device $(DESTDIR)/usr/bin/qvm-block
-	ln -sf qvm-device $(DESTDIR)/usr/bin/qvm-pci
-	ln -sf qvm-device $(DESTDIR)/usr/bin/qvm-usb
-	install -d $(DESTDIR)/usr/share/man/man1
-	ln -sf qvm-device.1.gz $(DESTDIR)/usr/share/man/man1/qvm-block.1.gz
-	ln -sf qvm-device.1.gz $(DESTDIR)/usr/share/man/man1/qvm-pci.1.gz
-	ln -sf qvm-device.1.gz $(DESTDIR)/usr/share/man/man1/qvm-usb.1.gz
 	$(MAKE) install -C relaxng
 	mkdir -p $(DESTDIR)/etc/qubes
 ifeq ($(BACKEND_VMM),xen)

--- a/rpm_spec/core-dom0.spec.in
+++ b/rpm_spec/core-dom0.spec.in
@@ -360,7 +360,6 @@ done
 /usr/bin/qubesd*
 
 %{_mandir}/man1/qubes*.1*
-%{_mandir}/man1/qvm-*.1*
 
 %dir %{python3_sitelib}/qubes-*.egg-info
 %{python3_sitelib}/qubes-*.egg-info/*


### PR DESCRIPTION
They are being moved to qubes-core-admin-client (QubesOS/qubes-core-admin-client#269).