### PR TITLE
tests: use pactl to switch source-outputs

### DIFF
--- a/qubes/tests/integ/salt.py
+++ b/qubes/tests/integ/salt.py
@@ -467,7 +467,7 @@ class SaltVMTestMixin(SaltTestMixin):
         self.assertEqual(stderr, b'')
 
     @unittest.expectedFailure
-    def test_002_granns_id(self):
+    def test_002_grains_id(self):
         vmname = self.make_vm_name('target')
         tplname = self.make_vm_name('tpl')
         self.test_template = self.app.add_new_vm('TemplateVM',
@@ -503,6 +503,7 @@ class SaltVMTestMixin(SaltTestMixin):
         self.assertTrue(tpl_output.startswith(tplname + ':\n'),
             'Full output: ' + state_output)
         tpl_output = tpl_output[len(tplname + ':\n'):].strip()
+        appvm_output = appvm_output.strip()
 
         for name, output in ((tplname, tpl_output), (vmname, appvm_output)):
             # skip trailing junk to workaround

--- a/qubes/tests/integ/vm_qrexec_gui.py
+++ b/qubes/tests/integ/vm_qrexec_gui.py
@@ -224,7 +224,7 @@ class TC_00_AudioMixin(TC_00_AppVMMixin):
         self.loop.run_until_complete(asyncio.sleep(2))
         if record.returncode is not None:
             self.fail("Recording process ended prematurely: exit code {}, stderr: {}".format(
-                      record.returncode, record.stderr.read()))
+                      record.returncode, self.loop.run_until_complete(record.stderr.read())))
         try:
             self.loop.run_until_complete(
                 self.testvm1.run_for_stdio(kill_cmd))
@@ -268,7 +268,7 @@ class TC_00_AudioMixin(TC_00_AppVMMixin):
         self.loop.run_until_complete(asyncio.sleep(2))
         if record.returncode is not None:
             self.fail("Recording process ended prematurely: exit code {}, stderr: {}".format(
-                      record.returncode, record.stderr.read()))
+                      record.returncode, self.loop.run_until_complete(record.stderr.read())))
         try:
             self.loop.run_until_complete(self.testvm1.run_for_stdio(kill_cmd))
         except subprocess.CalledProcessError:

--- a/qubes/tests/integ/vm_qrexec_gui.py
+++ b/qubes/tests/integ/vm_qrexec_gui.py
@@ -152,9 +152,8 @@ class TC_00_AudioMixin(TC_00_AppVMMixin):
                    '--raw audio_in.snd')
         with tempfile.NamedTemporaryFile() as recorded_audio:
             os.chmod(recorded_audio.name, 0o666)
-            # FIXME: -d 0 assumes only one audio device
             p = subprocess.Popen(['sudo', '-E', '-u', local_user,
-                'parecord', '-d', '0', '--raw',
+                'parecord', '-d', '@DEFAULT_MONITOR@', '--raw',
                 '--format=float32le', '--rate=44100', '--channels=1',
                 recorded_audio.name], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             try:

--- a/qubes/tests/integ/vm_qrexec_gui.py
+++ b/qubes/tests/integ/vm_qrexec_gui.py
@@ -340,6 +340,11 @@ class TC_20_AudioVM_Pulse(TC_00_AudioMixin):
         self.testvm1.virt_mode = 'hvm'
         self.testvm1.features['audio-model'] = 'ich6'
         self.prepare_audio_vm('pulseaudio')
+        pa_info = self.loop.run_until_complete(
+            self.testvm1.run_for_stdio("pactl info"))[0]
+        # Server Name: PulseAudio (on PipeWire 0.3.65)
+        if b"on PipeWire 0.3." in pa_info:
+            self.skipTest("Known-buggy pipewire runs inside VM")
         try:
             sinks = self.loop.run_until_complete(
                 self.testvm1.run_for_stdio("pactl -f json list sinks"))[0]


### PR DESCRIPTION
pacmd does not work with PipeWire, but pactl does.

QubesOS/qubes-issues#8955