### PR TITLE
Move device-related exceptions to the exc module

### DIFF
--- a/qubes/device_protocol.py
+++ b/qubes/device_protocol.py
@@ -38,18 +38,12 @@ from typing import Optional, Dict, Any, List, Union, Tuple, Callable
 from typing import TYPE_CHECKING
 
 import qubes.utils
-from qubes.exc import ProtocolError, QubesValueError
+from qubes.exc import ProtocolError, QubesValueError, UnexpectedDeviceProperty
 
 if TYPE_CHECKING:
     from qubes.vm.qubesvm import QubesVM
 else:
     QubesVM = "qubes.vm.qubesvm.QubesVM"
-
-
-class UnexpectedDeviceProperty(qubes.exc.QubesException, ValueError):
-    """
-    Device has unexpected property such as backend_domain, devclass etc.
-    """
 
 
 def qbool(value):

--- a/qubes/devices.py
+++ b/qubes/devices.py
@@ -71,31 +71,12 @@ from qubes.device_protocol import (
     VirtualDevice,
     AssignmentMode,
 )
-from qubes.exc import ProtocolError
-
-
-class DeviceNotAssigned(qubes.exc.QubesException, KeyError):
-    """
-    Trying to unassign not assigned device.
-    """
-
-
-class DeviceAlreadyAttached(qubes.exc.QubesException, KeyError):
-    """
-    Trying to attach already attached device.
-    """
-
-
-class DeviceAlreadyAssigned(qubes.exc.QubesException, KeyError):
-    """
-    Trying to assign already assigned device.
-    """
-
-
-class UnrecognizedDevice(qubes.exc.QubesException, ValueError):
-    """
-    Device identity is not as expected.
-    """
+from qubes.exc import (
+    ProtocolError,
+    DeviceNotAssigned,
+    DeviceAlreadyAttached,
+    DeviceAlreadyAssigned,
+)
 
 
 class DeviceCollection:

--- a/qubes/exc.py
+++ b/qubes/exc.py
@@ -269,3 +269,33 @@ class ProtocolError(AssertionError):
 
 class PermissionDenied(Exception):
     """Raised deliberately by handlers when we decide not to cooperate"""
+
+
+class DeviceNotAssigned(QubesException, KeyError):
+    """
+    Trying to unassign not assigned device.
+    """
+
+
+class DeviceAlreadyAttached(QubesException, KeyError):
+    """
+    Trying to attach already attached device.
+    """
+
+
+class DeviceAlreadyAssigned(QubesException, KeyError):
+    """
+    Trying to assign already assigned device.
+    """
+
+
+class UnrecognizedDevice(QubesException, ValueError):
+    """
+    Device identity is not as expected.
+    """
+
+
+class UnexpectedDeviceProperty(QubesException, ValueError):
+    """
+    Device has unexpected property such as backend_domain, devclass etc.
+    """

--- a/qubes/exc.py
+++ b/qubes/exc.py
@@ -299,3 +299,7 @@ class UnexpectedDeviceProperty(QubesException, ValueError):
     """
     Device has unexpected property such as backend_domain, devclass etc.
     """
+
+
+class StoragePoolException(QubesException):
+    """A general storage exception"""

--- a/qubes/ext/block.py
+++ b/qubes/ext/block.py
@@ -30,6 +30,7 @@ import lxml.etree
 
 import qubes.device_protocol
 import qubes.devices
+import qubes.exc
 import qubes.ext
 from qubes.ext import utils
 from qubes.storage import Storage
@@ -514,7 +515,7 @@ class BlockDeviceExtension(qubes.ext.Extension):
                 "not available, skipping.",
                 file=sys.stderr,
             )
-            raise qubes.devices.UnrecognizedDevice()
+            raise qubes.exc.UnrecognizedDevice()
 
         # validate options
         for option, value in options.items():
@@ -561,7 +562,7 @@ class BlockDeviceExtension(qubes.ext.Extension):
             return
 
         if device.attachment and device.attachment != expected_attachment:
