### PR TITLE
New option disable snapshots to use a private volume directly

### DIFF
--- a/qubes/api/__init__.py
+++ b/qubes/api/__init__.py
@@ -245,12 +245,12 @@ class AbstractQubesAPI:
         if not predicate:
             raise PermissionDenied()
 
-    def validate_size(self,
-                      untrusted_size: bytes,
-                      allow_negative: bool = False) -> int:
+    def validate_size(
+        self, untrusted_size: bytes, allow_negative: bool = False
+    ) -> int:
         self.enforce(isinstance(untrusted_size, bytes))
         coefficient = 1
-        if allow_negative and untrusted_size.startswith(b'-'):
+        if allow_negative and untrusted_size.startswith(b"-"):
             coefficient = -1
             untrusted_size = untrusted_size[1:]
         if not untrusted_size.isdigit():

--- a/qubes/api/__init__.py
+++ b/qubes/api/__init__.py
@@ -245,15 +245,21 @@ class AbstractQubesAPI:
         if not predicate:
             raise PermissionDenied()
 
-    def validate_size(self, untrusted_size: bytes) -> int:
+    def validate_size(self,
+                      untrusted_size: bytes,
+                      allow_negative: bool = False) -> int:
         self.enforce(isinstance(untrusted_size, bytes))
+        coefficient = 1
+        if allow_negative and untrusted_size.startswith(b'-'):
+            coefficient = -1
+            untrusted_size = untrusted_size[1:]
         if not untrusted_size.isdigit():
             raise qubes.exc.ProtocolError("Size must be ASCII digits (only)")
         if len(untrusted_size) >= 20:
             raise qubes.exc.ProtocolError("Sizes limited to 19 decimal digits")
         if untrusted_size[0] == 48 and untrusted_size != b"0":
             raise qubes.exc.ProtocolError("Spurious leading zeros not allowed")
-        return int(untrusted_size)
+        return int(untrusted_size) * coefficient
 
 
 class QubesDaemonProtocol(asyncio.Protocol):

--- a/qubes/api/admin.py
+++ b/qubes/api/admin.py
@@ -502,7 +502,7 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
             src_volume=src_volume, dst_volume=dst_volume
         )
         self.dest.volumes[self.arg] = await qubes.utils.coro_maybe(
-            dst_volume.import_volume(src_volume)
+            self.dest.storage.import_volume(dst_volume, src_volume)
         )
         self.app.save()
 

--- a/qubes/api/admin.py
+++ b/qubes/api/admin.py
@@ -550,7 +550,7 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
     )
     async def vm_volume_set_revisions_to_keep(self, untrusted_payload):
         self.enforce(self.arg in self.dest.volumes.keys())
-        newvalue = self.validate_size(untrusted_payload)
+        newvalue = self.validate_size(untrusted_payload, allow_negative=True)
 
         self.fire_event_for_permission(newvalue=newvalue)
 
@@ -820,7 +820,7 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
         self.enforce(self.dest.name == "dom0")
         self.enforce(self.arg in self.app.pools.keys())
         pool = self.app.pools[self.arg]
-        newvalue = self.validate_size(untrusted_payload)
+        newvalue = self.validate_size(untrusted_payload, allow_negative=True)
 
         self.fire_event_for_permission(newvalue=newvalue)
 

--- a/qubes/api/admin.py
+++ b/qubes/api/admin.py
@@ -552,6 +552,9 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
         self.enforce(self.arg in self.dest.volumes.keys())
         newvalue = self.validate_size(untrusted_payload, allow_negative=True)
 
+        if newvalue < -1:
+            raise qubes.api.ProtocolError("Invalid value for revisions_to_keep")
+
         self.fire_event_for_permission(newvalue=newvalue)
 
         currentvalue = self.dest.volumes[self.arg].revisions_to_keep
@@ -826,6 +829,9 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
         self.enforce(self.arg in self.app.pools.keys())
         pool = self.app.pools[self.arg]
         newvalue = self.validate_size(untrusted_payload, allow_negative=True)
+
+        if newvalue < -1:
+            raise qubes.api.ProtocolError("Invalid value for revisions_to_keep")
 
         self.fire_event_for_permission(newvalue=newvalue)
 

--- a/qubes/api/admin.py
+++ b/qubes/api/admin.py
@@ -554,7 +554,9 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
 
         self.fire_event_for_permission(newvalue=newvalue)
 
-        if newvalue == -1 and self.dest.is_running():
+        currentvalue = self.dest.volumes[self.arg].revisions_to_keep
+        if self.dest.is_running() and newvalue != currentvalue and \
+                (currentvalue == -1 or newvalue == -1):
             raise qubes.exc.QubesVMNotHaltedError(self.dest)
 
         self.dest.volumes[self.arg].revisions_to_keep = newvalue

--- a/qubes/api/admin.py
+++ b/qubes/api/admin.py
@@ -554,6 +554,9 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
 
         self.fire_event_for_permission(newvalue=newvalue)
 
+        if newvalue == -1 and self.dest.is_running():
+            raise qubes.exc.QubesVMNotHaltedError(self.dest)
+
         self.dest.volumes[self.arg].revisions_to_keep = newvalue
         self.app.save()
 

--- a/qubes/api/admin.py
+++ b/qubes/api/admin.py
@@ -551,18 +551,8 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
     async def vm_volume_set_revisions_to_keep(self, untrusted_payload):
         self.enforce(self.arg in self.dest.volumes.keys())
         newvalue = self.validate_size(untrusted_payload, allow_negative=True)
-
-        if newvalue < -1:
-            raise qubes.api.ProtocolError("Invalid value for revisions_to_keep")
-
         self.fire_event_for_permission(newvalue=newvalue)
-
-        currentvalue = self.dest.volumes[self.arg].revisions_to_keep
-        if self.dest.is_running() and newvalue != currentvalue and \
-                (currentvalue == -1 or newvalue == -1):
-            raise qubes.exc.QubesVMNotHaltedError(self.dest)
-
-        self.dest.volumes[self.arg].revisions_to_keep = newvalue
+        self.dest.storage.set_revisions_to_keep(self.arg, newvalue)
         self.app.save()
 
     @qubes.api.method("admin.vm.volume.Set.rw", scope="local", write=True)

--- a/qubes/backup.py
+++ b/qubes/backup.py
@@ -517,10 +517,15 @@ class Backup:
             summary_line += fmt.format(size_to_human(vm_size))
 
             if qid != 0 and vm_info.vm.is_running():
-                summary_line += (
-                    " <-- The VM is running, backup will contain "
-                    "its state from before its start!"
-                )
+                if [volume for volume in vm_info.vm.volumes.values()
+                           if volume.snapshots_disabled]:
+                    summary_line += (
+                        " <-- The VM is running and private volume snapshots "
+                        "are disabled. Backup will fail!"
+                    )
+                else:
+                    summary_line += " <-- The VM is running, backup will " \
+                                    "contain its state from before its start!"
 
             summary += summary_line + "\n"
 
@@ -823,6 +828,15 @@ class Backup:
             backup_app.domains[qid].features["backup-content"] = True
             backup_app.domains[qid].features["backup-path"] = vm_info.subdir
             backup_app.domains[qid].features["backup-size"] = vm_info.size
