### PR TITLE
fix: don't destroy underlying pool on admin.pool.Remove

### DIFF
--- a/qubes/app.py
+++ b/qubes/app.py
@@ -1500,7 +1500,6 @@ class Qubes(qubes.PropertyHolder):
                 "pool-pre-delete", pre_event=True, pool=pool
             )
             del self.pools[name]
-            await qubes.utils.coro_maybe(pool.destroy())
             await self.fire_event_async("pool-delete", pool=pool)
         except KeyError:
             return


### PR DESCRIPTION
`pool.destroy()` is only implemented for zfs driver which means calling it is a no-op for other drivers and causes dataset destruction on `qvm-pool remove` for zfs-based pools.

- Resolves https://github.com/QubesOS/qubes-issues/issues/9856


https://github.com/QubesOS/qubes-core-admin-client/blob/a72529d12ec97f1505c4a8121c6801dfe7310223/doc/manpages/qvm-pool.rst?plain=1#L96-L105