### PR TITLE
qubes-hcl-report: fix TPM family detection

### DIFF
--- a/qvm-tools/qubes-hcl-report
+++ b/qvm-tools/qubes-hcl-report
@@ -272,7 +272,7 @@ else
     HAP_VERBOSE="No"
 fi
 
-if [[ -f "/sys/class/tpm/tpm0/tpm_version_major" ]]
+if [[ -f "/sys/class/tpm/tpm0/tpm_version_major" && $(< "/sys/class/tpm/tpm0/tpm_version_major") == "2" ]]
   then
     TPM="Device present (TPM 2.0)"
     TPM_s="2.0"


### PR DESCRIPTION
For quite some time, "/sys/class/tpm/tpm0/tpm_version_major" is present also for TPM 1.2. To properly test for family, the content of this file must be read. It is "1" for TPM 1.2 and "2" for TPM 2.0.