+
+            # VM running private volumes without snapshoting them
+            # (revision_to_keep = -1) must be powered off to be backup
+            if backup_app.domains[qid].is_running:
+                for volume in backup_app.domains[qid].volumes.values():
+                    if volume.snapshots_disabled:
+                        raise qubes.exc.QubesVMNotHaltedError(
+                            backup_app.domains[qid]
+                        )
         backup_app.save()
         del backup_app
 

--- a/qubes/backup.py
+++ b/qubes/backup.py
@@ -517,15 +517,20 @@ class Backup:
             summary_line += fmt.format(size_to_human(vm_size))
 
             if qid != 0 and vm_info.vm.is_running():
-                if [volume for volume in vm_info.vm.volumes.values()
-                           if volume.snapshots_disabled]:
+                if [
+                    volume
+                    for volume in vm_info.vm.volumes.values()
+                    if volume.snapshots_disabled
+                ]:
                     summary_line += (
                         " <-- The VM is running and private volume snapshots "
                         "are disabled. Backup will fail!"
                     )
                 else:
-                    summary_line += " <-- The VM is running, backup will " \
-                                    "contain its state from before its start!"
+                    summary_line += (
+                        " <-- The VM is running, backup will "
+                        "contain its state from before its start!"
+                    )
 
             summary += summary_line + "\n"
 

--- a/qubes/storage/__init__.py
+++ b/qubes/storage/__init__.py
@@ -809,6 +809,12 @@ class Storage:
 
     async def start(self):
         """Execute the start method on each volume"""
+        for vol in self.vm.volumes.values():
+            if (vol.source and vol.source.snapshots_disabled
+                    and vol.source.is_running()):
+                raise qubes.exc.QubesVMError(
+                    self.vm, f"Volume {vol.source.vid} is running"
+                )
         await qubes.utils.void_coros_maybe(
             # pylint: disable=line-too-long
             (

--- a/qubes/storage/__init__.py
+++ b/qubes/storage/__init__.py
@@ -98,7 +98,7 @@ class Volume:
         snap_on_start=False,
         source=None,
         ephemeral=None,
-        **kwargs
+        **kwargs,
     ):
         """Initialize a volume.
 
@@ -517,9 +517,11 @@ class Volume:
 
     @property
     def snapshots_disabled(self) -> bool:
-        return (self.revisions_to_keep == -1 and
-                not self.snap_on_start and
-                self.save_on_stop)
+        return (
+            self.revisions_to_keep == -1
+            and not self.snap_on_start
+            and self.save_on_stop
+        )
 
     @property
     def state_file(self) -> str:
@@ -810,15 +812,17 @@ class Storage:
     def set_revisions_to_keep(self, volume, value):
         if value < -1:
             raise qubes.exc.QubesValueError(
-                "Invalid value for revisions_to_keep")
+                "Invalid value for revisions_to_keep"
+            )
 
         currentvalue = self.vm.volumes[volume].revisions_to_keep
-        enabling_disabling_snapshots = value != currentvalue and \
-                (currentvalue == -1 or value == -1)
+        enabling_disabling_snapshots = value != currentvalue and (
+            currentvalue == -1 or value == -1
+        )
         if self.vm.is_running() and enabling_disabling_snapshots:
             raise qubes.exc.QubesVMNotHaltedError(self.vm)
 
-        if self.vm.klass == 'AppVM' and enabling_disabling_snapshots:
+        if self.vm.klass == "AppVM" and enabling_disabling_snapshots:
             for vm in self.vm.dispvms:
                 if vm.is_running():
                     raise qubes.exc.QubesVMNotHaltedError(vm)
@@ -828,8 +832,11 @@ class Storage:
     async def start(self):
         """Execute the start method on each volume"""
         for vol in self.vm.volumes.values():
-            if (vol.source and vol.source.snapshots_disabled
-                    and vol.source.is_running()):
+            if (
+                vol.source
+                and vol.source.snapshots_disabled
+                and vol.source.is_running()
+            ):
                 raise qubes.exc.QubesVMError(
                     self.vm, f"Volume {vol.source.vid} is running"
                 )
@@ -846,7 +853,7 @@ class Storage:
         )
 
         for vol in self.vm.volumes.values():
-            with open(vol.state_file, 'w', encoding='ascii'):
+            with open(vol.state_file, "w", encoding="ascii"):
                 pass
 
     async def stop(self):

--- a/qubes/storage/__init__.py
+++ b/qubes/storage/__init__.py
@@ -513,6 +513,12 @@ class Volume:
         msg = msg.format(str(self.__class__.__name__), method_name)
         return NotImplementedError(msg)
 
+    @property
+    def snapshots_disabled(self) -> bool:
+        return (self.revisions_to_keep == -1 and
+                not self.snap_on_start and
+                self.save_on_stop)
+
 
 class Storage:
     """Class for handling VM virtual disks.

--- a/qubes/storage/__init__.py
+++ b/qubes/storage/__init__.py
@@ -921,6 +921,18 @@ class Storage:
             self.get_volume(volume).import_data_end(success=success)
         )
 
+    async def import_volume(self, dst_volume: Volume, src_volume: Volume):
+        """Helper function to import data from another volume"""
+        if src_volume.is_running() and src_volume.snapshots_disabled:
+            raise StoragePoolException(
+                f"Volume {src_volume.vid} must be stopped before importing its "
+                f"data"
+            )
+
+        return await qubes.utils.coro_maybe(
+            dst_volume.import_volume(src_volume)
+        )
+
 
 class VolumesCollection:
     """Convenient collection wrapper for pool.get_volume and

--- a/qubes/storage/__init__.py
+++ b/qubes/storage/__init__.py
@@ -525,8 +525,11 @@ class Volume:
     def state_file(self) -> str:
         return os.path.join(
             VOLUME_STATE_DIR,
-            f"{self.pool.name}__{self.vid}".replace(
-                '-', '--').replace('/', '-'))
+            VOLUME_STATE_PREFIX
+            + f"{self.pool.name}:{self.vid}".replace("-", "--").replace(
+                "/", "-"
+            ),
+        )
 
     def is_running(self) -> bool:
         return os.path.exists(self.state_file)
@@ -836,8 +839,7 @@ class Storage:
             for name, vol in self.vm.volumes.items()
         )
         for vol in self.vm.volumes.values():
-            if os.path.exists(vol.state_file):
-                os.unlink(vol.state_file)
+            qubes.utils.remove_file(vol.state_file)
 
     def unused_frontend(self):
         """Find an unused device name"""

--- a/qubes/storage/lvm.py
+++ b/qubes/storage/lvm.py
@@ -833,8 +833,9 @@ class ThinVolume(qubes.storage.Volume):
         """
         if self.snap_on_start or self.save_on_stop:
             vid = self.vid if self.snapshots_disabled else self._vid_snap
-            snap_path = ("/dev/mapper/" +
-                         vid.replace("-", "--").replace("/", "-"))
+            snap_path = "/dev/mapper/" + vid.replace("-", "--").replace(
+                "/", "-"
+            )
             return qubes.storage.BlockDevice(
                 snap_path, self.name, None, self.rw, self.domain, self.devtype
             )

--- a/qubes/storage/reflink.py
+++ b/qubes/storage/reflink.py
@@ -268,6 +268,8 @@ class ReflinkVolume(qubes.storage.Volume):
     def start(self):  # pylint: disable=invalid-overridden-method
         self._remove_incomplete_images()
         if self.snapshots_disabled:
+            self._prune_revisions(keep=0)
+            _remove_file(self._path_precache)
             return self
         if not self.is_dirty():
             if self.snap_on_start:

