### PR TITLE
tests: disable pvgrub test on debian-13

### DIFF
--- a/qubes/tests/integ/grub.py
+++ b/qubes/tests/integ/grub.py
@@ -239,6 +239,13 @@ class TC_40_PVGrub(GrubBase):
                 "Fedora kernel is compressed with zstd "
                 "which is not supported by pvgrub2"
             )
+        if "debian-13" in self.template:
+            # requires a zstd decompression filter in grub
+            # (see grub_file_filter_id enum in grub sources)
+            self.skipTest(
+                "Debian 13 kernel is compressed with zstd "
+                "which is not supported by pvgrub2"
+            )
         if "archlinux" in self.template:
             # requires a zstd decompression filter in grub
             # (see grub_file_filter_id enum in grub sources)


### PR DESCRIPTION
Debian 13 has kernel compressed with zstd, which isn't compatible with
pvgrub2. Since the PV mode is discouraged, disable the test, similar to
other distributions using zstd-compressed kernel. Note that PVH and HVM
modes are still fine.

QubesOS/qubes-issues#8841