### PR TITLE
Fix incorrect `use_hotplug` field name

### DIFF
--- a/qubes/qmemman/domainstate.py
+++ b/qubes/qmemman/domainstate.py
@@ -28,7 +28,7 @@ class DomainState:
         self.mem_used = None		# used memory, computed based on meminfo
         self.id = id			    # domain id
         self.last_target = 0		# the last memset target
-        self.use_hoplug = False     # use memory hotplug for mem-set
+        self.use_hotplug = False    # use memory hotplug for mem-set
         self.no_progress = False    # no react to memset
         self.slow_memset_react = False  # slow react to memset (after few
                                         # tries still above target)

--- a/qubes/tests/qmemman.py
+++ b/qubes/tests/qmemman.py
@@ -40,7 +40,7 @@ def construct_dominfo(id,
     d.memory_actual = memory_actual
     d.memory_current = memory_current
     d.last_target = last_target
-    d.use_hoplug = use_hotplug
+    d.use_hotplug = use_hotplug
     return d
 
 class TC_00_Qmemman_algo(qubes.tests.QubesTestCase):

--- a/qubes/tools/qmemmand.py
+++ b/qubes/tools/qmemmand.py
@@ -163,7 +163,7 @@ class XSWatcher:
 
                 system_state.refresh_meminfo(domain_id, untrusted_meminfo_key)
             except:  # pylint: disable=bare-except
-                self.log.exception('Updating meminfo for %d failed', domain_id)
+                self.log.exception('Updating meminfo for %s failed', domain_id)
         self.log.debug('global_lock released')
 
     def watch_loop(self):


### PR DESCRIPTION
Fixes misspelling in field name resulting in one runtime error, and other runtime error during describing the first runtime error.

```
Sep 25 21:29:11 dom0 qmemmand[2823]: AttributeError: 'DomainState' object has no attribute 'use_hotplug'. Did you mean: 'use_hoplug'?
Sep 25 21:29:11 dom0 qmemmand[2823]: During handling of the above exception, another exception occurred:
Sep 25 21:29:11 dom0 qmemmand[2823]: Traceback (most recent call last):
Sep 25 21:29:11 dom0 qmemmand[2823]:   File "/nix/store/h3i0acpmr8mrjx07519xxmidv8mpax4y-python3-3.12.5/lib/python3.12/logging/handlers.py", line 981, in emit
Sep 25 21:29:11 dom0 qmemmand[2823]:     msg = self.format(record)
Sep 25 21:29:11 dom0 qmemmand[2823]:           ^^^^^^^^^^^^^^^^^^^
Sep 25 21:29:11 dom0 qmemmand[2823]:   File "/nix/store/h3i0acpmr8mrjx07519xxmidv8mpax4y-python3-3.12.5/lib/python3.12/logging/__init__.py", line 999, in format
Sep 25 21:29:11 dom0 qmemmand[2823]:     return fmt.format(record)
Sep 25 21:29:11 dom0 qmemmand[2823]:            ^^^^^^^^^^^^^^^^^^
Sep 25 21:29:11 dom0 qmemmand[2823]:   File "/nix/store/h3i0acpmr8mrjx07519xxmidv8mpax4y-python3-3.12.5/lib/python3.12/logging/__init__.py", line 703, in format
Sep 25 21:29:11 dom0 qmemmand[2823]:     record.message = record.getMessage()
Sep 25 21:29:11 dom0 qmemmand[2823]:                      ^^^^^^^^^^^^^^^^^^^
Sep 25 21:29:11 dom0 qmemmand[2823]:   File "/nix/store/h3i0acpmr8mrjx07519xxmidv8mpax4y-python3-3.12.5/lib/python3.12/logging/__init__.py", line 392, in getMessage
Sep 25 21:29:11 dom0 qmemmand[2823]:     msg = msg % self.args
Sep 25 21:29:11 dom0 qmemmand[2823]:           ~~~~^~~~~~~~~~~
Sep 25 21:29:11 dom0 qmemmand[2823]: TypeError: %d format: a real number is required, not str
Sep 25 21:29:11 dom0 qmemmand[2823]: Call stack:
Sep 25 21:29:11 dom0 qmemmand[2823]:   File "/nix/store/62kh3161zm8r6hg4ggw070vfi812fbdf-python3.12-qubes-core-admin-4.3.6/bin/.qmemmand-wrapped", line 6, in <module>
Sep 25 21:29:11 dom0 qmemmand[2823]:     sys.exit(main())
Sep 25 21:29:11 dom0 qmemmand[2823]:   File "/nix/store/62kh3161zm8r6hg4ggw070vfi812fbdf-python3.12-qubes-core-admin-4.3.6/lib/python3.12/site-packages/qubes/tools/qmemmand.py", line 308, in main
Sep 25 21:29:11 dom0 qmemmand[2823]:     XSWatcher().watch_loop()
Sep 25 21:29:11 dom0 qmemmand[2823]:   File "/nix/store/62kh3161zm8r6hg4ggw070vfi812fbdf-python3.12-qubes-core-admin-4.3.6/lib/python3.12/site-packages/qubes/tools/qmemmand.py", line 175, in watch_loop
Sep 25 21:29:11 dom0 qmemmand[2823]:     token.func(self, token.param)
Sep 25 21:29:11 dom0 qmemmand[2823]:   File "/nix/store/62kh3161zm8r6hg4ggw070vfi812fbdf-python3.12-qubes-core-admin-4.3.6/lib/python3.12/site-packages/qubes/tools/qmemmand.py", line 166, in meminfo_changed
Sep 25 21:29:11 dom0 qmemmand[2823]:     self.log.exception('Updating meminfo for %d failed', domain_id)
Sep 25 21:29:11 dom0 qmemmand[2823]: Message: 'Updating meminfo for %d failed'
Sep 25 21:29:11 dom0 qmemmand[2823]: Arguments: ('0',)
```