-            raise qubes.devices.DeviceAlreadyAttached(
+            raise qubes.exc.DeviceAlreadyAttached(
                 "Device {!s} already attached to {!s}".format(
                     device, device.attachment
                 )

--- a/qubes/storage/__init__.py
+++ b/qubes/storage/__init__.py
@@ -38,16 +38,13 @@ import importlib.metadata
 import qubes
 import qubes.exc
 import qubes.utils
+from qubes.exc import StoragePoolException
 
 STORAGE_ENTRY_POINT = "qubes.storage"
 _am_root = os.getuid() == 0
 
 BYTES_TO_ZERO = 1 << 16
 _big_buffer = b"\0" * BYTES_TO_ZERO
-
-
-class StoragePoolException(qubes.exc.QubesException):
-    """A general storage exception"""
 
 
 class BlockDevice:

--- a/qubes/storage/callback.py
+++ b/qubes/storage/callback.py
@@ -25,12 +25,14 @@ import json
 import asyncio
 import locale
 from shlex import quote
+
+import qubes.exc
 from qubes.utils import coro_maybe
 
 import qubes.storage
 
 
-class UnhandledSignalException(qubes.storage.StoragePoolException):
+class UnhandledSignalException(qubes.exc.StoragePoolException):
     def __init__(self, pool, signal):
         super().__init__(
             "The pool %s failed to handle the signal %s, likely because it was run from synchronous code."
@@ -204,7 +206,7 @@ class CallbackPool(qubes.storage.Pool):
             "qubes.storage.callback"
         )  #: Logger instance.
         if not isinstance(conf_id, str):
-            raise qubes.storage.StoragePoolException(
+            raise qubes.exc.StoragePoolException(
                 "conf_id is no String. VM attack?!"
             )
         self._cb_conf_id = (
@@ -215,7 +217,7 @@ class CallbackPool(qubes.storage.Pool):
         with open(config_path, encoding="utf-8") as json_file:
             conf_all = json.load(json_file)
         if not isinstance(conf_all, dict):
-            raise qubes.storage.StoragePoolException(
+            raise qubes.exc.StoragePoolException(
                 "The file %s is supposed to define a dict." % config_path
             )
 
@@ -225,7 +227,7 @@ class CallbackPool(qubes.storage.Pool):
             ]  #: Dictionary holding all configuration for the given _cb_conf_id.
         except KeyError:
             # we cannot throw KeyErrors as we'll otherwise generate incorrect error messages @qubes.app._get_pool()
-            raise qubes.storage.StoragePoolException(
+            raise qubes.exc.StoragePoolException(
                 "The specified conf_id %s could not be found inside %s."
                 % (self._cb_conf_id, config_path)
             )
@@ -233,7 +235,7 @@ class CallbackPool(qubes.storage.Pool):
         try:
             bdriver = self._cb_conf["bdriver"]
         except KeyError:
-            raise qubes.storage.StoragePoolException(
+            raise qubes.exc.StoragePoolException(
                 "Missing bdriver for the conf_id %s inside %s."
                 % (self._cb_conf_id, config_path)
             )
@@ -247,12 +249,12 @@ class CallbackPool(qubes.storage.Pool):
                 qubes.storage.STORAGE_ENTRY_POINT, bdriver
             )
         except KeyError:
-            raise qubes.storage.StoragePoolException(
+            raise qubes.exc.StoragePoolException(
                 "The driver %s was not found on your system." % bdriver
             )
 
         if not issubclass(cls, qubes.storage.Pool):
-            raise qubes.storage.StoragePoolException(
+            raise qubes.exc.StoragePoolException(
                 "The class %s must be a subclass of qubes.storage.Pool." % cls
             )
 

--- a/qubes/storage/file.py
+++ b/qubes/storage/file.py
@@ -30,6 +30,7 @@ import stat
 import subprocess
 from contextlib import suppress
 
+import qubes.exc
 import qubes.storage
 import qubes.utils
 
@@ -350,7 +351,7 @@ class FileVolume(qubes.storage.Volume):
         """
         if not self.rw:
             msg = "Can not resize readonly volume {!s}".format(self)
-            raise qubes.storage.StoragePoolException(msg)
+            raise qubes.exc.StoragePoolException(msg)
 
         if self.snap_on_start:
             # this theoretically could be supported, but it's unusual
@@ -359,10 +360,10 @@ class FileVolume(qubes.storage.Volume):
                 "Cannot resize volume based on a template - resize"
                 "the template instead"
             )
-            raise qubes.storage.StoragePoolException(msg)
+            raise qubes.exc.StoragePoolException(msg)
 
         if size < self.size:
-            raise qubes.storage.StoragePoolException(
+            raise qubes.exc.StoragePoolException(
                 "For your own safety, shrinking of %s is"
                 " disabled. If you really know what you"
                 " are doing, use `truncate` on %s manually."
@@ -407,11 +408,11 @@ class FileVolume(qubes.storage.Volume):
             assert (
                 self._export_lock is FileVolume._marker_running
             ), "nested calls to export()"
-            raise qubes.storage.StoragePoolException(
+            raise qubes.exc.StoragePoolException(
                 "file pool cannot export running volumes"
             )
         if self.is_dirty():
-            raise qubes.storage.StoragePoolException(
+            raise qubes.exc.StoragePoolException(
                 "file pool cannot export dirty volumes"
             )
         self._export_lock = FileVolume._marker_exported
@@ -425,7 +426,7 @@ class FileVolume(qubes.storage.Volume):
 
     async def import_volume(self, src_volume):
         if src_volume.snap_on_start:
-            raise qubes.storage.StoragePoolException(
+            raise qubes.exc.StoragePoolException(
                 "Can not import snapshot volume {!s} in to pool {!s} ".format(
                     src_volume, self
                 )
@@ -441,7 +442,7 @@ class FileVolume(qubes.storage.Volume):
 
     def import_data(self, size):  # pylint: disable=invalid-overridden-method
         if not self.save_on_stop:
-            raise qubes.storage.StoragePoolException(
+            raise qubes.exc.StoragePoolException(
                 "Can not import into save_on_stop=False volume {!s}".format(
                     self
                 )
@@ -476,7 +477,7 @@ class FileVolume(qubes.storage.Volume):
             assert (
                 self._export_lock is FileVolume._marker_exported
             ), "nested calls to start()"
-            raise qubes.storage.StoragePoolException(
+            raise qubes.exc.StoragePoolException(
                 "file pool cannot start a VM with an exported volume"
             )
         self._export_lock = FileVolume._marker_running
@@ -559,7 +560,7 @@ class FileVolume(qubes.storage.Volume):
             self.snap_on_start or self.save_on_stop
         ):
             msg = "Missing image file: {!s}.".format(self.path)
-            raise qubes.storage.StoragePoolException(msg)
+            raise qubes.exc.StoragePoolException(msg)
         return True
 
     @property
@@ -722,4 +723,4 @@ def _check_path(path):
     """Raise an StoragePoolException if ``path`` does not exist"""
     if not os.path.exists(path):
         msg = "Missing image file: %s" % path
-        raise qubes.storage.StoragePoolException(msg)
+        raise qubes.exc.StoragePoolException(msg)

--- a/qubes/storage/kernels.py
+++ b/qubes/storage/kernels.py
@@ -25,7 +25,8 @@ import os
 
 import qubes.exc
 import qubes.storage
-from qubes.storage import Pool, StoragePoolException, Volume
+from qubes.storage import Pool, Volume
+from qubes.exc import StoragePoolException
 
 
 class LinuxModules(Volume):

--- a/qubes/storage/reflink.py
+++ b/qubes/storage/reflink.py
@@ -35,6 +35,7 @@ import subprocess
 import tempfile
 from contextlib import contextmanager, suppress
 
+import qubes.exc
 import qubes.storage
 import qubes.utils
 
@@ -94,7 +95,7 @@ class ReflinkPool(qubes.storage.Pool):
         if self._setup_check and not is_supported(self.dir_path):
             if created:
                 _remove_empty_dir(self.dir_path)
-            raise qubes.storage.StoragePoolException(
+            raise qubes.exc.StoragePoolException(
                 "The filesystem for {!r} does not support reflinks. If you"
                 " can live with VM startup delays and wasted disk space, pass"
                 ' the "setup_check=False" option.'.format(self.dir_path)
@@ -220,7 +221,7 @@ class ReflinkVolume(qubes.storage.Volume):
 
         if img is None or os.path.exists(img):
             return True
-        raise qubes.storage.StoragePoolException(
+        raise qubes.exc.StoragePoolException(
             "Missing image file {!r} for volume {}".format(img, self.vid)
         )
 
@@ -323,7 +324,7 @@ class ReflinkVolume(qubes.storage.Volume):
         self, revision=None
     ):  # pylint: disable=invalid-overridden-method
         if self.is_dirty():
-            raise qubes.storage.StoragePoolException(
+            raise qubes.exc.StoragePoolException(
                 "Cannot revert: {} is not cleanly stopped".format(self.vid)
             )
         path_revision = self._path_revision(revision)
@@ -339,7 +340,7 @@ class ReflinkVolume(qubes.storage.Volume):
         devices of the size change.
         """
         if not self.rw:
-            raise qubes.storage.StoragePoolException(
+            raise qubes.exc.StoragePoolException(
                 "Cannot resize: {} is read-only".format(self.vid)
             )
         try:
@@ -556,7 +557,7 @@ def _copy_file(src, dst, *, dst_size=None, copy_mtime=False):
                     check=False,
                 )
                 if result.returncode != 0:
-                    raise qubes.storage.StoragePoolException(str(result))
+                    raise qubes.exc.StoragePoolException(str(result))
             if dst_size is not None:
                 tmp_io.truncate(dst_size)
         if copy_mtime:

--- a/qubes/tests/api_admin.py
+++ b/qubes/tests/api_admin.py
@@ -2784,7 +2784,7 @@ netvm default=True type=vm \n"""
         with unittest.mock.patch.object(
             qubes.vm.qubesvm.QubesVM, "is_halted", lambda _: False
         ):
-            with self.assertRaises(qubes.devices.DeviceNotAssigned):
+            with self.assertRaises(qubes.exc.DeviceNotAssigned):
                 self.call_mgmt_func(
                     b"admin.vm.device.testclass.Detach",
                     b"test-vm1",
@@ -2827,7 +2827,7 @@ netvm default=True type=vm \n"""
         with unittest.mock.patch.object(
             qubes.vm.qubesvm.QubesVM, "is_halted", lambda _: False
         ):
-            with self.assertRaises(qubes.devices.DeviceNotAssigned):
+            with self.assertRaises(qubes.exc.DeviceNotAssigned):
                 self.call_mgmt_func(
                     b"admin.vm.device.testclass.Detach",
                     b"test-vm1",

--- a/qubes/tests/devices.py
+++ b/qubes/tests/devices.py
@@ -22,6 +22,7 @@ import sys
 #
 
 import qubes.devices
+import qubes.exc
 from qubes.device_protocol import (
     Port,
     DeviceInfo,
@@ -163,7 +164,7 @@ class TC_00_DeviceCollection(qubes.tests.QubesTestCase):
 
     def test_012_double_attach(self):
         self.attach()
-        with self.assertRaises(qubes.devices.DeviceAlreadyAttached):
+        with self.assertRaises(qubes.exc.DeviceAlreadyAttached):
             self.loop.run_until_complete(
                 self.collection.attach(self.assignment)
             )
@@ -175,7 +176,7 @@ class TC_00_DeviceCollection(qubes.tests.QubesTestCase):
         )
         self.detach()
 
-        with self.assertRaises(qubes.devices.DeviceNotAssigned):
+        with self.assertRaises(qubes.exc.DeviceNotAssigned):
             self.loop.run_until_complete(
                 self.collection.detach(self.assignment.port)
             )
@@ -183,7 +184,7 @@ class TC_00_DeviceCollection(qubes.tests.QubesTestCase):
     def test_014_double_assign(self):
         self.loop.run_until_complete(self.collection.assign(self.assignment))
 
-        with self.assertRaises(qubes.devices.DeviceAlreadyAssigned):
+        with self.assertRaises(qubes.exc.DeviceAlreadyAssigned):
             self.loop.run_until_complete(
                 self.collection.assign(self.assignment)
             )
@@ -192,7 +193,7 @@ class TC_00_DeviceCollection(qubes.tests.QubesTestCase):
         self.loop.run_until_complete(self.collection.assign(self.assignment))
         self.loop.run_until_complete(self.collection.unassign(self.assignment))
 
-        with self.assertRaises(qubes.devices.DeviceNotAssigned):
+        with self.assertRaises(qubes.exc.DeviceNotAssigned):
             self.loop.run_until_complete(
                 self.collection.unassign(self.assignment)
             )

--- a/qubes/tests/integ/audio.py
+++ b/qubes/tests/integ/audio.py
@@ -29,6 +29,7 @@ from distutils import spawn
 
 import numpy as np
 
+import qubes.exc
 import qubes.vm
 import qubes.devices
 from qubes.tests.integ.vm_qrexec_gui import TC_00_AppVMMixin, in_qemu
@@ -438,7 +439,7 @@ admin.vm.feature.CheckWithTemplate  +audio-model   {vm}     @tag:audiovm-{vm}  a
         if attach_mic:
             try:
                 self.detach_mic()
-            except qubes.devices.DeviceNotAssigned:
+            except qubes.exc.DeviceNotAssigned:
                 pass
             self.attach_mic()
         # connect VM's recording source output monitor (instead of mic)

--- a/qubes/tests/integ/basic.py
+++ b/qubes/tests/integ/basic.py
@@ -37,6 +37,7 @@ import shutil
 import sys
 
 import qubes
+import qubes.exc
 import qubes.firewall
 import qubes.tests
 import qubes.storage
@@ -888,7 +889,7 @@ class TC_05_StandaloneVMMixin(object):
             )
         except (
             subprocess.CalledProcessError,
-            qubes.storage.StoragePoolException,
+            qubes.exc.StoragePoolException,
         ) as e:
             # exception object would leak VM reference
             self.fail(str(e))
@@ -922,7 +923,7 @@ class TC_05_StandaloneVMMixin(object):
             )
         except (
             subprocess.CalledProcessError,
-            qubes.storage.StoragePoolException,
+            qubes.exc.StoragePoolException,
         ) as e:
             # exception object would leak VM reference
             self.fail(str(e))

--- a/qubes/tests/storage_callback.py
+++ b/qubes/tests/storage_callback.py
@@ -25,6 +25,8 @@
 import os
 import json
 import subprocess
+
+import qubes.exc
 import qubes.tests
 import qubes.tests.storage
 import qubes.tests.storage_lvm
@@ -395,21 +397,21 @@ class TC_92_CallbackPool(
     def test_003_errors(self):
         """Make sure we error out on common user & dev mistakes."""
         # missing conf_id
-        with self.assertRaises(qubes.storage.StoragePoolException):
+        with self.assertRaises(qubes.exc.StoragePoolException):
             cb = CallbackPool(name="some-name", conf_id="")
 
         # invalid conf_id
-        with self.assertRaises(qubes.storage.StoragePoolException):
+        with self.assertRaises(qubes.exc.StoragePoolException):
             cb = CallbackPool(name="some-name", conf_id="nonexisting-id")
 
         # incorrect backend driver
-        with self.assertRaises(qubes.storage.StoragePoolException):
+        with self.assertRaises(qubes.exc.StoragePoolException):
             cb = CallbackPool(
                 name="some-name", conf_id="testing-fail-incorrect-bdriver"
             )
 
         # missing config entries
-        with self.assertRaises(qubes.storage.StoragePoolException):
+        with self.assertRaises(qubes.exc.StoragePoolException):
             cb = CallbackPool(
                 name="some-name", conf_id="testing-fail-missing-all"
             )

--- a/qubes/tests/storage_zfs.py
+++ b/qubes/tests/storage_zfs.py
@@ -15,6 +15,7 @@ import sys
 import tempfile
 import unittest
 
+import qubes.exc
 import qubes.storage as storage
 import qubes.storage.zfs as zfs
 import qubes.tests
@@ -237,7 +238,7 @@ class TC_01_ZFSPool_solidstate(AsyncLoopHolderMixin):
     def test_fail_unless_exists_async(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             nonexistent = os.path.join(tmpdir, "x")
-            with self.assertRaises(storage.StoragePoolException):
+            with self.assertRaises(qubes.exc.StoragePoolException):
                 self.rc(zfs.fail_unless_exists_async(nonexistent))
             with open(nonexistent, "w", encoding="utf-8") as f:
                 f.write("now it exists")
@@ -295,7 +296,7 @@ class TC_01_ZFSPool_solidstate(AsyncLoopHolderMixin):
             with open(dst, "r", encoding="utf-8") as f:
                 self.assertEqual(f.read(), "now it exists")
             falsesrc = os.path.join(tmpdir, "unrelated")
-            with self.assertRaises(storage.StoragePoolException):
+            with self.assertRaises(qubes.exc.StoragePoolException):
                 self.rc(zfs.duplicate_disk(falsesrc, dst, log))
 
 
@@ -432,7 +433,7 @@ class TC_10_ZFSPool(ZFSBase):
 
         # Fail at shrinking.
         self.assertRaises(
-            storage.StoragePoolException,
+            qubes.exc.StoragePoolException,
             lambda: self.rc(volume.resize(1024 * 1024)),
         )
 
@@ -617,7 +618,7 @@ class TC_10_ZFSPool(ZFSBase):
         # This should never be the case.  Snap on start volumes
         # must instead be *sourced* from a save on stop volume.
         self.assertRaises(
-            storage.StoragePoolException,
+            qubes.exc.StoragePoolException,
             lambda: self.get_vol(ONEMEG_SNAP_ON_START, name="020-2"),
         )
 
@@ -813,9 +814,9 @@ class TC_10_ZFSPool(ZFSBase):
         with patch.object(
             tgt.vol.pool.accessor,
             "clone_snapshot_to_volume_async",
-            side_effect=storage.StoragePoolException("mocked failure!"),
+            side_effect=qubes.exc.StoragePoolException("mocked failure!"),
         ):
-            with self.assertRaises(storage.StoragePoolException):
+            with self.assertRaises(qubes.exc.StoragePoolException):
                 # Fail clone!
                 self.rc(tgt.vol.import_volume(src.vol))
 

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -1595,7 +1595,7 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.LocalVM):
         """Cleanup after domain was stopped"""
         try:
             await self.storage.stop()
-        except qubes.storage.StoragePoolException:
+        except qubes.exc.StoragePoolException:
             self.log.exception(
                 "Failed to stop storage for domain %s", self.name
             )


### PR DESCRIPTION
Admin API, especially the client side depends on having all exceptions
in one place. The exc.py need to be synchronized to core-admin-client
repo. Exceptions from outside this module are translated to a generic
QubesException, which is not perfect.

Specifically, exceptions in wrong place caused DeviceAlreadyAssigned and
DeviceAlreadyAttached being translate to QubesException, which confused
salt module.