### PR TITLE
tests: simple end-to-end remote qrexec test

### DIFF
--- a/qubes/tests/__init__.py
+++ b/qubes/tests/__init__.py
@@ -1146,16 +1146,16 @@ class SystemTestCase(QubesTestCase):
                 pass
         # break dependencies
         for vm in vms:
-            if vm.default_dispvm in vms:
-                vm.default_dispvm = None
-            if vm.netvm in vms:
-                vm.netvm = None
-            if vm.management_dispvm in vms:
-                vm.management_dispvm = None
-            if vm.guivm in vms:
-                vm.guivm = None
-            if vm.audiovm in vms:
-                vm.audiovm = None
+            for attr in (
+                "default_dispvm",
+                "netvm",
+                "management_dispvm",
+                "guivm",
+                "audiovm",
+                "relayvm",
+            ):
+                if getattr(vm, attr, None) in vms:
+                    setattr(vm, attr, None)
         # take app instance from any VM to be removed
         app = vms[0].app
         if app.default_dispvm in vms:


### PR DESCRIPTION
Test vm1 -> relay -> vm2-remote call path. Do it on a single host by having
relay service that transform names (source to source-remote and 
target-remote to target). For this to work, there need to be matching pairs
of VMs with and without -remote suffix, and appropriate policy for both
outgoing and incoming connections.

QubesOS/qubes-issues#9015