### PR TITLE
tests: fix clipboard test

### DIFF
--- a/qubes/device_protocol.py
+++ b/qubes/device_protocol.py
@@ -632,13 +632,14 @@ class DeviceCategory(Enum):
     Microphone = ("m******",)
     # Multimedia = Audio, Video, Displays etc.
     Multimedia = (
-        "u01****",
-        "u0e****",
         "u06****",
         "u10****",
         "p03****",
         "p04****",
     )
+    Audio = ("p0403**", "u01****")
+    Display = ("p0300**", "p0380**")
+    Video = ("p0400**", "u0e****")
     Wireless = ("ue0****", "p0d****")
     Bluetooth = ("ue00101", "p0d11**")
     Storage = ("b******", "u08****", "p01****")


### PR DESCRIPTION
First of all, wait for the zenity process to finish, do not leak it.

But then, adjust the test string to not be a single long line - zenity
often hangs on a single 300k line.

Fixes QubesOS/qubes-issues#9646