### PR TITLE
Introduce gui-background-color feature

### DIFF
--- a/qubes/ext/gui.py
+++ b/qubes/ext/gui.py
@@ -84,7 +84,7 @@ class GUI(qubes.ext.Extension):
 
     @qubes.ext.handler("domain-qdb-create")
     def on_domain_qdb_create(self, vm, event):
-        for feature in ("gui-videoram-overhead", "gui-videoram-min"):
+        for feature in ("gui-videoram-overhead", "gui-videoram-min", "gui-background-color"):
             try:
                 vm.untrusted_qdb.write(
                     "/qubes-{}".format(feature),


### PR DESCRIPTION
Introduces the gui-background-color feature and qubes-gui-background-color property in order to support changes made to gui-agent-linux, in order to allow changing the background color for https://github.com/QubesOS/qubes-issues/issues/2846. This property accepts an integer value. Requires https://github.com/QubesOS/qubes-gui-agent-linux/pull/238 to be merged before this will be effective