### PR TITLE
Fix handling empty os metadata from a template

### DIFF
--- a/qubes/ext/core_features.py
+++ b/qubes/ext/core_features.py
@@ -36,11 +36,13 @@ class CoreFeatures(qubes.ext.Extension):
                 'Ignoring qubes.NotifyTools for template-based VM')
             return
 
-        if "os-distribution" in untrusted_features:
+        if "os-distribution" in untrusted_features \
+                and untrusted_features["os-distribution"]:
             # entry point already validates values for safe characters
             vm.features["os-distribution"] = \
                 untrusted_features["os-distribution"]
-        if "os-version" in untrusted_features:
+        if "os-version" in untrusted_features \
+                and untrusted_features["os-version"]:
             # no letters in versions please
             safe_set = string.digits + ".-"
             untrusted_version = untrusted_features["os-version"]
@@ -53,7 +55,8 @@ class CoreFeatures(qubes.ext.Extension):
                     "Invalid 'os-version' value '%s', must start "
                     "with a digit and only digits and _ or . are allowed",
                     untrusted_version)
-        if "os-eol" in untrusted_features:
+        if "os-eol" in untrusted_features \
+                and untrusted_features["os-eol"]:
             untrusted_eol = untrusted_features["os-eol"]
             valid = False
             if re.match(r"\A\d{4}-\d{2}-\d{2}\Z", untrusted_eol):

--- a/qubes/tests/ext.py
+++ b/qubes/tests/ext.py
@@ -313,6 +313,21 @@ class TC_00_CoreFeatures(qubes.tests.QubesTestCase):
             ('features.get', ('qrexec', False), {}),
         ])
 
+    def test_034_distro_meta_empty(self):
+        self.features['qrexec'] = True
+        del self.vm.template
+        self.loop.run_until_complete(
+            self.ext.qubes_features_request(self.vm, 'features-request',
+                untrusted_features={
+                    'os': '',
+                    'os-distribution': '',
+                    'os-version': '',
+                    'os-eol': '',
+                }))
+        self.assertListEqual(self.vm.mock_calls, [
+            ('features.get', ('qrexec', False), {}),
+        ])
+
     def test_100_servicevm_feature(self):
         self.vm.provides_network = True
         self.ext.set_servicevm_feature(self.vm)


### PR DESCRIPTION
Do not check for just presence of os-* requested features, but check if
they aren't empty too. This fixes handling empty version from Arch:

    Traceback (most recent call last):
      File "/usr/lib/python3.11/site-packages/qubes/api/__init__.py", line 297, in respond
        response = await self.mgmt.execute(
                   ^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.11/site-packages/qubes/api/misc.py", line 63, in qubes_features_request
        await self.src.fire_event_async('features-request',
      File "/usr/lib/python3.11/site-packages/qubes/events.py", line 234, in fire_event_async
        effect = task.result()
                 ^^^^^^^^^^^^^
      File "/usr/lib/python3.11/site-packages/qubes/ext/core_features.py", line 48, in qubes_features_request
        and untrusted_version[0].isdigit():
            ~~~~~~~~~~~~~~~~~^^^
    IndexError: string index out of range

Reported at
https://github.com/QubesOS/qubes-issues/issues/9171#issuecomment-2088108181
by @lubellier