--- a/qubes/storage/reflink.py
+++ b/qubes/storage/reflink.py
@@ -176,8 +176,9 @@ class ReflinkVolume(qubes.storage.Volume):
         self._path_precache = self._path_vid + "-precache.img"
         self._path_dirty = self._path_vid + "-dirty.img"
         self._path_import = self._path_vid + "-import.img"
-        self.path = self._path_clean if self.snapshots_disabled \
-                                     else self._path_dirty
+        self.path = (
+            self._path_clean if self.snapshots_disabled else self._path_dirty
+        )
 
     @contextmanager
     def _update_precache(self):

--- a/qubes/storage/zfs.py
+++ b/qubes/storage/zfs.py
@@ -1892,7 +1892,7 @@ class ZFSVolume(qubes.storage.Volume):
                 )
             )
         )
-        num = self.revisions_to_keep
+        num = max(0, self.revisions_to_keep)
         for snapshot, _ in revs[num:]:
             vsn = VolumeSnapshot.make(self.vid, snapshot)
             self.log.debug("Pruning %s", vsn)
@@ -1908,8 +1908,9 @@ class ZFSVolume(qubes.storage.Volume):
             )
             if s.name.is_clean_snapshot()
         ]
-        new = self.volume.clean_snapshot()
-        await self.pool.accessor.snapshot_volume_async(new, log=self.log)
+        if not self.snapshots_disabled:
+            new = self.volume.clean_snapshot()
+            await self.pool.accessor.snapshot_volume_async(new, log=self.log)
         for old in existing_cleans:
             await self.pool.accessor.remove_volume_async(
                 old,
@@ -2006,6 +2007,18 @@ class ZFSVolume(qubes.storage.Volume):
             # then clone it from there.
             samepoolsource = cast(ZFSVolume, source)
             self.log.debug("Source shares pool with me")
+            if samepoolsource.snapshots_disabled:
+                if samepoolsource.is_running():
+                    raise qubes.storage.StoragePoolException(
+                        f"Volume {samepoolsource.vid} must be stopped before "
+                        "being cloned."
+                    )
+                assert not samepoolsource.is_running(), \
+                    f"Volume {samepoolsource.vid} is running"
+                await samepoolsource.pool.accessor.snapshot_volume_async(
+                    samepoolsource.volume.clean_snapshot(),
+                    log=samepoolsource.log
+                )
             try:
                 src = samepoolsource.latest_clean_snapshot[0]
             except DatasetDoesNotExist:
@@ -2016,6 +2029,11 @@ class ZFSVolume(qubes.storage.Volume):
             async with self._clone_volume_2phase(src):
                 # Do nothing.  The context manager takes care of everything.
                 pass
+
+            if samepoolsource.snapshots_disabled:
+                # This will schedule removing of created clean snapshot
+                # pylint: disable=protected-access
+                await samepoolsource._mark_clean()
         else:
             # Source is not a ZFS one;
             # create the dataset with the size of the
@@ -2499,6 +2517,15 @@ class ZFSVolume(qubes.storage.Volume):
             )
         exported = self.exported_volume_name(get_random_string(8))
         dest_dset = Volume.make(exported)
+        if self.snapshots_disabled:
+            if self.is_running():
+                raise qubes.storage.StoragePoolException(
+                    f"Volume {self.vid} must be stopped before being cloned"
+                )
+            await self.pool.accessor.snapshot_volume_async(
+                    self.volume.clean_snapshot(),
+                    log=self.log
+                  )
         try:
             src = self.latest_clean_snapshot[0]
         except DatasetDoesNotExist:
@@ -2514,6 +2541,8 @@ class ZFSVolume(qubes.storage.Volume):
             NO_AUTO_SNAPSHOT,
             log=self.log,
         )
+        if self.snapshots_disabled:
+            await self._mark_clean()
         return os.path.join(ZVOL_DIR, exported)
 
     async def export_end(self, path: str) -> None:

--- a/qubes/storage/zfs.py
+++ b/qubes/storage/zfs.py
@@ -2013,11 +2013,12 @@ class ZFSVolume(qubes.storage.Volume):
                         f"Volume {samepoolsource.vid} must be stopped before "
                         "being cloned."
                     )
-                assert not samepoolsource.is_running(), \
-                    f"Volume {samepoolsource.vid} is running"
+                assert (
+                    not samepoolsource.is_running()
+                ), f"Volume {samepoolsource.vid} is running"
                 await samepoolsource.pool.accessor.snapshot_volume_async(
                     samepoolsource.volume.clean_snapshot(),
-                    log=samepoolsource.log
+                    log=samepoolsource.log,
                 )
             try:
                 src = samepoolsource.latest_clean_snapshot[0]
@@ -2523,9 +2524,8 @@ class ZFSVolume(qubes.storage.Volume):
                     f"Volume {self.vid} must be stopped before being cloned"
                 )
             await self.pool.accessor.snapshot_volume_async(
-                    self.volume.clean_snapshot(),
-                    log=self.log
-                  )
+                self.volume.clean_snapshot(), log=self.log
+            )
         try:
             src = self.latest_clean_snapshot[0]
         except DatasetDoesNotExist:

