### PR TITLE
Enable S0ix workarounds with one knob

### DIFF
--- a/linux/aux-tools/startup-misc.sh
+++ b/linux/aux-tools/startup-misc.sh
@@ -17,3 +17,37 @@ fi
 
 # Hide mounted devices from qubes-block list (at first udev run, only / is mounted)
 udevadm trigger --action=change --subsystem-match=block
+
+bind_to_pciback() {
+    local sbdf="$1"
+
+    if [ -e "/sys/bus/pci/devices/$sbdf/driver" ]; then
+        echo "$sbdf" > "/sys/bus/pci/devices/$sbdf/driver/unbind"
+    fi
+    echo "$sbdf" > /sys/bus/pci/drivers/pciback/new_slot
+    echo "$sbdf" > /sys/bus/pci/drivers/pciback/bind
+}
+
+if [ -n "$(qvm-features dom0 suspend-s0ix)" ]; then
+    # assign thunderbolt root ports to pciback as workaround for suspend
+    # issue without PCI hotplut enabled, see
+    # https://github.com/QubesOS/qubes-linux-kernel/pull/903 for details
+    for dev in /sys/bus/pci/devices/0000:00:*; do
+        [ -h "$dev" ] || continue
+        sbdf=$(basename "$dev")
+        read -r dev_class < "$dev/class"
+        # PCIe bridge
+        if [ "$dev_class" = "0x060400" ]; then
+            # There seems to be no property saying it's thunderbolt other than product id...
+            lspci -s "$sbdf" | grep -q Thunderbolt || continue
+
+            bind_to_pciback "$sbdf"
+            echo "$sbdf" > /sys/bus/pci/drivers/pciback/qubes_exp_pm_suspend
+            echo "$sbdf" > /sys/bus/pci/drivers/pciback/qubes_exp_pm_suspend_force
+        elif [ "$dev_class" = "0x0c0340" ]; then
+            # Thunderbolt 4 NIH device
+            bind_to_pciback "$sbdf"
+            echo "$sbdf" > /sys/bus/pci/drivers/pciback/qubes_exp_pm_suspend
+        fi
+    done
+fi

