### PR TITLE
tests: only close watch fd for LocalVM

### DIFF
--- a/qubes/tests/__init__.py
+++ b/qubes/tests/__init__.py
@@ -880,7 +880,7 @@ class SystemTestCase(QubesTestCase):
     def close_qdb_on_remove(self, app, event, vm, **kwargs):
         # only close QubesDB connection, do not perform other (destructive)
         # actions of vm.close()
-        if vm._qdb_connection_watch is not None:
+        if getattr(vm, "_qdb_connection_watch", None) is not None:
             asyncio.get_event_loop().remove_reader(
                 vm._qdb_connection_watch.watch_fd()
             )


### PR DESCRIPTION
```
======================================================================
ERROR: qubes.tests.integ.misc/TC_10_RemoteVM_fedora-41-xfce/test_000_full_connect
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.13/site-packages/qubes/tests/__init__.py", line 891, in cleanup_app
    self.remove_test_vms()
    ~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/site-packages/qubes/tests/__init__.py", line 1216, in remove_test_vms
    self.remove_vms(
    ~~~~~~~~~~~~~~~^
        [
        ^
    ...<9 lines>...
        ]
        ^
    )
    ^
  File "/usr/lib/python3.13/site-packages/qubes/tests/__init__.py", line 1187, in remove_vms
    self._remove_vm_qubes(vm)
    ~~~~~~~~~~~~~~~~~~~~~^^^^
  File "/usr/lib/python3.13/site-packages/qubes/tests/__init__.py", line 1029, in _remove_vm_qubes
    del app.domains[vm.qid]
        ~~~~~~~~~~~^^^^^^^^
  File "/usr/lib/python3.13/site-packages/qubes/app.py", line 568, in __delitem__
    self.app.fire_event("domain-delete", vm=vm)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/qubes/events.py", line 200, in fire_event
    sync_effects, async_effects = self._fire_event(
                                  ~~~~~~~~~~~~~~~~^
        event, kwargs, pre_event=pre_event
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/lib/python3.13/site-packages/qubes/events.py", line 169, in _fire_event
    effect = func(self, event, **kwargs)
  File "/usr/lib/python3.13/site-packages/qubes/tests/__init__.py", line 883, in close_qdb_on_remove
    if vm._qdb_connection_watch is not None:
       ^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'RemoteVM' object has no attribute '_qdb_connection_watch'
```

Related to https://github.com/QubesOS/qubes-core-admin/pull/669.