### PR TITLE
Improve checking for memory hotplug support and ease pvgrub usage

### DIFF
--- a/qubes/storage/kernels.py
+++ b/qubes/storage/kernels.py
@@ -137,7 +137,6 @@ class LinuxModules(Volume):
     def verify(self):  # pylint: disable=invalid-overridden-method
         if self.vid:
             _check_path(self.vmlinuz)
-            _check_path(self.initramfs)
 
     def block_device(self):
         path = self.path

--- a/qubes/tests/vm/qubesvm.py
+++ b/qubes/tests/vm/qubesvm.py
@@ -502,20 +502,21 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
         vm = self.get_vm()
         self._test_generic_bool_property(vm, 'include_in_backups', True)
 
-    @qubes.tests.skipUnlessDom0
+    @unittest.mock.patch('qubes.config.qubes_base_dir', '/tmp/qubes-test')
     def test_250_kernel(self):
-        kernels = os.listdir(os.path.join(
-            qubes.config.qubes_base_dir,
-            qubes.config.system_path['qubes_kernels_base_dir']))
-        if not len(kernels):
-            self.skipTest('Needs at least one kernel installed')
-        self.app.default_kernel = kernels[0]
+        for kver in ("dummy", "dummy2"):
+            kernel_dir = '/tmp/qubes-test/vm-kernels/' + kver
+            os.makedirs(kernel_dir, exist_ok=True)
+            open(os.path.join(kernel_dir, 'vmlinuz'), 'w').close()
+            open(os.path.join(kernel_dir, 'initramfs'), 'w').close()
+        self.addCleanup(shutil.rmtree, '/tmp/qubes-test')
+        self.app.default_kernel = "dummy"
         vm = self.get_vm()
-        self.assertPropertyDefaultValue(vm, 'kernel', kernels[0])
-        self.assertPropertyValue(vm, 'kernel', kernels[-1], kernels[-1],
-            kernels[-1])
+        self.assertPropertyDefaultValue(vm, 'kernel', "dummy")
+        self.assertPropertyValue(vm, 'kernel', "dummy2", "dummy2",
+            "dummy2")
         del vm.kernel
-        self.assertPropertyDefaultValue(vm, 'kernel', kernels[0])
+        self.assertPropertyDefaultValue(vm, 'kernel', "dummy")
 
     @qubes.tests.skipUnlessDom0
     def test_251_kernel_invalid(self):

--- a/qubes/tests/vm/qubesvm.py
+++ b/qubes/tests/vm/qubesvm.py
@@ -773,8 +773,8 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
         <vcpu placement="static">2</vcpu>
         <os>
             <type arch="x86_64" machine="xenpv">linux</type>
-            <kernel>/tmp/kernel/vmlinuz</kernel>
-            <initrd>/tmp/kernel/initramfs</initrd>
+            <kernel>/tmp/qubes-test/vm-kernels/dummy/vmlinuz</kernel>
+            <initrd>/tmp/qubes-test/vm-kernels/dummy/initramfs</initrd>
             <cmdline>root=/dev/mapper/dmroot ro nomodeset console=hvc0 rd_NO_PLYMOUTH rd.plymouth.enable=0 plymouth.enable=0 swiotlb=2048</cmdline>
         </os>
         <features>
@@ -788,7 +788,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
         <devices>
             <disk type="block" device="disk">
                 <driver name="phy" />
-                <source dev="/tmp/kernel/modules.img" />
+                <source dev="/tmp/qubes-test/vm-kernels/dummy/modules.img" />
                 <target dev="xvdd" />
                 <backenddomain name="dom0" />
                 <script path="/etc/xen/scripts/qubes-block" />
@@ -811,16 +811,16 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             open(os.path.join(kernel_dir, 'initramfs'), 'w').close()
             self.addCleanup(shutil.rmtree, '/tmp/qubes-test')
             vm.kernel = 'dummy'
