### PR TITLE
Expose S3 graceful VM suspend/resume API calls

### DIFF
--- a/qubes/api/admin.py
+++ b/qubes/api/admin.py
@@ -993,6 +993,22 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
         await self.dest.unpause()
 
     @qubes.api.method(
+        "admin.vm.Suspend", no_payload=True, scope="local", execute=True
+    )
+    async def vm_suspend(self):
+        self.enforce(not self.arg)
+        self.fire_event_for_permission()
+        await self.dest.suspend()
+
+    @qubes.api.method(
+        "admin.vm.Resume", no_payload=True, scope="local", execute=True
+    )
+    async def vm_resume(self):
+        self.enforce(not self.arg)
+        self.fire_event_for_permission()
+        await self.dest.resume()
+
+    @qubes.api.method(
         "admin.vm.Kill", no_payload=True, scope="local", execute=True
     )
     async def vm_kill(self):

--- a/qubes/tests/api_admin.py
+++ b/qubes/tests/api_admin.py
@@ -1439,6 +1439,17 @@ netvm default=True type=vm \n"""
         self.assertIsNone(value)
         func_mock.assert_called_once_with()
 
+    def test_241_suspend(self):
+        func_mock = unittest.mock.Mock()
+
+        async def coroutine_mock(*args, **kwargs):
+            return func_mock(*args, **kwargs)
+
+        self.vm.suspend = coroutine_mock
+        value = self.call_mgmt_func(b"admin.vm.Suspend", b"test-vm1")
+        self.assertIsNone(value)
+        func_mock.assert_called_once_with()
+
     def test_250_unpause(self):
         func_mock = unittest.mock.Mock()
 
@@ -1447,6 +1458,17 @@ netvm default=True type=vm \n"""
 
         self.vm.unpause = coroutine_mock
         value = self.call_mgmt_func(b"admin.vm.Unpause", b"test-vm1")
+        self.assertIsNone(value)
+        func_mock.assert_called_once_with()
+
+    def test_251_resume(self):
+        func_mock = unittest.mock.Mock()
+
+        async def coroutine_mock(*args, **kwargs):
+            return func_mock(*args, **kwargs)
+
+        self.vm.resume = coroutine_mock
+        value = self.call_mgmt_func(b"admin.vm.Resume", b"test-vm1")
         self.assertIsNone(value)
         func_mock.assert_called_once_with()
 


### PR DESCRIPTION
This could be useful for preloaded disposables as (emergency) paused disposables might hang after hypervisor goes to suspend mode and resumes from it.

related: https://github.com/QubesOS/qubes-issues/issues/9918