### PR TITLE
Late GUID for preloaded disposables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,6 @@ all:
 
 install:
 ifeq ($(OS),Linux)
-	$(MAKE) install -C linux/autostart
 	$(MAKE) install -C linux/systemd
 	$(MAKE) install -C linux/aux-tools
 	$(MAKE) install -C linux/system-config

--- a/linux/autostart/Makefile
+++ b/linux/autostart/Makefile
@@ -1,6 +1,0 @@
-all:
-	true
-
-install:
-	mkdir -p $(DESTDIR)/etc/xdg/autostart
-	cp qubes-preload-dispvm.desktop $(DESTDIR)/etc/xdg/autostart

--- a/linux/autostart/qubes-preload-dispvm.desktop
+++ b/linux/autostart/qubes-preload-dispvm.desktop
@@ -1,9 +1,0 @@
-[Desktop Entry]
-Icon=qubes
-Name=Qubes Preload Disposables
-Comment=Workaround for session monitoring with qubes.WaitForSession
-Categories=System;Monitor;
-Exec=systemctl start qubes-preload-dispvm.service
-Terminal=false
-NoDisplay=true
-Type=Application

--- a/qubes/tests/api_admin.py
+++ b/qubes/tests/api_admin.py
@@ -3861,7 +3861,7 @@ netvm default=True type=vm \n"""
             "domain-preload-dispvm-autostart", self._test_event_handler
         )
         self.vm.features["qrexec"] = "1"
-        self.vm.features["supported-rpc.qubes.WaitForSession"] = "1"
+        self.vm.features["supported-rpc.qubes.WaitForRunningSystem"] = "1"
         self.vm.features["preload-dispvm-max"] = "1"
         for _ in range(10):
             if len(self.vm.get_feat_preload()) == 1:

--- a/qubes/vm/mix/dvmtemplate.py
+++ b/qubes/vm/mix/dvmtemplate.py
@@ -100,16 +100,11 @@ class DVMTemplateMixin(qubes.events.Emitter):
         if not self.features.check_with_template("qrexec", None):
             raise qubes.exc.QubesValueError("Qube does not support qrexec")
 
-        gui = bool(self.guivm and self.features.get("gui", True))
-        if gui:
-            service = "qubes.WaitForSession"
-        else:
-            service = "qubes.WaitForRunningSystem"
+        service = "qubes.WaitForRunningSystem"
         supported_service = "supported-rpc." + service
         if not self.features.check_with_template(supported_service, False):
             raise qubes.exc.QubesValueError(
-                "Qube GUI is '%s' and does not support the RPC '%s'"
-                % (gui, service)
+                "Qube does not support the RPC '%s'" % service
             )
 
         value = value or "0"

--- a/rpm_spec/core-dom0.spec.in
+++ b/rpm_spec/core-dom0.spec.in
@@ -368,7 +368,6 @@ done
 /usr/bin/qubes-*
 /usr/bin/qmemmand
 /usr/bin/qubesd*
-/etc/xdg/autostart/qubes-preload-dispvm.desktop
 
 %{_mandir}/man1/qubes*.1*
 


### PR DESCRIPTION
- Autostarted applications don't show when preloading; and
- Preloaded qubes paused before the session will have a working GUI when
  the session starts.

For: https://github.com/QubesOS/qubes-issues/issues/1512
For: https://github.com/qubesos/qubes-issues/issues/9940
For: https://github.com/qubesos/qubes-issues/issues/9907
Requires: https://github.com/QubesOS/qubes-core-admin-client/pull/359
Requires: https://github.com/QubesOS/qubes-core-admin/pull/689