### PR TITLE
Keep AppVM boot modes and template AppVM default boot mode in sync

### DIFF
--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -1204,9 +1204,7 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.BaseVM):
             self._domain_stopped_event_handled = False
 
     @qubes.events.handler("domain-feature-set:boot-mode.active")
-    def on_feature_bootmode_active_set(
-        self, event, feature, value, oldvalue=None
-    ):
+    def on_feature_bootmode_set(self, event, feature, value, oldvalue=None):
         # pylint: disable=unused-argument
         if value == oldvalue:
             return

--- a/qubes/vm/templatevm.py
+++ b/qubes/vm/templatevm.py
@@ -125,6 +125,29 @@ class TemplateVM(QubesVM):
                     appvm.fire_event("property-reset:bootmode", name="bootmode")
 
     @qubes.events.handler(
+        "property-set:appvm_default_bootmode",
+    )
+    def on_property_bootmode_appvm_set(
+        self, event, name, newvalue, oldvalue=None
+    ):
+        # pylint: disable=unused-argument
+        if newvalue == oldvalue:
+            return
+        for appvm in getattr(self, "appvms", []):
+            if appvm.property_is_default("bootmode"):
+                appvm.fire_event("property-reset:bootmode", name="bootmode")
+
+    # pylint: disable=invalid-name
+    @qubes.events.handler(
+        "property-reset:appvm_default_bootmode",
+    )
+    def on_property_bootmode_appvm_reset(self, event, name, oldvalue=None):
+        # pylint: disable=unused-argument
+        for appvm in getattr(self, "appvms", []):
+            if appvm.property_is_default("bootmode"):
+                appvm.fire_event("property-reset:bootmode", name="bootmode")
+
+    @qubes.events.handler(
         "property-set:default_user",
         "property-set:kernel",
         "property-set:kernelopts",


### PR DESCRIPTION
Qube Manager was showing the wrong boot mode kernel options for AppVMs if you changed a template's AppVM default boot mode. Issue had a similar root cause to https://github.com/QubesOS/qubes-core-admin/pull/653#issuecomment-2692575990. This PR fixes it.