-        # tests for storage are later
-        vm.volumes['kernel'] = unittest.mock.Mock(**{
-            'kernels_dir': '/tmp/kernel',
-            'block_device.return_value.domain': 'dom0',
-            'block_device.return_value.path': '/tmp/kernel/modules.img',
-            'block_device.return_value.devtype': 'disk',
-            'block_device.return_value.name': 'kernel',
-            'ephemeral': False,
-        })
-        libvirt_xml = vm.create_config_file()
+            # tests for storage are later
+            vm.volumes['kernel'] = unittest.mock.Mock(**{
+                'kernels_dir': '/tmp/qubes-test/vm-kernels/dummy',
+                'block_device.return_value.domain': 'dom0',
+                'block_device.return_value.path': '/tmp/qubes-test/vm-kernels/dummy/modules.img',
+                'block_device.return_value.devtype': 'disk',
+                'block_device.return_value.name': 'kernel',
+                'ephemeral': False,
+            })
+            libvirt_xml = vm.create_config_file()
         self.assertXMLEqual(lxml.etree.XML(libvirt_xml),
             lxml.etree.XML(expected))
 
@@ -1034,8 +1034,8 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
         </cpu>
         <os>
             <type arch="x86_64" machine="xenpvh">xenpvh</type>
-            <kernel>/tmp/kernel/vmlinuz</kernel>
-            <initrd>/tmp/kernel/initramfs</initrd>
+            <kernel>/tmp/qubes-test/vm-kernels/dummy/vmlinuz</kernel>
+            <initrd>/tmp/qubes-test/vm-kernels/dummy/initramfs</initrd>
             <cmdline>root=/dev/mapper/dmroot ro nomodeset console=hvc0 rd_NO_PLYMOUTH rd.plymouth.enable=0 plymouth.enable=0 swiotlb=2048</cmdline>
         </os>
         <features>
@@ -1053,7 +1053,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
         <devices>
             <disk type="block" device="disk">
                 <driver name="phy" />
-                <source dev="/tmp/kernel/modules.img" />
+                <source dev="/tmp/qubes-test/vm-kernels/dummy/modules.img" />
                 <target dev="xvdd" />
                 <backenddomain name="dom0" />
                 <script path="/etc/xen/scripts/qubes-block" />
@@ -1076,16 +1076,16 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             open(os.path.join(kernel_dir, 'initramfs'), 'w').close()
             self.addCleanup(shutil.rmtree, '/tmp/qubes-test')
             vm.kernel = 'dummy'
-        # tests for storage are later
-        vm.volumes['kernel'] = unittest.mock.Mock(**{
-            'kernels_dir': '/tmp/kernel',
-            'block_device.return_value.domain': 'dom0',
-            'block_device.return_value.path': '/tmp/kernel/modules.img',
-            'block_device.return_value.devtype': 'disk',
-            'block_device.return_value.name': 'kernel',
-            'ephemeral': False,
-        })
-        libvirt_xml = vm.create_config_file()
+            # tests for storage are later
+            vm.volumes['kernel'] = unittest.mock.Mock(**{
+                'kernels_dir': '/tmp/qubes-test/vm-kernels/dummy',
+                'block_device.return_value.domain': 'dom0',
+                'block_device.return_value.path': '/tmp/qubes-test/vm-kernels/dummy/modules.img',
+                'block_device.return_value.devtype': 'disk',
+                'block_device.return_value.name': 'kernel',
+                'ephemeral': False,
+            })
+            libvirt_xml = vm.create_config_file()
         self.assertXMLEqual(lxml.etree.XML(libvirt_xml),
             lxml.etree.XML(expected))
 
@@ -1105,8 +1105,8 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
         </cpu>
         <os>
             <type arch="x86_64" machine="xenpvh">xenpvh</type>
-            <kernel>/tmp/kernel/vmlinuz</kernel>
-            <initrd>/tmp/kernel/initramfs</initrd>
+            <kernel>/tmp/qubes-test/vm-kernels/dummy/vmlinuz</kernel>
+            <initrd>/tmp/qubes-test/vm-kernels/dummy/initramfs</initrd>
             <cmdline>root=/dev/mapper/dmroot ro nomodeset console=hvc0 rd_NO_PLYMOUTH rd.plymouth.enable=0 plymouth.enable=0 swiotlb=2048</cmdline>
         </os>
         <features>
@@ -1124,7 +1124,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
         <devices>
             <disk type="block" device="disk">
                 <driver name="phy" />
-                <source dev="/tmp/kernel/modules.img" />
+                <source dev="/tmp/qubes-test/vm-kernels/dummy/modules.img" />
                 <target dev="xvdd" />
                 <backenddomain name="dom0" />
                 <script path="/etc/xen/scripts/qubes-block" />
@@ -1148,16 +1148,16 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             open(os.path.join(kernel_dir, 'initramfs'), 'w').close()
             self.addCleanup(shutil.rmtree, '/tmp/qubes-test')
             vm.kernel = 'dummy'
