### PR TITLE
Allow VM boot modes to change a VM's default user

### DIFF
--- a/qubes/tests/ext.py
+++ b/qubes/tests/ext.py
@@ -1587,6 +1587,95 @@ class TC_00_CoreFeatures(qubes.tests.QubesTestCase):
             ],
         )
 
+    def test_056_bootmode_default_user(self):
+        del self.vm.template
+        self.loop.run_until_complete(
+            self.ext.qubes_features_request(
+                self.vm,
+                "features-request",
+                untrusted_features={
+                    "boot-mode.name.vmreq": "VMReq",
+                    "boot-mode.kernelopts.vmreq": "vmreq1 vmreq2",
+                    "boot-mode.default-user.vmreq": "altuser",
+                },
+            )
+        )
+        self.assertListEqual(
+            self.vm.mock_calls,
+            [
+                ("features.items", (), {}),
+                (
+                    "features.__setitem__",
+                    ("boot-mode.kernelopts.vmreq", "vmreq1 vmreq2"),
+                    {},
+                ),
+                (
+                    "features.__setitem__",
+                    ("boot-mode.name.vmreq", "VMReq"),
+                    {},
+                ),
+                (
+                    "features.__setitem__",
+                    ("boot-mode.default-user.vmreq", "altuser"),
+                    {},
+                ),
+                ("features.get", ("qrexec", False), {}),
+                ("features.get", ("qrexec", False), {}),
+            ],
+        )
+
+    def test_056_bootmode_default_user_mismatch(self):
+        del self.vm.template
+        self.loop.run_until_complete(
+            self.ext.qubes_features_request(
+                self.vm,
+                "features-request",
+                untrusted_features={
+                    "boot-mode.name.vmreq": "VMReq",
+                    "boot-mode.kernelopts.vmreq": "vmreq1 vmreq2",
+                    "boot-mode.default-user.nope": "altuser",
+                },
+            )
+        )
+        self.assertListEqual(
+            self.vm.mock_calls,
+            [
+                ("features.items", (), {}),
+                (
+                    "features.__setitem__",
+                    ("boot-mode.kernelopts.vmreq", "vmreq1 vmreq2"),
+                    {},
+                ),
+                (
+                    "features.__setitem__",
+                    ("boot-mode.name.vmreq", "VMReq"),
+                    {},
+                ),
+                ("features.get", ("qrexec", False), {}),
+                ("features.get", ("qrexec", False), {}),
+            ],
+        )
+
+    def test_057_bootmode_default_user_default_bootmode(self):
+        del self.vm.template
+        self.loop.run_until_complete(
+            self.ext.qubes_features_request(
+                self.vm,
+                "features-request",
+                untrusted_features={
+                    "boot-mode.default-user.default": "altuser",
+                },
+            )
+        )
+        self.assertListEqual(
+            self.vm.mock_calls,
+            [
+                ("features.items", (), {}),
+                ("features.get", ("qrexec", False), {}),
+                ("features.get", ("qrexec", False), {}),
+            ],
+        )
+
     def test_100_servicevm_feature(self):
         self.vm.provides_network = True
         self.ext.set_servicevm_feature(self.vm)

--- a/qubes/tests/vm/qubesvm.py
+++ b/qubes/tests/vm/qubesvm.py
@@ -3232,3 +3232,25 @@ class TC_90_QubesVM(QubesVMTestsMixin, qubes.tests.QubesTestCase):
         self.assertEqual(vm.bootmode, "testmode3")
         del vm.template.features["boot-mode.kernelopts.testmode3"]
         self.assertEqual(vm.bootmode, "default")
+
+    def test_812_bootmode_default_user(self):
+        vm = self.get_vm(cls=qubes.vm.appvm.AppVM)
+        vm.template = self.get_vm(cls=qubes.vm.templatevm.TemplateVM)
+        vm.bootmode = qubes.property.DEFAULT
+        self.assertEqual(vm.get_default_user(), "user")
+        vm.features["boot-mode.kernelopts.testmode1"] = "abc def"
+        vm.features["boot-mode.default-user.testmode1"] = "altuser"
+        vm.features["boot-mode.active"] = "testmode1"
+        self.assertEqual(vm.get_default_user(), "altuser")
+        del vm.features["boot-mode.default-user.testmode1"]
+        self.assertEqual(vm.get_default_user(), "user")
+        vm.features["boot-mode.default-user.testmode1"] = "altuser"
+        del vm.features["boot-mode.kernelopts.testmode1"]
+        self.assertEqual(vm.get_default_user(), "user")
+        del vm.features["boot-mode.default-user.testmode1"]
+        vm.template.features["boot-mode.kernelopts.testmode2"] = "ghi jkl"
+        vm.template.features["boot-mode.default-user.testmode2"] = "altuser2"
+        vm.features["boot-mode.active"] = "testmode2"
+        self.assertEqual(vm.get_default_user(), "altuser2")
+        del vm.features["boot-mode.active"]
+        self.assertEqual(vm.get_default_user(), "user")


### PR DESCRIPTION
Pretty straightforward, adds another feature category `boot-mode.default-user.<boot-mode-name>`. Regression tests pass on my end, and the feature itself works in testing. I'm able to remove the qrexec overrides for Whonix-Workstation, add a default-user feature for sysmaint mode, and have sysmaint mode appear to function properly. Software updates also work again as dom0 can now run commands in VMs as root again.