### PR TITLE
Remove too strict checking for kernel on startup

### DIFF
--- a/qubes/tests/integ/grub.py
+++ b/qubes/tests/integ/grub.py
@@ -157,7 +157,7 @@ class GrubBase(object):
                      'grub-xen package not installed')
 class TC_40_PVGrub(GrubBase):
     virt_mode = 'pv'
-    kernel = 'pvgrub2'
+    kernel = None
 
     def setUp(self):
         if 'fedora' in self.template:
@@ -176,7 +176,7 @@ class TC_41_HVMGrub(GrubBase):
                      'grub2-xen-pvh package not installed')
 class TC_42_PVHGrub(GrubBase):
     virt_mode = 'pvh'
-    kernel = 'pvgrub2-pvh'
+    kernel = None
 
 def create_testcases_for_templates():
     yield from qubes.tests.create_testcases_for_templates('TC_40_PVGrub',

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -1188,9 +1188,6 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
                                 f'not available'
                             )
 
-                if self.virt_mode == 'pvh' and not self.kernel:
-                    raise qubes.exc.QubesException(
-                        'virt_mode PVH require kernel to be set')
                 await self.storage.verify()
 
                 if self.netvm is not None:


### PR DESCRIPTION
Nowadays empty kernel is automatically converted to pvgrub2, so don't 
refuse that value.

Fixes: ba8bc655 "Allow setting "none" kernel to use in-vm kernel in any
virt_mode"

QubesOS/qubes-issues#5212