### PR TITLE
api/admin: gracefully handle device listing during qubesd shutdown

### DIFF
--- a/qubes/api/admin.py
+++ b/qubes/api/admin.py
@@ -1199,7 +1199,13 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
         scope='local', read=True)
     async def vm_device_available(self, endpoint):
         devclass = endpoint
-        devices = self.dest.devices[devclass].get_exposed_devices()
+        try:
+            devices = self.dest.devices[devclass].get_exposed_devices()
+        except AttributeError as e:
+            if e.name == 'devices':
+                # shutdown in progress, return specific error
+                raise qubes.exc.QubesException("qubesd shutdown in progress")
+            raise
         if self.arg:
             devices = [dev for dev in devices if dev.ident == self.arg]
             # no duplicated devices, but device may not exist, in which case
@@ -1216,8 +1222,14 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
         scope='local', read=True)
     async def vm_device_list(self, endpoint):
         devclass = endpoint
-        device_assignments = list(
-            self.dest.devices[devclass].get_assigned_devices())
+        try:
+            device_assignments = list(
+                self.dest.devices[devclass].get_assigned_devices())
+        except AttributeError as e:
+            if e.name == 'devices':
+                # shutdown in progress, return specific error
+                raise qubes.exc.QubesException("qubesd shutdown in progress")
+            raise
         if self.arg:
             select_backend, select_ident = self.arg.split('+', 1)
             device_assignments = [dev for dev in device_assignments
@@ -1245,7 +1257,14 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
         no_payload=True, scope='local', read=True)
     async def vm_device_attached(self, endpoint):
         devclass = endpoint
-        device_assignments = self.dest.devices[devclass].get_attached_devices()
+        try:
+            device_assignments = \
+                self.dest.devices[devclass].get_attached_devices()
+        except AttributeError as e:
+            if e.name == 'devices':
+                # shutdown in progress, return specific error
+                raise qubes.exc.QubesException("qubesd shutdown in progress")
+            raise
         if self.arg:
             select_backend, select_ident = self.arg.split('+', 1)
             device_assignments = [dev for dev in device_assignments

--- a/qubes/vm/adminvm.py
+++ b/qubes/vm/adminvm.py
@@ -25,6 +25,7 @@ import asyncio
 import grp
 import subprocess
 import libvirt
+import uuid
 
 import qubes
 import qubes.exc
@@ -45,7 +46,7 @@ class AdminVM(BaseVM):
         default=0, type=int, setter=qubes.property.forbidden)
 
     uuid = qubes.property('uuid',
-        default='00000000-0000-0000-0000-000000000000',
+        default=uuid.UUID('00000000-0000-0000-0000-000000000000'),
         setter=qubes.property.forbidden)
 
     default_dispvm = qubes.VMProperty('default_dispvm',


### PR DESCRIPTION
When shutting down qubesd during tests, a bunch of properties are
cleaned up early (see 'close()' method of QubesVM object). Do not fail
with unhandled exception in this case, but report a clear error message
instead.