-        # tests for storage are later
-        vm.volumes['kernel'] = unittest.mock.Mock(**{
-            'kernels_dir': '/tmp/kernel',
-            'block_device.return_value.domain': 'dom0',
-            'block_device.return_value.path': '/tmp/kernel/modules.img',
-            'block_device.return_value.devtype': 'disk',
-            'block_device.return_value.name': 'kernel',
-            'ephemeral': False,
-        })
-        libvirt_xml = vm.create_config_file()
+            # tests for storage are later
+            vm.volumes['kernel'] = unittest.mock.Mock(**{
+                'kernels_dir': '/tmp/qubes-test/vm-kernels/dummy',
+                'block_device.return_value.domain': 'dom0',
+                'block_device.return_value.path': '/tmp/qubes-test/vm-kernels/dummy/modules.img',
+                'block_device.return_value.devtype': 'disk',
+                'block_device.return_value.name': 'kernel',
+                'ephemeral': False,
+            })
+            libvirt_xml = vm.create_config_file()
         self.assertXMLEqual(lxml.etree.XML(libvirt_xml),
             lxml.etree.XML(expected))
 
@@ -1363,7 +1363,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
         <devices>
             <disk type="block" device="disk">
                 <driver name="phy" />
-                <source dev="/tmp/kernel/modules.img" />
+                <source dev="/tmp/qubes-test/vm-kernels/dummy/modules.img" />
                 <target dev="xvdd" />
                 <backenddomain name="dom0" />
                 <script path="/etc/xen/scripts/qubes-block" />
@@ -1409,22 +1409,22 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             open(os.path.join(kernel_dir, 'initramfs'), 'w').close()
             self.addCleanup(shutil.rmtree, '/tmp/qubes-test')
             vm.kernel = 'dummy'
-        # tests for storage are later
-        vm.volumes['kernel'] = unittest.mock.Mock(**{
-            'kernels_dir': '/tmp/kernel',
-            'block_device.return_value.domain': 'dom0',
-            'block_device.return_value.path': '/tmp/kernel/modules.img',
-            'block_device.return_value.devtype': 'disk',
-            'block_device.return_value.name': 'kernel',
-            'ephemeral': False,
-        })
-        dom0.events_enabled = True
-        self.app.vmm.offline_mode = False
-        dev = qubes.devices.DeviceAssignment(
-            dom0, 'sda',
-            {'devtype': 'cdrom', 'read-only': 'yes'}, persistent=True)
-        self.loop.run_until_complete(vm.devices['block'].attach(dev))
-        libvirt_xml = vm.create_config_file()
+            # tests for storage are later
+            vm.volumes['kernel'] = unittest.mock.Mock(**{
+                'kernels_dir': '/tmp/qubes-test/vm-kernels/dummy',
+                'block_device.return_value.domain': 'dom0',
+                'block_device.return_value.path': '/tmp/qubes-test/vm-kernels/dummy/modules.img',
+                'block_device.return_value.devtype': 'disk',
+                'block_device.return_value.name': 'kernel',
+                'ephemeral': False,
+            })
+            dom0.events_enabled = True
+            self.app.vmm.offline_mode = False
+            dev = qubes.devices.DeviceAssignment(
+                dom0, 'sda',
+                {'devtype': 'cdrom', 'read-only': 'yes'}, persistent=True)
+            self.loop.run_until_complete(vm.devices['block'].attach(dev))
+            libvirt_xml = vm.create_config_file()
         self.assertXMLEqual(lxml.etree.XML(libvirt_xml),
             lxml.etree.XML(expected))
 

--- a/qubes/tests/vm/qubesvm.py
+++ b/qubes/tests/vm/qubesvm.py
@@ -1089,6 +1089,75 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
         self.assertXMLEqual(lxml.etree.XML(libvirt_xml),
             lxml.etree.XML(expected))
 