--- a/qubes/tests/api_admin.py
+++ b/qubes/tests/api_admin.py
@@ -3523,35 +3523,38 @@ netvm default=True type=vm \n"""
 
     def test_612_backup_when_vm_with_disabled_snapshots_is_running(self):
         backup_profile = (
-            'include:\n'
-            ' - test-vm1\n'
-            'destination_vm: test-vm1\n'
-            'destination_path: /var/tmp\n'
-            'passphrase_text: test\n'
+            "include:\n"
+            " - test-vm1\n"
+            "destination_vm: test-vm1\n"
+            "destination_path: /var/tmp\n"
+            "passphrase_text: test\n"
         )
         expected_info = (
-            '------------------+--------------+--------------+\n'
-            '               VM |         type |         size |\n'
-            '------------------+--------------+--------------+\n'
-            '         test-vm1 |           VM |            0 | <-- The VM is \
-running and private volume snapshots are disabled. Backup will fail!\n'
-            '------------------+--------------+--------------+\n'
-            '      Total size: |                           0 |\n'
-            '------------------+--------------+--------------+\n'
-            'VMs not selected for backup:\n'
-            ' - dom0\n'
-            ' - test-template\n'
+            "------------------+--------------+--------------+\n"
+            "               VM |         type |         size |\n"
+            "------------------+--------------+--------------+\n"
+            "         test-vm1 |           VM |            0 | <-- The VM is \
+running and private volume snapshots are disabled. Backup will fail!\n"
+            "------------------+--------------+--------------+\n"
+            "      Total size: |                           0 |\n"
+            "------------------+--------------+--------------+\n"
+            "VMs not selected for backup:\n"
+            " - dom0\n"
+            " - test-template\n"
         )
         with tempfile.TemporaryDirectory() as profile_dir:
-            with open(os.path.join(profile_dir, 'testprofile.conf'), 'w') as \
-                    profile_file:
+            with open(
+                os.path.join(profile_dir, "testprofile.conf"), "w"
+            ) as profile_file:
                 profile_file.write(backup_profile)
             self.vm.is_running = lambda: True
             self.vm.volumes["private"].revisions_to_keep = -1
-            with unittest.mock.patch('qubes.config.backup_profile_dir',
-                                     profile_dir):
-                result = self.call_mgmt_func(b'admin.backup.Info', b'dom0',
-                                             b'testprofile')
+            with unittest.mock.patch(
+                "qubes.config.backup_profile_dir", profile_dir
+            ):
+                result = self.call_mgmt_func(
+                    b"admin.backup.Info", b"dom0", b"testprofile"
+                )
             self.assertEqual(result, expected_info)
 
     @unittest.mock.patch("qubes.backup.Backup")
@@ -3630,33 +3633,39 @@ running and private volume snapshots are disabled. Backup will fail!\n'
             "qubes.BackupPassphrase+testprofile"
         )
 
-    @unittest.mock.patch('qubes.backup.Backup')
-    def test_622_backup_execute_when_disable_snapshot_vm_running(self, mock_backup):
+    @unittest.mock.patch("qubes.backup.Backup")
+    def test_622_backup_execute_when_disable_snapshot_vm_running(
+        self, mock_backup
+    ):
         backup_profile = (
-            'include:\n'
-            ' - test-vm1\n'
-            'destination_vm: test-vm1\n'
-            'destination_path: /home/user\n'
-            'passphrase_text: test\n'
+            "include:\n"
+            " - test-vm1\n"
+            "destination_vm: test-vm1\n"
+            "destination_path: /home/user\n"
+            "passphrase_text: test\n"
         )
         mock_backup.return_value.backup_do.side_effect = self.dummy_coro
         with tempfile.TemporaryDirectory() as profile_dir:
-            with open(os.path.join(profile_dir, 'testprofile.conf'), 'w') as \
-                    profile_file:
+            with open(
+                os.path.join(profile_dir, "testprofile.conf"), "w"
+            ) as profile_file:
                 profile_file.write(backup_profile)
-            with unittest.mock.patch('qubes.config.backup_profile_dir',
-                                     profile_dir):
-                result = self.call_mgmt_func(b'admin.backup.Execute', b'dom0',
-                                             b'testprofile')
+            with unittest.mock.patch(
+                "qubes.config.backup_profile_dir", profile_dir
+            ):
+                result = self.call_mgmt_func(
+                    b"admin.backup.Execute", b"dom0", b"testprofile"
+                )
         self.assertIsNone(result)
         mock_backup.assert_called_once_with(
             self.app,
             {self.vm},
             set(),
             target_vm=self.vm,
-            target_dir='/home/user',
+            target_dir="/home/user",
             compressed=True,
-            passphrase='test')
+            passphrase="test",
+        )
         mock_backup.return_value.backup_do.assert_called_once_with()
 
     def test_630_vm_stats(self):
@@ -4333,11 +4342,17 @@ running and private volume snapshots are disabled. Backup will fail!\n'
             "keys.return_value": ["root", "private", "volatile", "kernel"],
         }
         self.vm.volumes.configure_mock(**volumes_conf)
-        value = self.call_mgmt_func(b'admin.vm.volume.Set.revisions_to_keep',
-            b'test-vm1', b'private', b'2')
+        value = self.call_mgmt_func(
+            b"admin.vm.volume.Set.revisions_to_keep",
+            b"test-vm1",
+            b"private",
+            b"2",
+        )
         self.assertIsNone(value)
-        self.assertIn(('__getitem__', ('private',), {}), self.vm.volumes.mock_calls)
-        self.assertEqual(self.vm.volumes['private'].revisions_to_keep, 2)
+        self.assertIn(
+            ("__getitem__", ("private",), {}), self.vm.volumes.mock_calls
+        )
+        self.assertEqual(self.vm.volumes["private"].revisions_to_keep, 2)
         self.app.save.assert_called_once_with()
 
     def test_711_vm_volume_set_revisions_to_keep_negative(self):
@@ -4348,10 +4363,10 @@ running and private volume snapshots are disabled. Backup will fail!\n'
         self.vm.volumes.configure_mock(**volumes_conf)
         with self.assertRaises(qubes.exc.QubesValueError):
             self.call_mgmt_func(
-                b'admin.vm.volume.Set.revisions_to_keep',
-                b'test-vm1',
-                b'private',
-                b'-2',
+                b"admin.vm.volume.Set.revisions_to_keep",
+                b"test-vm1",
+                b"private",
+                b"-2",
             )
 
     def test_712_vm_volume_set_revisions_to_keep_not_a_number(self):
@@ -4362,32 +4377,32 @@ running and private volume snapshots are disabled. Backup will fail!\n'
         self.vm.volumes.configure_mock(**volumes_conf)
         with self.assertRaises(qubes.api.ProtocolError):
             self.call_mgmt_func(
-                b'admin.vm.volume.Set.revisions_to_keep',
-                b'test-vm1',
-                b'private',
-                b'abc',
+                b"admin.vm.volume.Set.revisions_to_keep",
+                b"test-vm1",
+                b"private",
+                b"abc",
             )
 
     def test_713_vm_volume_disable_snapshots_while_running(self):
         self.vm.volumes = unittest.mock.MagicMock()
         volumes_conf = {
-            'keys.return_value': ['root', 'private', 'volatile', 'kernel'],
+            "keys.return_value": ["root", "private", "volatile", "kernel"],
         }
         self.vm.volumes.configure_mock(**volumes_conf)
         with unittest.mock.patch.object(self.vm, "is_running") as _mock:
             _mock.return_value = True
             with self.assertRaises(qubes.exc.QubesVMNotHaltedError):
                 self.call_mgmt_func(
-                    b'admin.vm.volume.Set.revisions_to_keep',
-                    b'test-vm1',
-                    b'private',
-                    b'-1',
+                    b"admin.vm.volume.Set.revisions_to_keep",
+                    b"test-vm1",
+                    b"private",
+                    b"-1",
                 )
 
     def test_714_vm_volume_re_enable_snapshots_while_running(self):
         self.vm.volumes = unittest.mock.MagicMock()
         volumes_conf = {
-            'keys.return_value': ['root', 'private', 'volatile', 'kernel'],
+            "keys.return_value": ["root", "private", "volatile", "kernel"],
         }
         self.vm.volumes.configure_mock(**volumes_conf)
         self.vm.volumes["private"].revisions_to_keep = -1
@@ -4395,56 +4410,70 @@ running and private volume snapshots are disabled. Backup will fail!\n'
             _mock.return_value = True
             with self.assertRaises(qubes.exc.QubesVMNotHaltedError):
                 self.call_mgmt_func(
-                    b'admin.vm.volume.Set.revisions_to_keep',
-                    b'test-vm1',
-                    b'private',
-                    b'2',
+                    b"admin.vm.volume.Set.revisions_to_keep",
+                    b"test-vm1",
+                    b"private",
+                    b"2",
                 )
 
     def test_715_start_volume_sourcing_running_volume_without_snapshot(self):
         self.vm.volumes = {
-            'root': unittest.mock.Mock(),
-            'private': unittest.mock.Mock(),
-            'volatile': unittest.mock.Mock(),
-            'kernel': unittest.mock.Mock(),
+            "root": unittest.mock.Mock(),
+            "private": unittest.mock.Mock(),
+            "volatile": unittest.mock.Mock(),
+            "kernel": unittest.mock.Mock(),
         }
         self.vm.volumes["private"].source = unittest.mock.Mock()
         self.vm.volumes["private"].source.snapshots_disabled = True
         self.vm.volumes["private"].source.is_running.return_value = True
         with self.assertRaises(qubes.exc.QubesVMError):
             self.loop.run_until_complete(
-                asyncio.wait_for(self.vm.storage.start(), 1))
+                asyncio.wait_for(self.vm.storage.start(), 1)
+            )
 
     def test_716_enable_or_disable_snapshots_while_dispvm_running(self):
         self.vm.volumes = unittest.mock.MagicMock()
         volumes_conf = {
-            'keys.return_value': ['root', 'private', 'volatile', 'kernel'],
+            "keys.return_value": ["root", "private", "volatile", "kernel"],
         }
         self.vm.volumes.configure_mock(**volumes_conf)
-        self.vm.volumes['private'].revisions_to_keep = 2
+        self.vm.volumes["private"].revisions_to_keep = 2
 
         fake_running_dispvm = unittest.mock.MagicMock()
         fake_running_dispvm.is_running.return_value = True
         type(self.vm).dispvms = unittest.mock.PropertyMock(
-            return_value=[fake_running_dispvm])
+            return_value=[fake_running_dispvm]
+        )
 
         # Trying to disable snapshot on a VM having a running DispVM based on
         # it and currently running
         with self.assertRaises(qubes.exc.QubesVMNotHaltedError):
-            self.call_mgmt_func(b'admin.vm.volume.Set.revisions_to_keep',
-                                b'test-vm1', b'private', b'-1')
+            self.call_mgmt_func(
+                b"admin.vm.volume.Set.revisions_to_keep",
+                b"test-vm1",
+                b"private",
+                b"-1",
+            )
 
         # Trying to renable snapshot on a VM having a running DispVM based on
         # it and currently running
-        self.vm.volumes['private'].revisions_to_keep = -1
+        self.vm.volumes["private"].revisions_to_keep = -1
         with self.assertRaises(qubes.exc.QubesVMNotHaltedError):
-            self.call_mgmt_func(b'admin.vm.volume.Set.revisions_to_keep',
-                                b'test-vm1', b'private', b'1')
+            self.call_mgmt_func(
+                b"admin.vm.volume.Set.revisions_to_keep",
+                b"test-vm1",
+                b"private",
+                b"1",
+            )
 
         # Changing the number of revisions should work
-        self.vm.volumes['private'].revisions_to_keep = 1
-        self.call_mgmt_func(b'admin.vm.volume.Set.revisions_to_keep',
-                            b'test-vm1', b'private', b'2')
+        self.vm.volumes["private"].revisions_to_keep = 1
+        self.call_mgmt_func(
+            b"admin.vm.volume.Set.revisions_to_keep",
+            b"test-vm1",
+            b"private",
+            b"2",
+        )
 
     def test_720_vm_volume_set_rw(self):
         self.vm.volumes = unittest.mock.MagicMock()

--- a/qubes/tests/api_admin.py
+++ b/qubes/tests/api_admin.py
@@ -4316,6 +4316,33 @@ netvm default=True type=vm \n"""
                 b"abc",
             )
 
