### PR TITLE
Reproduce bug in qrexec tests

### DIFF
--- a/qubes/tests/integ/qrexec.py
+++ b/qubes/tests/integ/qrexec.py
@@ -496,7 +496,7 @@ class TC_00_QrexecMixin(object):
         self.create_remote_file(
             self.testvm2,
             "/etc/qubes-rpc/test.Argument",
-            '/usr/bin/printf %s "$1"',
+            'sleep 20 && /usr/bin/printf %s "$1"',
         )
         with self.qrexec_policy("test.Argument", self.testvm1, self.testvm2):
             stdout, stderr = self.loop.run_until_complete(


### PR DESCRIPTION
The qrexec tests are broken and fail intermittently.  This patch makes the bug obvious: by adding a sleep, it causes the test to fail right away, reliably.