+    def test_600_libvirt_xml_pvh_no_initramfs(self):
+        expected = '''<domain type="xen">
+        <name>test-inst-test</name>
+        <uuid>7db78950-c467-4863-94d1-af59806384ea</uuid>
+        <memory unit="MiB">500</memory>
+        <currentMemory unit="MiB">400</currentMemory>
+        <vcpu placement="static">2</vcpu>
+        <cpu mode='host-passthrough'>
+            <!-- disable nested HVM -->
+            <feature name='vmx' policy='disable'/>
+            <feature name='svm' policy='disable'/>
+            <!-- let the guest know the TSC is safe to use (no migration) -->
+            <feature name='invtsc' policy='require'/>
+        </cpu>
+        <os>
+            <type arch="x86_64" machine="xenpvh">xenpvh</type>
+            <kernel>/tmp/qubes-test/vm-kernels/dummy/vmlinuz</kernel>
+            <cmdline>root=/dev/mapper/dmroot ro nomodeset console=hvc0 rd_NO_PLYMOUTH rd.plymouth.enable=0 plymouth.enable=0 swiotlb=2048</cmdline>
+        </os>
+        <features>
+            <pae/>
+            <acpi/>
+            <apic/>
+            <viridian/>
+        </features>
+        <clock offset='utc' adjustment='reset'>
+            <timer name="tsc" mode="native"/>
+        </clock>
+        <on_poweroff>destroy</on_poweroff>
+        <on_reboot>destroy</on_reboot>
+        <on_crash>destroy</on_crash>
+        <devices>
+            <disk type="block" device="disk">
+                <driver name="phy" />
+                <source dev="/tmp/qubes-test/vm-kernels/dummy/modules.img" />
+                <target dev="xvdd" />
+                <backenddomain name="dom0" />
+                <script path="/etc/xen/scripts/qubes-block" />
+            </disk>
+            <console type="pty">
+                <target type="xen" port="0"/>
+            </console>
+        </devices>
+        </domain>
+        '''
+        my_uuid = '7db78950-c467-4863-94d1-af59806384ea'
+        vm = self.get_vm(uuid=my_uuid)
+        vm.netvm = None
+        vm.virt_mode = 'pvh'
+        with unittest.mock.patch('qubes.config.qubes_base_dir',
+                '/tmp/qubes-test'):
+            kernel_dir = '/tmp/qubes-test/vm-kernels/dummy'
+            os.makedirs(kernel_dir, exist_ok=True)
+            open(os.path.join(kernel_dir, 'vmlinuz'), 'w').close()
+            self.addCleanup(shutil.rmtree, '/tmp/qubes-test')
+            vm.kernel = 'dummy'
+            # tests for storage are later
+            vm.volumes['kernel'] = unittest.mock.Mock(**{
+                'kernels_dir': '/tmp/qubes-test/vm-kernels/dummy',
+                'block_device.return_value.domain': 'dom0',
+                'block_device.return_value.path': '/tmp/qubes-test/vm-kernels/dummy/modules.img',
+                'block_device.return_value.devtype': 'disk',
+                'block_device.return_value.name': 'kernel',
+                'ephemeral': False,
+            })
+            libvirt_xml = vm.create_config_file()
+        self.assertXMLEqual(lxml.etree.XML(libvirt_xml),
+            lxml.etree.XML(expected))
+
     def test_600_libvirt_xml_pvh_no_membalance(self):
         expected = '''<domain type="xen">
         <name>test-inst-test</name>

--- a/qubes/tests/vm/qubesvm.py
+++ b/qubes/tests/vm/qubesvm.py
@@ -504,7 +504,7 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
 
     @unittest.mock.patch('qubes.config.qubes_base_dir', '/tmp/qubes-test')
     def test_250_kernel(self):
-        for kver in ("dummy", "dummy2"):
+        for kver in ("dummy", "dummy2", "pvgrub2", "pvgrub2-pvh"):
             kernel_dir = '/tmp/qubes-test/vm-kernels/' + kver
             os.makedirs(kernel_dir, exist_ok=True)
             open(os.path.join(kernel_dir, 'vmlinuz'), 'w').close()
@@ -517,6 +517,12 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             "dummy2")
         del vm.kernel
         self.assertPropertyDefaultValue(vm, 'kernel', "dummy")
+        vm.kernel = None
+        self.assertEqual(vm.kernel_path, "/tmp/qubes-test/vm-kernels/pvgrub2-pvh/vmlinuz")
+        vm.virt_mode = "pv"
+        self.assertEqual(vm.kernel_path, "/tmp/qubes-test/vm-kernels/pvgrub2/vmlinuz")
+        vm.virt_mode = "hvm"
+        self.assertIsNone(vm.kernel_path)
 
     @qubes.tests.skipUnlessDom0
     def test_251_kernel_invalid(self):

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -1034,7 +1034,7 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
                 self, self.property_get_def(name), newvalue,
                 'Kernel {!r} not installed'.format(
                     newvalue))
-        for filename in ('vmlinuz', 'initramfs'):
+        for filename in ('vmlinuz',):
             if not os.path.exists(os.path.join(dirname, filename)):
                 raise qubes.exc.QubesPropertyValueError(
                     self, self.property_get_def(name), newvalue,
@@ -1652,7 +1652,10 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
     def initramfs_path(self):
         if not self.kernel:
             return None
-        return self.storage.kernels_dir + "/initramfs"
+        initramfs_path = self.storage.kernels_dir + "/initramfs"
+        if not os.path.exists(initramfs_path):
+            return None
+        return initramfs_path
 
     def is_kernel_from_vm(self):
         """Does the kernel is really a bootloader loading the kernel

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -1645,6 +1645,18 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
     @property
     def kernel_path(self):
         if not self.kernel:
+            if self.virt_mode == 'pvh':
+                return os.path.join(
+                    qubes.config.qubes_base_dir,
+                    qubes.config.system_path['qubes_kernels_base_dir'],
+                    "pvgrub2-pvh",
+                    "vmlinuz")
+            if self.virt_mode == "pv":
+                return os.path.join(
+                    qubes.config.qubes_base_dir,
+                    qubes.config.system_path['qubes_kernels_base_dir'],
+                    "pvgrub2",
+                    "vmlinuz")
             return None
         return self.storage.kernels_dir + "/vmlinuz"
 
@@ -1663,9 +1675,9 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
         if self.virt_mode == 'hvm':
             return not self.kernel
         if self.virt_mode == 'pvh':
-            return self.kernel == 'pvgrub2-pvh'
+            return not self.kernel or self.kernel == 'pvgrub2-pvh'
         if self.virt_mode == 'pv':
-            return self.kernel == 'pvgrub2'
+            return not self.kernel or self.kernel == 'pvgrub2'
         assert False
 
     @property

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -1642,6 +1642,18 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
                 return False
         return True
 
+    @property
+    def kernel_path(self):
+        if not self.kernel:
+            return None
+        return self.storage.kernels_dir + "/vmlinuz"
+
+    @property
+    def initramfs_path(self):
+        if not self.kernel:
+            return None
+        return self.storage.kernels_dir + "/initramfs"
+
     def is_kernel_from_vm(self):
         """Does the kernel is really a bootloader loading the kernel
         from within the VM?"""

--- a/templates/libvirt/xen.xml
+++ b/templates/libvirt/xen.xml
@@ -47,7 +47,9 @@
                     <type arch="x86_64" machine="xenpv">linux</type>
                 {% elif bug("Bad virt mode %r", vm.virt_mode) %}{% endif %}
                 <kernel>{{ vm.kernel_path }}</kernel>
+                {% if vm.initramfs_path -%}
                 <initrd>{{ vm.initramfs_path }}</initrd>
+                {% endif -%}
             {% endif %}
             {% if vm.kernel %}
                 {% if vm.features.check_with_template('no-default-kernelopts', False) -%}

--- a/templates/libvirt/xen.xml
+++ b/templates/libvirt/xen.xml
@@ -46,8 +46,8 @@
                 {% elif vm.virt_mode == 'pv' %}
                     <type arch="x86_64" machine="xenpv">linux</type>
                 {% elif bug("Bad virt mode %r", vm.virt_mode) %}{% endif %}
-                <kernel>{{ vm.storage.kernels_dir }}/vmlinuz</kernel>
-                <initrd>{{ vm.storage.kernels_dir }}/initramfs</initrd>
+                <kernel>{{ vm.kernel_path }}</kernel>
+                <initrd>{{ vm.initramfs_path }}</initrd>
             {% endif %}
             {% if vm.kernel %}
                 {% if vm.features.check_with_template('no-default-kernelopts', False) -%}


### PR DESCRIPTION
1. Fix handling HVM to match the intention described in the comment.
2. Fix distinguishing dom0-provided and vm-provided kernels - the actual
   "kernel" property value depends on the `virt_mode`

While at it, make kernel "none" use in-vm kernel for PV and PVH too - translating automatically to appropriate pvgrub flavor. And make initramfs really optional.

QubesOS/qubes-issues#7956
https://github.com/QubesOS/qubes-issues/issues/5212
https://github.com/QubesOS/qubes-issues/issues/5516