### PR TITLE
tests: add audiovm and its dynamic switching test

### DIFF
--- a/qubes/ext/admin.py
+++ b/qubes/ext/admin.py
@@ -69,6 +69,10 @@ class AdminExtension(qubes.ext.Extension):
             # dom0 can always list everything
             return None
 
+        if not hasattr(vm, 'app'):
+            # process cleanup, do not allow listing VMs anymore
+            return ((lambda _vm: False),)
+
         policy = self.policy_cache.get_policy()
         system_info = qubes.api.internal.get_system_info(vm.app)
 
@@ -113,6 +117,10 @@ class AdminExtension(qubes.ext.Extension):
                     dest = kwargs['vm'].name
                 else:
                     dest = '@adminvm'
+
+            if not hasattr(vm, 'app'):
+                # process cleanup, do not send events anymore
+                return False
 
             policy = self.policy_cache.get_policy()
             # TODO: cache system_info (based on last qubes.xml write time?)

--- a/qubes/ext/audio.py
+++ b/qubes/ext/audio.py
@@ -32,7 +32,7 @@ class AUDIO(qubes.ext.Extension):
     @staticmethod
     def set_qubesdb_audiovm(vm):
         # Ensure that qube is ready
-        if not vm.untrusted_qdb:
+        if not vm.is_running():
             return
 
         # Add AudioVM Xen ID for gui-agent

--- a/qubes/ext/audio.py
+++ b/qubes/ext/audio.py
@@ -26,6 +26,8 @@ class AUDIO(qubes.ext.Extension):
     @staticmethod
     def attached_vms(vm):
         for domain in vm.app.domains:
+            if domain == vm:
+                continue
             if getattr(domain, "audiovm", None) == vm:
                 yield domain
 

--- a/qubes/tests/__init__.py
+++ b/qubes/tests/__init__.py
@@ -1012,6 +1012,8 @@ class SystemTestCase(QubesTestCase):
             vm.default_dispvm = None
             vm.netvm = None
             vm.management_dispvm = None
+            vm.guivm = None
+            vm.audiovm = None
         # take app instance from any VM to be removed
         app = vms[0].app
         if app.default_dispvm in vms:
@@ -1020,6 +1022,10 @@ class SystemTestCase(QubesTestCase):
             app.default_netvm = None
         if app.management_dispvm in vms:
             app.management_dispvm = None
+        if app.default_audiovm in vms:
+            app.default_audiovm = None
+        if app.default_guivm in vms:
+            app.default_guivm = None
         del app
         # then remove in reverse topological order (wrt template), using naive
         # algorithm

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -1333,6 +1333,7 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
         except qubes.storage.StoragePoolException:
             self.log.exception('Failed to stop storage for domain %s',
                                self.name)
+        self._qdb_connection = None
         self.fire_event('property-reset:xid', name='xid')
         self.fire_event('property-reset:stubdom_xid', name='stubdom_xid')
         self.fire_event('property-reset:start_time', name='start_time')


### PR DESCRIPTION
Besides new tests, rename "prepare_audio_vm" to "prepare_audio_test" to
avoid confusion with "audiovm".

QubesOS/qubes-issues#8975
Fixes https://github.com/QubesOS/qubes-issues/issues/9127