### PR TITLE
Support using UUIDs instead of VM names

### DIFF
--- a/qubes/api/internal.py
+++ b/qubes/api/internal.py
@@ -43,6 +43,7 @@ def get_system_info(app):
             'guivm': (domain.guivm.name if getattr(domain, 'guivm', None)
                       else None),
             'power_state': domain.get_power_state(),
+            'uuid': str(domain.uuid),
         } for domain in app.domains
     }}
     return system_info

--- a/qubes/app.py
+++ b/qubes/app.py
@@ -516,6 +516,7 @@ class VMCollection:
 
         if isinstance(key, uuid.UUID):
             for vm in self:
+                assert isinstance(vm.uuid, uuid.UUID)
                 if vm.uuid == key:
                     return vm
             raise KeyError(key)
@@ -540,7 +541,7 @@ class VMCollection:
         self.app.fire_event('domain-delete', vm=vm)
 
     def __contains__(self, key):
-        return any((key in (vm, vm.qid, vm.name))
+        return any((key in (vm, vm.qid, vm.name, vm.uuid))
                    for vm in self)
 
     def __len__(self):

--- a/qubes/exc.py
+++ b/qubes/exc.py
@@ -37,6 +37,14 @@ class QubesVMNotFoundError(QubesException, KeyError):
         # KeyError overrides __str__ method
         return QubesException.__str__(self)
 
+class QubesVMInvalidUUIDError(QubesException):
+    """Domain UUID is invalid"""
+    # pylint: disable = super-init-not-called
+    def __init__(self, uuid: str) -> None:
+        # QubesVMNotFoundError overrides __init__ method
+        # pylint: disable = non-parent-init-called
+        QubesException.__init__(self, f"VM UUID is not valid: {uuid!r}")
+        self.vmname = uuid
 
 class QubesVMError(QubesException):
     '''Some problem with domain state.'''

--- a/qubes/tests/api_internal.py
+++ b/qubes/tests/api_internal.py
@@ -23,12 +23,15 @@ import qubes.tests
 import qubes.vm.adminvm
 from unittest import mock
 import json
+import uuid
 
 def mock_coro(f):
     async def coro_f(*args, **kwargs):
         return f(*args, **kwargs)
 
     return coro_f
+
+TEST_UUID = uuid.UUID("50c7dad4-5f1e-4586-9f6a-bf10a86ba6f0")
 
 class TC_00_API_Misc(qubes.tests.QubesTestCase):
     def setUp(self):
@@ -150,6 +153,7 @@ class TC_00_API_Misc(qubes.tests.QubesTestCase):
         self.dom0.template_for_dispvms = False
         self.dom0.label.icon = 'icon-dom0'
         self.dom0.get_power_state.return_value = 'Running'
+        self.dom0.uuid = uuid.UUID("00000000-0000-0000-0000-000000000000")
         del self.dom0.guivm
 
         vm = mock.NonCallableMock(spec=qubes.vm.qubesvm.QubesVM)
@@ -160,6 +164,7 @@ class TC_00_API_Misc(qubes.tests.QubesTestCase):
         vm.label.icon = 'icon-vm'
         vm.guivm = vm
         vm.get_power_state.return_value = 'Halted'
+        vm.uuid = TEST_UUID
         self.domains['vm'] = vm
 
         ret = json.loads(self.call_mgmt_func(b'internal.GetSystemInfo'))
@@ -173,6 +178,7 @@ class TC_00_API_Misc(qubes.tests.QubesTestCase):
                     'icon': 'icon-dom0',
                     'guivm': None,
                     'power_state': 'Running',
+                    'uuid': "00000000-0000-0000-0000-000000000000",
                 },
                 'vm': {
                     'tags': ['tag3', 'tag4'],
@@ -182,6 +188,7 @@ class TC_00_API_Misc(qubes.tests.QubesTestCase):
                     'icon': 'icon-vm',
                     'guivm': 'vm',
                     'power_state': 'Halted',
+                    "uuid": str(TEST_UUID),
                 }
             }
         })

--- a/qubes/vm/adminvm.py
+++ b/qubes/vm/adminvm.py
@@ -25,6 +25,7 @@ import asyncio
 import grp
 import subprocess
 import libvirt
+import uuid
 
 import qubes
 import qubes.exc
@@ -45,7 +46,7 @@ class AdminVM(BaseVM):
         default=0, type=int, setter=qubes.property.forbidden)
 
     uuid = qubes.property('uuid',
-        default='00000000-0000-0000-0000-000000000000',
+        default=uuid.UUID('00000000-0000-0000-0000-000000000000'),
         setter=qubes.property.forbidden)
 
     default_dispvm = qubes.VMProperty('default_dispvm',

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -61,6 +61,7 @@ except ImportError:
 MEM_OVERHEAD_BASE = (3 + 1) * 1024 * 1024
 MEM_OVERHEAD_PER_VCPU = 3 * 1024 * 1024 / 2
 
+_vm_uuid_re = re.compile(rb"\A/vm/[0-9a-f]{8}(?:-[0-9a-f]{4}){4}[0-9a-f]{8}\Z")
 
 def _setter_kernel(self, prop, value):
     """ Helper for setting the domain kernel and running sanity checks on it.
@@ -800,6 +801,17 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
             self.log.exception('libvirt error code: {!r}'.format(
                 e.get_error_code()))
             raise
+
+    @qubes.stateless_property
+    def stubdom_uuid(self):
+        stubdom_xid = self.stubdom_xid
+        if stubdom_xid == -1:
+            return ""
+        stubdom_uuid = self.app.vmm.xs.read(
+            '', '/local/domain/{}/vm'.format(
+                stubdom_xid))
+        assert _vm_uuid_re.match(stubdom_uuid), "Invalid UUID in XenStore"
+        return stubdom_uuid[4:].decode("ascii", "strict")
 
     @qubes.stateless_property
     def stubdom_xid(self):
@@ -1807,9 +1819,11 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
 
         self.log.debug('Starting the qrexec daemon')
         if stubdom:
-            qrexec_args = [str(self.stubdom_xid), self.name + '-dm', 'root']
+            qrexec_args = ["-u", self.stubdom_uuid, "--",
+                           str(self.stubdom_xid), self.name + '-dm', 'root']
         else:
-            qrexec_args = [str(self.xid), self.name, self.default_user]
+            qrexec_args = ["-u", str(self.uuid), "--",
+                           str(self.xid), self.name, self.default_user]
 
         if not self.debug:
             qrexec_args.insert(0, "-q")


### PR DESCRIPTION
This supports using UUIDs (instead of VM names) in the Admin API.  It also provides the UUIDs to qrexec-policy-daemon, which will use them to support the `@uuid:` keyword.

All admin APIs now support UUIDs as source and destination.  Specific APIs changed include:

- `admin.vm.CreateDisposable`: if the "uuid" argument is used, the VM UUID is returned instead of the name.
- `admin.vm.List`: the UUID is included in the returned list.
- `internal.GetSystemInfo`: the UUID is returned in the `uuid` key of each VM's JSON object.

Fixes: QubesOS/qubes-issues#8862