### PR TITLE
api: cache system info

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,7 +41,6 @@ checks:tests:
 
 mypy:
   stage: checks
-  image: fedora:40
   tags:
     - docker
   before_script:

--- a/qubes/ext/admin.py
+++ b/qubes/ext/admin.py
@@ -82,7 +82,7 @@ class AdminExtension(qubes.ext.Extension):
             return ((lambda _vm: False),)
 
         policy = self.policy_cache.get_policy()
-        system_info = qubes.api.internal.get_system_info(vm.app)
+        system_info = qubes.api.internal.SystemInfoCache.get_system_info(vm.app)
 
         def filter_vms(dest_vm):
             request = parser.Request(
@@ -133,7 +133,9 @@ class AdminExtension(qubes.ext.Extension):
 
             policy = self.policy_cache.get_policy()
             # TODO: cache system_info (based on last qubes.xml write time?)
-            system_info = qubes.api.internal.get_system_info(vm.app)
+            system_info = qubes.api.internal.SystemInfoCache.get_system_info(
+                vm.app
+            )
             request = parser.Request(
                 "admin.Events",
                 "+" + event.replace(":", "_"),

--- a/qubes/tests/__init__.py
+++ b/qubes/tests/__init__.py
@@ -525,6 +525,9 @@ class QubesTestCase(unittest.TestCase):
         self.skip_kernel_validation_patch.start()
 
     def cleanup_gc(self):
+        # remove cached references to Qubes() object
+        qubes.api.internal.SystemInfoCache.cache_for_app = None
+
         gc.collect()
         leaked = [
             obj

--- a/qubes/tests/integ/backup.py
+++ b/qubes/tests/integ/backup.py
@@ -720,6 +720,8 @@ class TC_10_BackupVMMixin(BackupTestsMixin):
             self.loop.run_until_complete(self.backupvm.start())
             self.loop.run_until_complete(
                 self.backupvm.run_for_stdio(
+                    # add sbin in Debian/Whonix for mkfs.ext4
+                    "PATH=$PATH:/usr/sbin;"
                     # Debian 7 has too old losetup to handle loop-control device
                     "mknod /dev/loop0 b 7 0;"
                     "truncate -s 50M /home/user/backup.img && "

--- a/qubes/tests/integ/devices_block.py
+++ b/qubes/tests/integ/devices_block.py
@@ -81,6 +81,8 @@ class TC_00_List(qubes.tests.SystemTestCase):
         if self.template is None:
             self.skipTest("loop devices excluded in dom0")
         self.run_script(
+            # add sbin in Debian/Whonix for mkfs.ext4
+            "PATH=$PATH:/usr/sbin;"
             "set -e;"
             "truncate -s 128M {path}; "
             "losetup -f {path}; "
@@ -106,6 +108,8 @@ class TC_00_List(qubes.tests.SystemTestCase):
         if self.template is None:
             self.skipTest("loop devices excluded in dom0")
         self.run_script(
+            # add sbin in Debian/Whonix for mkfs.ext4
+            "PATH=$PATH:/usr/sbin;"
             "set -e;"
             "truncate -s 128M {path}; "
             "mkfs.ext4 -q -F {path}; "
@@ -128,6 +132,8 @@ class TC_00_List(qubes.tests.SystemTestCase):
 
     def test_010_list_dm(self):
         self.run_script(
+            # add sbin in Debian/Whonix for mkfs.ext4
+            "PATH=$PATH:/usr/sbin;"
             "set -e;"
             "truncate -s 128M {path}; "
             "loopdev=`losetup -f`; "
@@ -158,6 +164,8 @@ class TC_00_List(qubes.tests.SystemTestCase):
 
     def test_011_list_dm_mounted(self):
         self.run_script(
+            # add sbin in Debian/Whonix for mkfs.ext4
+            "PATH=$PATH:/usr/sbin;"
             "set -e;"
             "truncate -s 128M {path}; "
             "loopdev=`losetup -f`; "
@@ -192,6 +200,8 @@ class TC_00_List(qubes.tests.SystemTestCase):
 
     def test_012_list_dm_delayed(self):
         self.run_script(
+            # add sbin in Debian/Whonix for mkfs.ext4
+            "PATH=$PATH:/usr/sbin;"
             "set -e;"
             "truncate -s 128M {path}; "
             "loopdev=`losetup -f`; "
@@ -227,6 +237,8 @@ class TC_00_List(qubes.tests.SystemTestCase):
                 "test not supported in dom0 - loop devices excluded " "in dom0"
             )
         self.run_script(
+            # add sbin in Debian/Whonix for mkfs.ext4
+            "PATH=$PATH:/usr/sbin;"
             "set -e;"
             "truncate -s 128M {path}; "
             "loopdev=`losetup -f`; "
@@ -257,6 +269,8 @@ class TC_00_List(qubes.tests.SystemTestCase):
         if self.template is None:
             self.skipTest("loop devices excluded in dom0")
         self.run_script(
+            # add sbin in Debian/Whonix for mkfs.ext4
+            "PATH=$PATH:/usr/sbin;"
             "set -e;"
             "truncate -s 128M {path}; "
             "echo ,,L | sfdisk {path};"
@@ -286,6 +300,8 @@ class TC_00_List(qubes.tests.SystemTestCase):
         if self.template is None:
             self.skipTest("loop devices excluded in dom0")
         self.run_script(
+            # add sbin in Debian/Whonix for mkfs.ext4
+            "PATH=$PATH:/usr/sbin;"
             "set -e;"
             "truncate -s 128M {path}; "
             "echo ,,L | sfdisk {path};"
@@ -345,6 +361,8 @@ class AttachMixin:
             self.fail("Failed to start some VM: {!r}".format(exc))
         self.loop.run_until_complete(
             self.backend.run_for_stdio(
+                # add sbin in Debian/Whonix for mkfs.ext4
+                "PATH=$PATH:/usr/sbin;"
                 "set -e;"
                 "truncate -s 128M {path}; "
                 "losetup -f {path}; "

--- a/qubes/tests/integ/dispvm.py
+++ b/qubes/tests/integ/dispvm.py
@@ -489,6 +489,7 @@ class TC_20_DispVMMixin(object):
             "mozilla-thunderbird",
             "thunderbird",
             "org.mozilla.thunderbird",
+            "net.thunderbird.Thunderbird",
         ):
             with open(
                 "/usr/share/qubes/tests-data/"
@@ -537,6 +538,9 @@ class TC_20_DispVMMixin(object):
         # F40+ has org.mozilla.thunderbird
         if "org.mozilla.thunderbird" in self._get_apps_list(self.template):
             app_id = "org.mozilla.thunderbird"
+        # F41+ has net.thunderbird.Thunderbird
+        if "net.thunderbird.Thunderbird" in self._get_apps_list(self.template):
+            app_id = "net.thunderbird.Thunderbird"
 
         self.testvm1.features["service.app-dispvm." + app_id] = "1"
         self.loop.run_until_complete(self.testvm1.start())

--- a/qubes/tests/integ/qrexec.py
+++ b/qubes/tests/integ/qrexec.py
@@ -57,6 +57,17 @@ class TC_00_QrexecMixin(object):
         self.app.save()
 
     def tearDown(self):
+        if not self.success():
+            if self.testvm1.is_running():
+                p = self.loop.run_until_complete(
+                    self.testvm1.run("cat /home/user/.xsession-errors")
+                )
+                self.loop.run_until_complete(p.communicate())
+        if self.testvm2.is_running():
+            p = self.loop.run_until_complete(
+                self.testvm2.run("cat /home/user/.xsession-errors")
+            )
+            self.loop.run_until_complete(p.communicate())
         # socket-based qrexec tests:
         if os.path.exists("/etc/qubes-rpc/test.Socket"):
             os.unlink("/etc/qubes-rpc/test.Socket")

--- a/qubes/tests/integ/qrexec_perf.py
+++ b/qubes/tests/integ/qrexec_perf.py
@@ -33,11 +33,13 @@ class TC_00_QrexecPerfMixin:
             "AppVM",
             name=self.make_vm_name("vm1"),
             label="red",
+            template=self.app.domains[self.template],
         )
         self.vm2 = self.app.add_new_vm(
             "AppVM",
             name=self.make_vm_name("vm2"),
             label="red",
+            template=self.app.domains[self.template],
         )
         self.loop.run_until_complete(
             asyncio.gather(


### PR DESCRIPTION
collecting the information used for qrexec policy evaluation can be 
expensive, but it doesn't change that often. cache it inside qubesd daemon,
and invalidate the cache based on events related to any of the included
information.

fixes qubesos/qubes-issues#9362