### PR TITLE
Fix OVMF path in libvirt xml config

### DIFF
--- a/templates/libvirt/xen.xml
+++ b/templates/libvirt/xen.xml
@@ -42,7 +42,11 @@
                      and SeaBIOS based on the loader type. This has nothing to
                      do with the hvmloader binary.
                 -->
-                <loader type="{{ "pflash" if vm.features.check_with_template('uefi', False) else "rom" }}">hvmloader</loader>
+                {% if vm.features.check_with_template('uefi', False) -%}
+                <loader type="pflash">/usr/share/edk2/xen/OVMF.fd</loader>
+                {% else -%}
+                <loader type="rom">hvmloader</loader>
+                {% endif -%}
                 <boot dev="cdrom" />
                 <boot dev="hd" />
             {% else %}


### PR DESCRIPTION
Libvirt 9.2.0+ no longer ignores specific value of the <loader/>
element for UEFI variant. Fix it to the proper OVMF firmware path.

QubesOS/qubes-issues#8625