### PR TITLE
Use systemd units for qubesd-spawned daemons

### DIFF
--- a/linux/systemd/qubesd.service
+++ b/linux/systemd/qubesd.service
@@ -6,7 +6,6 @@ Before=systemd-user-sessions.service
 Type=notify
 ExecStart=/usr/bin/qubesd
 StandardOutput=syslog
-KillMode=process
 Restart=on-failure
 RestartSec=1s
 


### PR DESCRIPTION
This allows systemd to properly track processes spawned by qubesd and ensures they are in a proper systemd login session.