### PR TITLE
lvm: suppress logs on stdout when expecting json output

### DIFF
--- a/qubes/storage/lvm.py
+++ b/qubes/storage/lvm.py
@@ -234,6 +234,7 @@ class ThinPool(qubes.storage.Pool):
 _init_cache_cmd = [
     _lvm,
     "lvs",
+    "--quiet",
     "--noheadings",
     "-o",
     "vg_name,pool_lv,name,lv_size,data_percent,lv_attr,origin,lv_metadata_size,"


### PR DESCRIPTION
Apparently lvm sometimes logs messages to stdout (instead of stderr),
which messes up json format. Disable those messages by passing --quiet
option.

Fixes QubesOS/qubes-issues#10023