### PR TITLE
Allow equal sign and coma in feature requests

### DIFF
--- a/qubes/api/misc.py
+++ b/qubes/api/misc.py
@@ -58,7 +58,7 @@ class QubesMiscAPI(qubes.api.AbstractQubesAPI):
             for key in keys
         }
 
-        safe_set = string.ascii_letters + string.digits + "-._ "
+        safe_set = string.ascii_letters + string.digits + "-.,_= "
         for untrusted_key in untrusted_features:
             untrusted_value = untrusted_features[untrusted_key]
             self.enforce(all((c in safe_set) for c in untrusted_value))


### PR DESCRIPTION
It is necessary for boot mode feature, as a common character in
kernelopts

QubesOS/qubes-issues#9750