+    def test_713_vm_volume_disable_snapshots_while_running(self):
+        self.vm.volumes = unittest.mock.MagicMock()
+        volumes_conf = {
+            'keys.return_value': ['root', 'private', 'volatile', 'kernel'],
+        }
+        self.vm.volumes.configure_mock(**volumes_conf)
+        self.vm.storage = unittest.mock.Mock()
+        with unittest.mock.patch.object(self.vm, "is_running") as _mock:
+            _mock.return_value = True
+            with self.assertRaises(qubes.exc.QubesVMNotHaltedError):
+                self.call_mgmt_func(b'admin.vm.volume.Set.revisions_to_keep',
+                    b'test-vm1', b'private', b'-1')
+
+    def test_714_vm_volume_re_enable_snapshots_while_running(self):
+        self.vm.volumes = unittest.mock.MagicMock()
+        volumes_conf = {
+            'keys.return_value': ['root', 'private', 'volatile', 'kernel'],
+        }
+        self.vm.volumes.configure_mock(**volumes_conf)
+        self.vm.volumes["private"].revisions_to_keep = -1
+        self.vm.storage = unittest.mock.Mock()
+        with unittest.mock.patch.object(self.vm, "is_running") as _mock:
+            _mock.return_value = True
+            with self.assertRaises(qubes.exc.QubesVMNotHaltedError):
+                self.call_mgmt_func(b'admin.vm.volume.Set.revisions_to_keep',
+                    b'test-vm1', b'private', b'2')
+
     def test_720_vm_volume_set_rw(self):
         self.vm.volumes = unittest.mock.MagicMock()
         volumes_conf = {

--- a/qubes/tests/api_admin.py
+++ b/qubes/tests/api_admin.py
@@ -4405,6 +4405,20 @@ running and private volume snapshots are disabled. Backup will fail!\n'
                 self.call_mgmt_func(b'admin.vm.volume.Set.revisions_to_keep',
                     b'test-vm1', b'private', b'2')
 
+    def test_715_start_volume_sourcing_running_volume_without_snapshot(self):
+        self.vm.volumes = {
+            'root': unittest.mock.Mock(),
+            'private': unittest.mock.Mock(),
+            'volatile': unittest.mock.Mock(),
+            'kernel': unittest.mock.Mock(),
+        }
+        self.vm.volumes["private"].source = unittest.mock.Mock()
+        self.vm.volumes["private"].source.snapshots_disabled = True
+        self.vm.volumes["private"].source.is_running.return_value = True
+        with self.assertRaises(qubes.exc.QubesVMError):
+            self.loop.run_until_complete(
+                asyncio.wait_for(self.vm.storage.start(), 1))
+
     def test_720_vm_volume_set_rw(self):
         self.vm.volumes = unittest.mock.MagicMock()
         volumes_conf = {

--- a/qubes/tests/api_admin.py
+++ b/qubes/tests/api_admin.py
@@ -4341,10 +4341,10 @@ running and private volume snapshots are disabled. Backup will fail!\n'
             b"2",
         )
         self.assertIsNone(value)
-        self.assertEqual(
-            self.vm.volumes.mock_calls,
-            [unittest.mock.call.keys(), ("__getitem__", ("private",), {})],
-        )
+        self.assertEqual(self.vm.volumes.mock_calls,
+            [unittest.mock.call.keys(),
+            ("__getitem__", ("private",), {}),
+            ("__getitem__", ("private",), {})])
         self.assertEqual(self.vm.volumes["private"].revisions_to_keep, 2)
         self.app.save.assert_called_once_with()
 

--- a/qubes/tests/api_admin.py
+++ b/qubes/tests/api_admin.py
@@ -3144,6 +3144,11 @@ netvm default=True type=vm \n"""
 
     def test_520_vm_volume_clone(self):
         self.setup_for_clone()
+
+        self.vm.volumes["private"].is_running = lambda: False
+        self.vm.storage.get_volume = lambda x: x
+        self.vm2.storage.get_volume = lambda x: x
+
         token = self.call_mgmt_func(
             b"admin.vm.volume.CloneFrom", b"test-vm1", b"private", b""
         )
@@ -3165,6 +3170,10 @@ netvm default=True type=vm \n"""
     def test_521_vm_volume_clone_invalid_volume(self):
         self.setup_for_clone()
 
+        self.vm.volumes["private"].is_running = lambda: False
+        self.vm.storage.get_volume = lambda x: x
+        self.vm2.storage.get_volume = lambda x: x
+
         with self.assertRaises(qubes.exc.PermissionDenied):
             self.call_mgmt_func(
                 b"admin.vm.volume.CloneFrom", b"test-vm1", b"private123", b""
@@ -3177,6 +3186,10 @@ netvm default=True type=vm \n"""
 
     def test_522_vm_volume_clone_invalid_volume2(self):
         self.setup_for_clone()
+
+        self.vm.volumes["private"].is_running = lambda: False
+        self.vm.storage.get_volume = lambda x: x
+        self.vm2.storage.get_volume = lambda x: x
 
         token = self.call_mgmt_func(
             b"admin.vm.volume.CloneFrom", b"test-vm1", b"private", b""
@@ -3196,6 +3209,10 @@ netvm default=True type=vm \n"""
 
     def test_523_vm_volume_clone_removed_volume(self):
         self.setup_for_clone()
+
+        self.vm.volumes["private"].is_running = lambda: False
+        self.vm.storage.get_volume = lambda x: x
+        self.vm2.storage.get_volume = lambda x: x
 
         token = self.call_mgmt_func(
             b"admin.vm.volume.CloneFrom", b"test-vm1", b"private", b""
@@ -3224,6 +3241,10 @@ netvm default=True type=vm \n"""
     def test_524_vm_volume_clone_invlid_token(self):
         self.setup_for_clone()
 
+        self.vm.volumes["private"].is_running = lambda: False
+        self.vm.storage.get_volume = lambda x: x
+        self.vm2.storage.get_volume = lambda x: x
+
         with self.assertRaises(qubes.exc.PermissionDenied):
             self.call_mgmt_func(
                 b"admin.vm.volume.CloneTo",
@@ -3236,6 +3257,26 @@ netvm default=True type=vm \n"""
             map(operator.itemgetter(0), self.pool.mock_calls),
         )
         self.assertFalse(self.app.save.called)
+
+    def test_525_vm_volume_clone_snapshots_disabled(self):
+        self.setup_for_clone()
+
+        self.vm.volumes["private"].revisions_to_keep = -1
+        self.vm.volumes["private"].is_running = lambda: True
+        self.vm.storage.get_volume = lambda x: x
+        self.vm2.storage.get_volume = lambda x: x
+
+        token = self.call_mgmt_func(
+            b"admin.vm.volume.CloneFrom", b"test-vm1", b"private", b""
+        )
+
+        with self.assertRaises(qubes.storage.StoragePoolException):
+            self.call_mgmt_func(
+                b"admin.vm.volume.CloneTo",
+                b"test-vm2",
+                b"private",
+                token.encode(),
+            )
 
     def test_530_tag_list(self):
         self.vm.tags.add("tag1")

--- a/qubes/tests/storage_file.py
+++ b/qubes/tests/storage_file.py
@@ -531,18 +531,18 @@ class TC_01_FileVolumes(qubes.tests.QubesTestCase):
 
     def test_025_private_snapshots_disabled(self):
         config = {
-            'name': 'private',
-            'pool': self.POOL_NAME,
-            'size': defaults['root_img_size'],
-            'rw': True,
-            'save_on_stop': True,
-            'revisions_to_keep': -1,
+            "name": "private",
+            "pool": self.POOL_NAME,
+            "size": defaults["root_img_size"],
+            "rw": True,
+            "save_on_stop": True,
+            "revisions_to_keep": -1,
         }
         vm = qubes.tests.storage.TestVM(self)
         volume = self.app.get_pool(self.POOL_NAME).init_volume(vm, config)
-        self.assertEqual(volume.name, 'private')
+        self.assertEqual(volume.name, "private")
         self.assertEqual(volume.pool, self.POOL_NAME)
-        self.assertEqual(volume.size, defaults['root_img_size'])
+        self.assertEqual(volume.size, defaults["root_img_size"])
         self.assertFalse(volume.snap_on_start)
         self.assertTrue(volume.save_on_stop)
         self.assertTrue(volume.rw)
@@ -554,10 +554,10 @@ class TC_01_FileVolumes(qubes.tests.QubesTestCase):
 
         self.assertTrue(os.path.exists(volume.path))
         self.assertFalse(os.path.exists(volume.path_cow))
-        self.assertEqual(volume.block_device().path,
-                         os.path.join("/tmp/test-pool/appvms/",
-                                      vm.name,
-                                      "private.img"))
+        self.assertEqual(
+            volume.block_device().path,
+            os.path.join("/tmp/test-pool/appvms/", vm.name, "private.img"),
+        )
 
         self.loop.run_until_complete(volume.stop())
         self.loop.run_until_complete(volume.remove())
@@ -565,20 +565,20 @@ class TC_01_FileVolumes(qubes.tests.QubesTestCase):
 
     def test_026_private_snapshots_disabled_pool_level(self):
         config = {
-            'name': 'private',
-            'pool': self.POOL_NAME,
-            'size': defaults['root_img_size'],
-            'rw': True,
-            'save_on_stop': True,
+            "name": "private",
+            "pool": self.POOL_NAME,
+            "size": defaults["root_img_size"],
+            "rw": True,
+            "save_on_stop": True,
         }
         vm = qubes.tests.storage.TestVM(self)
         pool = self.app.get_pool(self.POOL_NAME)
         pool.revisions_to_keep = -1
         volume = pool.init_volume(vm, config)
         self.assertEqual(volume.revisions_to_keep, -1)
-        self.assertEqual(volume.name, 'private')
+        self.assertEqual(volume.name, "private")
         self.assertEqual(volume.pool, self.POOL_NAME)
-        self.assertEqual(volume.size, defaults['root_img_size'])
+        self.assertEqual(volume.size, defaults["root_img_size"])
         self.assertFalse(volume.snap_on_start)
         self.assertTrue(volume.save_on_stop)
         self.assertTrue(volume.rw)
@@ -590,10 +590,10 @@ class TC_01_FileVolumes(qubes.tests.QubesTestCase):
 
         self.assertTrue(os.path.exists(volume.path))
         self.assertFalse(os.path.exists(volume.path_cow))
-        self.assertEqual(volume.block_device().path,
-                         os.path.join("/tmp/test-pool/appvms/",
-                                      vm.name,
-                                      "private.img"))
+        self.assertEqual(
+            volume.block_device().path,
+            os.path.join("/tmp/test-pool/appvms/", vm.name, "private.img"),
+        )
 
         self.loop.run_until_complete(volume.stop())
         self.loop.run_until_complete(volume.remove())

--- a/qubes/tests/storage_file.py
+++ b/qubes/tests/storage_file.py
@@ -529,6 +529,76 @@ class TC_01_FileVolumes(qubes.tests.QubesTestCase):
         self.assertEqual(volume_data.strip(b"\0"), b"test")
         self.assertEqual(len(volume_data), new_size)
 
+    def test_025_private_snapshots_disabled(self):
+        config = {
+            'name': 'private',
+            'pool': self.POOL_NAME,
+            'size': defaults['root_img_size'],
+            'rw': True,
+            'save_on_stop': True,
+            'revisions_to_keep': -1,
+        }
+        vm = qubes.tests.storage.TestVM(self)
+        volume = self.app.get_pool(self.POOL_NAME).init_volume(vm, config)
+        self.assertEqual(volume.name, 'private')
+        self.assertEqual(volume.pool, self.POOL_NAME)
+        self.assertEqual(volume.size, defaults['root_img_size'])
+        self.assertFalse(volume.snap_on_start)
+        self.assertTrue(volume.save_on_stop)
+        self.assertTrue(volume.rw)
+
+        volume.commit = unittest.mock.MagicMock()
+
+        volume.create()
+        self.loop.run_until_complete(volume.start())
+
+        self.assertTrue(os.path.exists(volume.path))
+        self.assertFalse(os.path.exists(volume.path_cow))
+        self.assertEqual(volume.block_device().path,
+                         os.path.join("/tmp/test-pool/appvms/",
+                                      vm.name,
+                                      "private.img"))
+
+        self.loop.run_until_complete(volume.stop())
+        self.loop.run_until_complete(volume.remove())
+        volume.commit.assert_not_called()
+
+    def test_026_private_snapshots_disabled_pool_level(self):
+        config = {
+            'name': 'private',
+            'pool': self.POOL_NAME,
+            'size': defaults['root_img_size'],
+            'rw': True,
+            'save_on_stop': True,
+        }
+        vm = qubes.tests.storage.TestVM(self)
+        pool = self.app.get_pool(self.POOL_NAME)
+        pool.revisions_to_keep = -1
+        volume = pool.init_volume(vm, config)
+        self.assertEqual(volume.revisions_to_keep, -1)
+        self.assertEqual(volume.name, 'private')
+        self.assertEqual(volume.pool, self.POOL_NAME)
+        self.assertEqual(volume.size, defaults['root_img_size'])
+        self.assertFalse(volume.snap_on_start)
+        self.assertTrue(volume.save_on_stop)
+        self.assertTrue(volume.rw)
+
+        volume.commit = unittest.mock.MagicMock()
+
+        volume.create()
+        self.loop.run_until_complete(volume.start())
+
+        self.assertTrue(os.path.exists(volume.path))
+        self.assertFalse(os.path.exists(volume.path_cow))
+        self.assertEqual(volume.block_device().path,
+                         os.path.join("/tmp/test-pool/appvms/",
+                                      vm.name,
+                                      "private.img"))
+
+        self.loop.run_until_complete(volume.stop())
+        self.loop.run_until_complete(volume.remove())
+        volume.commit.assert_not_called()
+
     def _get_loop_size(self, path):
         try:
             loop_name = (
@@ -716,6 +786,8 @@ class TC_03_FilePool(qubes.tests.QubesTestCase):
         with self.assertRaises((NotImplementedError, ValueError)):
             pool.revisions_to_keep = 2
         self.assertEqual(pool.revisions_to_keep, 1)
+        pool.revisions_to_keep = -1
+        self.assertEqual(pool.revisions_to_keep, -1)
 
     def test_011_appvm_file_images(self):
         """Check if all the needed image files are created for an AppVm"""

--- a/qubes/tests/storage_lvm.py
+++ b/qubes/tests/storage_lvm.py
@@ -1362,24 +1362,22 @@ class TC_00_ThinPool(ThinPoolBase):
             "ephemeral_volatile flag must be ignored for read-only volumes",
         )
 
-
     def test_130_private_snapshots_disabled(self):
         config = {
-            'name': 'private',
-            'pool': self.pool.name,
-            'save_on_stop': True,
-            'rw': True,
-            'size': qubes.config.defaults['root_img_size'],
-            'revisions_to_keep': -1,
+            "name": "private",
+            "pool": self.pool.name,
+            "save_on_stop": True,
+            "rw": True,
+            "size": qubes.config.defaults["root_img_size"],
+            "revisions_to_keep": -1,
         }
 
         vm = qubes.tests.storage.TestVM(self)
         volume = self.app.get_pool(self.pool.name).init_volume(vm, config)
         self.assertIsInstance(volume, self.volume_class)
-        self.assertEqual(volume.name, 'private')
+        self.assertEqual(volume.name, "private")
         self.assertEqual(volume.pool, self.pool.name)
-        self.assertEqual(volume.size,
-                         qubes.config.defaults['root_img_size'])
+        self.assertEqual(volume.size, qubes.config.defaults["root_img_size"])
         self.loop.run_until_complete(volume.create())
 
         volume._commit = unittest.mock.Mock()
@@ -1388,10 +1386,12 @@ class TC_00_ThinPool(ThinPoolBase):
         self.assertTrue(os.path.exists(f"/dev/{volume.vid}"))
         self.assertFalse(os.path.exists(f"/dev/{volume._vid_snap}"))
 
-        self.assertEqual(volume.block_device().path,
-                         "/dev/mapper/{}-vm--test--inst--appvm--private".format(
-                             self.pool.volume_group
-                         ))
+        self.assertEqual(
+            volume.block_device().path,
+            "/dev/mapper/{}-vm--test--inst--appvm--private".format(
+                self.pool.volume_group
+            ),
+        )
 
         self.loop.run_until_complete(volume.stop())
         self.loop.run_until_complete(volume.remove())
@@ -1400,11 +1400,11 @@ class TC_00_ThinPool(ThinPoolBase):
 
     def test_131_private_snapshots_disabled_pool_level(self):
         config = {
-            'name': 'private',
-            'pool': self.pool.name,
-            'save_on_stop': True,
-            'rw': True,
-            'size': qubes.config.defaults['root_img_size'],
+            "name": "private",
+            "pool": self.pool.name,
+            "save_on_stop": True,
+            "rw": True,
+            "size": qubes.config.defaults["root_img_size"],
         }
 
         vm = qubes.tests.storage.TestVM(self)
@@ -1412,10 +1412,9 @@ class TC_00_ThinPool(ThinPoolBase):
         pool.revisions_to_keep = -1
         volume = pool.init_volume(vm, config)
         self.assertIsInstance(volume, self.volume_class)
-        self.assertEqual(volume.name, 'private')
+        self.assertEqual(volume.name, "private")
         self.assertEqual(volume.pool, self.pool.name)
-        self.assertEqual(volume.size,
-                         qubes.config.defaults['root_img_size'])
+        self.assertEqual(volume.size, qubes.config.defaults["root_img_size"])
         self.loop.run_until_complete(volume.create())
 
         volume._commit = unittest.mock.Mock()
@@ -1424,10 +1423,12 @@ class TC_00_ThinPool(ThinPoolBase):
         self.assertTrue(os.path.exists(f"/dev/{volume.vid}"))
         self.assertFalse(os.path.exists(f"/dev/{volume._vid_snap}"))
 
-        self.assertEqual(volume.block_device().path,
-                         "/dev/mapper/{}-vm--test--inst--appvm--private".format(
-                             self.pool.volume_group
-                         ))
+        self.assertEqual(
+            volume.block_device().path,
+            "/dev/mapper/{}-vm--test--inst--appvm--private".format(
+                self.pool.volume_group
+            ),
+        )
 
         self.loop.run_until_complete(volume.stop())
         self.loop.run_until_complete(volume.remove())

--- a/qubes/tests/storage_reflink.py
+++ b/qubes/tests/storage_reflink.py
@@ -349,28 +349,31 @@ class TC_10_ReflinkPool(qubes.tests.QubesTestCase):
 
     def test_120_private_snapshots_disabled(self):
         config = {
-            'name': 'private',
-            'pool': self.pool.name,
-            'save_on_stop': True,
-            'rw': True,
-            'size': qubes.config.defaults['root_img_size'],
-            'revisions_to_keep': -1,
+            "name": "private",
+            "pool": self.pool.name,
+            "save_on_stop": True,
+            "rw": True,
+            "size": qubes.config.defaults["root_img_size"],
+            "revisions_to_keep": -1,
         }
 
         vm = qubes.tests.storage.TestVM(self)
         volume = self.pool.init_volume(vm, config)
         self.assertIsInstance(volume, reflink.ReflinkVolume)
-        self.assertEqual(volume.name, 'private')
+        self.assertEqual(volume.name, "private")
         self.assertEqual(volume.pool, self.pool.name)
         volume._copy_file = unittest.mock.Mock()
         self.loop.run_until_complete(volume.create())
-        self.assertEqual(volume.block_device().path,
-                         "/var/tmp/test-reflink-units-on-btrfs/appvms/test-inst-appvm/private.img")
+        self.assertEqual(
+            volume.block_device().path,
+            "/var/tmp/test-reflink-units-on-btrfs/appvms/test-inst-appvm/private.img",
+        )
         self.assertFalse(os.path.exists(volume._path_dirty))
         self.assertFalse(os.path.exists(volume._path_precache))
         self.loop.run_until_complete(volume.stop())
         self.loop.run_until_complete(volume.remove())
         volume._copy_file.assert_not_called()
+
 
 def setup_loopdev(img, cleanup_via=None):
     dev = str.strip(cmd("sudo", "losetup", "-f", "--show", img).decode())

--- a/qubes/tests/storage_reflink.py
+++ b/qubes/tests/storage_reflink.py
@@ -364,13 +364,17 @@ class TC_10_ReflinkPool(qubes.tests.QubesTestCase):
         self.assertEqual(volume.pool, self.pool.name)
         volume._copy_file = unittest.mock.Mock()
         self.loop.run_until_complete(volume.create())
+        self.loop.run_until_complete(volume.start())
         self.assertEqual(
             volume.block_device().path,
-            "/var/tmp/test-reflink-units-on-btrfs/appvms/test-inst-appvm/private.img",
+            "/var/tmp/test-reflink-units-on-btrfs/appvms/test-inst-appvm/private-dirty.img",
         )
-        self.assertFalse(os.path.exists(volume._path_dirty))
+        self.assertFalse(os.path.exists(volume._path_clean))
         self.assertFalse(os.path.exists(volume._path_precache))
         self.loop.run_until_complete(volume.stop())
+        self.assertFalse(os.path.exists(volume._path_dirty))
+        self.assertTrue(os.path.exists(volume._path_clean))
+        self.assertFalse(os.path.exists(volume._path_precache))
         self.loop.run_until_complete(volume.remove())
         volume._copy_file.assert_not_called()
 

--- a/qubes/tests/storage_zfs.py
+++ b/qubes/tests/storage_zfs.py
@@ -830,11 +830,7 @@ class TC_10_ZFSPool(ZFSBase):
         deinit()
 
     def test_026_snapshots_disabled(self) -> None:
-        v = self.get_vol(
-            ONEMEG_SAVE_ON_STOP,
-            name="026",
-            revisions_to_keep = 0
-        )
+        v = self.get_vol(ONEMEG_SAVE_ON_STOP, name="026", revisions_to_keep=0)
         self.rc(v.create())
         self.assertEqual(len(v.revisions), 0)
         self.rc(v.start())
@@ -843,11 +839,7 @@ class TC_10_ZFSPool(ZFSBase):
         self.assertEqual(len(v.revisions), 0)
 
     def test_027_snapshots_disabled_removes_old_snapshots(self) -> None:
-        v = self.get_vol(
-            ONEMEG_SAVE_ON_STOP,
-            name="027",
-            revisions_to_keep=1
-        )
+        v = self.get_vol(ONEMEG_SAVE_ON_STOP, name="027", revisions_to_keep=1)
         self.rc(v.create())
         self.rc(v.start())
         self.rc(v.stop())
@@ -859,11 +851,7 @@ class TC_10_ZFSPool(ZFSBase):
         self.assertEqual(len(v.revisions), 0)
 
     def test_028_prevent_export_when_volume_in_use(self) -> None:
-        v = self.get_vol(
-            ONEMEG_SAVE_ON_STOP,
-            name="028",
-            revisions_to_keep=-1
-        )
+        v = self.get_vol(ONEMEG_SAVE_ON_STOP, name="028", revisions_to_keep=-1)
 
         v.is_running = lambda: True
         self.rc(v.create())
@@ -875,18 +863,14 @@ class TC_10_ZFSPool(ZFSBase):
 
     def test_029_prevent_cloning_running_volume_with_snapshots_disabled(self):
         v1 = self.get_vol(
-            ONEMEG_SAVE_ON_STOP,
-            name="029_1",
-            revisions_to_keep=-1
+            ONEMEG_SAVE_ON_STOP, name="029_1", revisions_to_keep=-1
         )
         v1.is_running = lambda: True
         self.rc(v1.create())
         self.rc(v1.start())
 
         v2 = self.get_vol(
-            ONEMEG_SAVE_ON_STOP,
-            name="029_2",
-            revisions_to_keep=1
+            ONEMEG_SAVE_ON_STOP, name="029_2", revisions_to_keep=1
         )
         self.rc(v2.create())
         with self.assertRaises(qubes.storage.StoragePoolException):

--- a/qubes/vm/dispvm.py
+++ b/qubes/vm/dispvm.py
@@ -408,9 +408,7 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
             self.use_preload()
 
     @qubes.events.handler("domain-shutdown")
-    async def on_domain_shutdown(
-        self, _event, **_kwargs
-    ):
+    async def on_domain_shutdown(self, _event, **_kwargs):
         """Do auto cleanup if enabled"""
         await self._auto_cleanup()
 

--- a/qubes/vm/mix/dvmtemplate.py
+++ b/qubes/vm/mix/dvmtemplate.py
@@ -121,7 +121,7 @@ class DVMTemplateMixin(qubes.events.Emitter):
     @qubes.events.handler("domain-pre-start")
     def __on_domain_pre_start(self, event, **kwargs):
         """Prevents startup for domain having a volume with disabled snapshots
-           and a DispVM based on this volume started
+        and a DispVM based on this volume started
         """
         # pylint: disable=unused-argument
         volume_with_disabled_snapshots = False

--- a/qubes/vm/mix/dvmtemplate.py
+++ b/qubes/vm/mix/dvmtemplate.py
@@ -118,6 +118,23 @@ class DVMTemplateMixin(qubes.events.Emitter):
                 "Invalid preload-dispvm-max value: not a digit"
             )
 
+    @qubes.events.handler("domain-pre-start")
+    def __on_domain_pre_start(self, event, **kwargs):
+        """Prevents startup for domain having a volume with disabled snapshots
+           and a DispVM based on this volume started
+        """
+        # pylint: disable=unused-argument
+        volume_with_disabled_snapshots = False
+        for vol in self.volumes.values():
+            volume_with_disabled_snapshots |= vol.snapshots_disabled
+
+        if not volume_with_disabled_snapshots:
+            return
+
+        for vm in self.dispvms:
+            if vm.is_running():
+                raise qubes.exc.QubesVMNotHaltedError(vm)
+
     @qubes.events.handler("domain-feature-set:preload-dispvm-max")
     def on_feature_set_preload_dispvm_max(
         self, event, feature, value, oldvalue=None


### PR DESCRIPTION
This PR is related to issue https://github.com/QubesOS/qubes-issues/issues/8767

A new option **disable snapshots** can be set on volumes (lvm, file, reflink and zfs supported). When enabled on a private volume, the volume is used directly instead of doing a snapshot and use it.

The option can be enabled by setting ``revisions_to_keep = -1``

Using the volume directly saves space but requires features like backup, dispvm or cloning to be disabled when the volume is in use.