### PR TITLE
Fix handling a bit slower sys-net/sys-usb resume

### DIFF
--- a/qubes/tests/vm/qubesvm.py
+++ b/qubes/tests/vm/qubesvm.py
@@ -2975,6 +2975,24 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
             )
             self.assertFalse(start_mock.called)
 
+        mock_subprocess.reset_mock()
+        start_mock.reset_mock()
+        with self.subTest("connection_timeout"):
+            vm.is_running = lambda: True
+            vm.is_qrexec_running = lambda stubdom=False: True
+            self.loop.run_until_complete(
+                vm.run_service("test.service", connection_timeout=10)
+            )
+            mock_subprocess.assert_called_once_with(
+                "/usr/bin/qrexec-client",
+                "-d",
+                "test-inst-vm",
+                "-w",
+                "10",
+                "user:QUBESRPC test.service dom0",
+            )
+            self.assertFalse(start_mock.called)
+
     @unittest.mock.patch("qubes.vm.qubesvm.QubesVM.run")
     def test_710_run_for_stdio(self, mock_run):
         vm = self.get_vm(cls=qubes.vm.standalonevm.StandaloneVM, name="vm")

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -1728,7 +1728,9 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.LocalVM):
                 try:
                     await asyncio.wait_for(
                         self.run_service_for_stdio(
-                            "qubes.SuspendPost", user="root"
+                            "qubes.SuspendPost",
+                            user="root",
+                            connection_timeout=qubes.config.suspend_timeout,
                         ),
                         qubes.config.suspend_timeout,
                     )

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -1769,6 +1769,7 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.LocalVM):
         filter_esc=False,
         autostart=False,
         gui=False,
+        connection_timeout=None,
         **kwargs,
     ):
         """Run service on this VM
@@ -1782,6 +1783,8 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.LocalVM):
         :param bool autostart: if :py:obj:`True`, machine will be started if \
             it is not running
         :param bool gui: when autostarting, also start gui daemon
+        :param int connection_timeout: override default qrexec connection
+            timeout (in seconds)
         :rtype: asyncio.subprocess.Process
 
         .. note::
@@ -1827,6 +1830,7 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.LocalVM):
             qubes.config.system_path["qrexec_client_path"],
             "-d",
             str(name),
+            *(("-w", str(connection_timeout)) if connection_timeout else ()),
             *(("-t", "-T") if filter_esc else ()),
             "{}:QUBESRPC {} {}".format(user, service, source),
             **kwargs,


### PR DESCRIPTION
Do not timeout early when VM kernel needs a bit more time on resume. Apply the
suspend_timeout (60s) uniformly to the whole qubes.SuspendPost call.

Fixes QubesOS/qubes-issues#9942