### PR TITLE
api/admin: tag DispVMs with created-by-* tags too

### DIFF
--- a/qubes/api/admin.py
+++ b/qubes/api/admin.py
@@ -1150,6 +1150,7 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
 
         dispvm = await qubes.vm.dispvm.DispVM.from_appvm(dispvm_template)
         # TODO: move this to extension (in race-free fashion, better than here)
+        dispvm.tags.add('created-by-' + str(self.src))
         dispvm.tags.add('disp-created-by-' + str(self.src))
 
         return dispvm.name


### PR DESCRIPTION
DispVMs created with admin.vm.CreateDisposable method got only
disp-created-by-* tag, which is inconsistent with any other method a VM
can be created. Especially admin.vm.Create.DispVM adds created-by-*.
This also meant that 'tag-created-vm-with' feature didn't work for
those.

Fix this by adding created-by- tag too, but keep adding also
disp-created-by- in case some mechanism relied on it.