### PR TITLE
Allow spaces in values of requested features

### DIFF
--- a/qubes/api/misc.py
+++ b/qubes/api/misc.py
@@ -58,7 +58,7 @@ class QubesMiscAPI(qubes.api.AbstractQubesAPI):
             for key in keys
         }
 
-        safe_set = string.ascii_letters + string.digits + "-._"
+        safe_set = string.ascii_letters + string.digits + "-._ "
         for untrusted_key in untrusted_features:
             untrusted_value = untrusted_features[untrusted_key]
             self.enforce(all((c in safe_set) for c in untrusted_value))

--- a/qubes/tests/api_misc.py
+++ b/qubes/tests/api_misc.py
@@ -73,7 +73,7 @@ class TC_00_API_Misc(qubes.tests.QubesTestCase):
         qdb_entries = {
             "/features-request/feature1": b"1",
             "/features-request/feature2": b"",
-            "/features-request/feature3": b"other",
+            "/features-request/feature3": b"other with spaces",
         }
         self.configure_qdb(qdb_entries)
         response = self.call_mgmt_func(b"qubes.FeaturesRequest")
@@ -91,7 +91,7 @@ class TC_00_API_Misc(qubes.tests.QubesTestCase):
                     untrusted_features={
                         "feature1": "1",
                         "feature2": "",
-                        "feature3": "other",
+                        "feature3": "other with spaces",
                     },
                 ),
             ],
@@ -114,7 +114,7 @@ class TC_00_API_Misc(qubes.tests.QubesTestCase):
 
     def test_002_features_request_invalid1(self):
         qdb_entries = {
-            "/features-request/feature1": b"test spaces",
+            "/features-request/feature1": b"test$chars",
         }
         self.configure_qdb(qdb_entries)
         with self.assertRaises(qubes.exc.PermissionDenied):


### PR DESCRIPTION
Some extensions may want to allow VM to include spaces in requested
values - for example as part of requested human friendly name. Allow for
that.

Currently present extensions do not use space, and each does its own
filtering anyway that is stricter than the set here.

Related to QubesOS/qubes-issues#9750
Fixes https://github.com/QubesOS/qubes-issues/issues/9775