### PR TITLE
Rename on_domain_shutdown to avoid DispVM clobbering the function

### DIFF
--- a/qubes/vm/dispvm.py
+++ b/qubes/vm/dispvm.py
@@ -410,7 +410,7 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
     @qubes.events.handler("domain-shutdown")
     async def on_domain_shutdown(
         self, _event, **_kwargs
-    ):  # pylint: disable=invalid-overridden-method
+    ):
         """Do auto cleanup if enabled"""
         await self._auto_cleanup()
 

--- a/qubes/vm/mix/net.py
+++ b/qubes/vm/mix/net.py
@@ -306,7 +306,7 @@ class NetVMMixin(qubes.events.Emitter):
             self.netvm = None
 
     @qubes.events.handler("domain-shutdown")
-    def on_domain_shutdown(self, event, **kwargs):
+    def on_domain_shutdown_net(self, event, **kwargs):
         """Cleanup network interfaces of connected, running VMs.
 
         This will allow re-reconnecting them cleanly later.


### PR DESCRIPTION
DispVM.on_domain_shutdown clobbers NetVMMixin.on_domain_shutdown. Rename
the latter to avoid that.