--- a/qubes/ext/pci.py
+++ b/qubes/ext/pci.py
@@ -257,7 +257,9 @@ class PCIDeviceExtension(qubes.ext.Extension):
             self.bind_pci_to_pciback(vm.app, device)
             vm.libvirt_domain.attachDevice(
                 vm.app.env.get_template('libvirt/devices/pci.xml').render(
-                    device=device, vm=vm, options=options))
+                    device=device, vm=vm, options=options,
+                    power_mgmt=vm.app.domains[0].features.get(
+                        'suspend-s0ix', False)))
         except subprocess.CalledProcessError as e:
             vm.log.exception('Failed to attach PCI device {!r} on the fly,'
                 ' changes will be seen after VM restart.'.format(
@@ -290,7 +292,9 @@ class PCIDeviceExtension(qubes.ext.Extension):
                 user='root', input='00:{}'.format(vmdev))
             vm.libvirt_domain.detachDevice(
                 vm.app.env.get_template('libvirt/devices/pci.xml').render(
-                    device=device, vm=vm))
+                    device=device, vm=vm,
+                    power_mgmt=vm.app.domains[0].features.get(
+                        'suspend-s0ix', False)))
         except (subprocess.CalledProcessError, libvirt.libvirtError) as e:
             vm.log.exception('Failed to detach PCI device {!r} on the fly,'
                 ' changes will be seen after VM restart.'.format(

--- a/qubes/tests/vm/qubesvm.py
+++ b/qubes/tests/vm/qubesvm.py
@@ -1224,6 +1224,91 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
         my_uuid = '7db78950-c467-4863-94d1-af59806384ea'
         # required for PCI devices listing
         self.app.vmm.offline_mode = False
+        dom0 = self.get_vm(name='dom0', qid=0)
+        vm = self.get_vm(uuid=my_uuid)
+        vm.netvm = None
+        vm.virt_mode = 'hvm'
+        vm.kernel = None
+        # even with meminfo-writer enabled, should have memory==maxmem
+        vm.features['service.meminfo-writer'] = True
+        assignment = qubes.devices.DeviceAssignment(
+            vm,  # this is violation of API, but for PCI the argument
+            #  is unused
+            '00_00.0',
+            bus='pci',
+            persistent=True)
+        vm.devices['pci']._set.add(
+            assignment)
+        libvirt_xml = vm.create_config_file()
+        self.assertXMLEqual(lxml.etree.XML(libvirt_xml),
+            lxml.etree.XML(expected))
+
+    def test_600_libvirt_xml_hvm_pcidev_s0ix(self):
+        expected = '''<domain type="xen">
+        <name>test-inst-test</name>
+        <uuid>7db78950-c467-4863-94d1-af59806384ea</uuid>
+        <memory unit="MiB">400</memory>
+        <currentMemory unit="MiB">400</currentMemory>
+        <vcpu placement="static">2</vcpu>
+        <cpu mode='host-passthrough'>
+            <!-- disable nested HVM -->
+            <feature name='vmx' policy='disable'/>
+            <feature name='svm' policy='disable'/>
+            <!-- let the guest know the TSC is safe to use (no migration) -->
+            <feature name='invtsc' policy='require'/>
+        </cpu>
+        <os>
+            <type arch="x86_64" machine="xenfv">hvm</type>
+                <!--
+                     For the libxl backend libvirt switches between OVMF (UEFI)
+                     and SeaBIOS based on the loader type. This has nothing to
+                     do with the hvmloader binary.
+                -->
+            <loader type="rom">hvmloader</loader>
+            <boot dev="cdrom" />
+            <boot dev="hd" />
+        </os>
+        <features>
+            <pae/>
+            <acpi/>
+            <apic/>
+            <viridian/>
+            <xen>
+                <e820_host state="on"/>
+            </xen>
+        </features>
+        <clock offset="variable" adjustment="0" basis="utc" />
+        <on_poweroff>destroy</on_poweroff>
+        <on_reboot>destroy</on_reboot>
+        <on_crash>destroy</on_crash>
+        <devices>
+            <hostdev type="pci" managed="yes">
+                <source
+                    powerManagementFiltering="no">
+                    <address
+                        bus="0x00"
+                        slot="0x00"
+                        function="0x0" />
+                </source>
+            </hostdev>
+            <!-- server_ip is the address of stubdomain. It hosts it's own DNS server. -->
+            <emulator type="stubdom-linux" />
+            <input type="tablet" bus="usb"/>
+            <video>
+                <model type="vga"/>
+            </video>
+            <graphics type="qubes"/>
+            <console type="pty">
+                <target type="xen" port="0"/>
+            </console>
+        </devices>
+        </domain>
+        '''
+        my_uuid = '7db78950-c467-4863-94d1-af59806384ea'
+        # required for PCI devices listing
+        self.app.vmm.offline_mode = False
+        dom0 = self.get_vm(name='dom0', qid=0)
+        dom0.features['suspend-s0ix'] = True
         vm = self.get_vm(uuid=my_uuid)
         vm.netvm = None
         vm.virt_mode = 'hvm'

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -229,8 +229,11 @@ def _default_kernelopts(self):
             qubes.config.system_path['qubes_kernels_base_dir'],
             self.kernel)
     pci = bool(list(self.devices['pci'].persistent()))
+    extra_opts = ""
     if pci:
         path = os.path.join(kernels_dir, 'default-kernelopts-pci.txt')
+        if self.app.domains[0].features.get('suspend-s0ix', False):
+            extra_opts = " qubes_exp_pm_use_suspend=1"
     else:
         try:
             return self.template.kernelopts
@@ -239,10 +242,10 @@ def _default_kernelopts(self):
         path = os.path.join(kernels_dir, 'default-kernelopts-nopci.txt')
     if os.path.exists(path):
         with open(path, encoding='ascii') as f_kernelopts:
-            return f_kernelopts.read().strip()
+            return f_kernelopts.read().strip() + extra_opts
     else:
         return (qubes.config.defaults['kernelopts_pcidevs'] if pci else
-                qubes.config.defaults['kernelopts'])
+                qubes.config.defaults['kernelopts']) + extra_opts
 
 
 class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):

--- a/templates/libvirt/devices/pci.xml
+++ b/templates/libvirt/devices/pci.xml
@@ -7,6 +7,9 @@
 {% if options.get('permissive', False) %}
      writeFiltering="no"
 {% endif %}
+{% if power_mgmt %}
+     powerManagementFiltering="no"
+{% endif %}
     >
         <address
             bus="0x{{ device.bus }}"

--- a/templates/libvirt/xen.xml
+++ b/templates/libvirt/xen.xml
@@ -162,6 +162,8 @@
             {% for assignment in vm.devices.pci.assignments(True) %}
                 {% set device = assignment.device %}
                 {% set options = assignment.options %}
+                {% set power_mgmt =
+                    vm.app.domains[0].features.get('suspend-s0ix', False) %}
                 {% include 'libvirt/devices/pci.xml' %}
             {% endfor %}
 


### PR DESCRIPTION
To enable all S0ix parts, do one single:

    qvm-features dom0 suspend-s0ix 1

It will enable "suspend" instead of "freeze" suspend mode of PCI-having
VMs (sys-net, sys-usb), and also assign thunderbolt controllers to
pciback which will force suspending them.

QubesOS/qubes-issues#6411