### PR TITLE
Fix multiple issues with preload tests

### DIFF
--- a/qubes/tests/integ/dispvm.py
+++ b/qubes/tests/integ/dispvm.py
@@ -330,9 +330,11 @@ class TC_20_DispVMMixin(object):
         global_preload_max = None
         if default_dispvm:
             global_preload_max = default_dispvm.get_feat_global_preload_max()
+        threshold = self.adminvm.features.get("preload-dispvm-threshold", None)
         preload_dict["global"] = {
             "name": default_dispvm.name if default_dispvm else None,
             "max": global_preload_max,
+            "threshold": threshold,
         }
         for qube in [self.disp_base, self.disp_base_alt]:
             preload = qube.get_feat_preload()

--- a/qubes/tests/integ/dispvm.py
+++ b/qubes/tests/integ/dispvm.py
@@ -742,6 +742,10 @@ class TC_20_DispVMMixin(object):
             await self.wait_preload(preload_max)
             old_preload = self.disp_base.get_feat_preload()
             await qube.start()
+            # If services are still starting, it may delay shutdown longer than
+            # the default timeout. Because we can't just kill default
+            # templates, wait gracefully for system services to have started.
+            await qube.run_service_for_stdio("qubes.WaitForRunningSystem")
             logger.info("shutdown '%s'", qube.name)
             await qube.shutdown(wait=True)
             await self.wait_preload(preload_max)

--- a/qubes/tests/integ/dispvm.py
+++ b/qubes/tests/integ/dispvm.py
@@ -314,6 +314,9 @@ class TC_20_DispVMMixin(object):
                 )
             logger.info("deleting global feature")
             del self.app.domains["dom0"].features["preload-dispvm-max"]
+        if "preload-dispvm-threshold" in self.app.domains["dom0"].features:
+            logger.info("deleting global threshold feature")
+            del self.app.domains["dom0"].features["preload-dispvm-threshold"]
         logger.info("end")
 
     async def no_preload(self):

--- a/qubes/tests/integ/dispvm_perf.py
+++ b/qubes/tests/integ/dispvm_perf.py
@@ -73,13 +73,6 @@ class TC_00_DispVMPerfMixin:
                     self.vm2.shutdown(),
                 )
             )
-        if not os.getenv("QUBES_TEST_SKIP_TEARDOWN_SLEEP"):
-            # Avoid previous test load interfering with new test.
-            if self._testMethodName.startswith("vm"):
-                delay = 5
-            else:
-                delay = 15
-            time.sleep(delay)
 
     def run_test(self, name):
         dvm = self.dvm.name

--- a/tests/dispvm_perf.py
+++ b/tests/dispvm_perf.py
@@ -254,7 +254,7 @@ class TestRun:
         timeout=60,
     ):
         """Waiting for completion avoids coroutine objects leaking."""
-        logger.info("preload_max='%s'", preload_max)
+        logger.info("preload_max: '%s'", preload_max)
         if not appvm:
             appvm = self.dvm
         for _ in range(timeout):
@@ -332,7 +332,8 @@ class TestRun:
             "set -eu --; "
             f'max_concurrency="{MAX_CONCURRENCY}"; '
             f"for i in $(seq {self.iterations}); do "
-            f"  out=$({cmd}) {term}"
+            '  echo "$i"; '
+            f"  {cmd} {term}"
             '  pid="${!-}"; '
             '  if test -n "${pid}"; then '
             '    set -- "${@}" "${pid}"; '
@@ -347,7 +348,7 @@ class TestRun:
         start_time = get_time()
         try:
             if test.from_dom0:
-                subprocess.run(code, shell=True, check=True, timeout=timeout)
+                subprocess.run(code, shell=True, check=True, capture_output=True, timeout=timeout)
             else:
                 self.vm1.run(code, timeout=timeout)
         except subprocess.CalledProcessError as e:
@@ -565,6 +566,9 @@ class TestRun:
             else:
                 result = self.run_latency_calls(test)
             self.report_result(test, result)
+        except:
+            logger.error("Failed to run test: '%s'", test.name)
+            raise
         finally:
             if test.preload_max:
                 old_preload_max = int(

--- a/tests/dispvm_perf.py
+++ b/tests/dispvm_perf.py
@@ -543,17 +543,16 @@ class TestRun:
                 f"{gui_prefix} {target} allow\n"
                 f"{nogui_prefix} {target} allow\n"
             )
-        if test.preload_max:
-            orig_preload_threshold = self.dom0.features.get(
-                "preload-dispvm-threshold"
-            )
-            orig_preload_max = self.dom0.features.get("preload-dispvm-max")
-            if orig_preload_threshold is not None:
-                logger.info("Deleting threshold feature")
-                del self.dom0.features["preload-dispvm-threshold"]
-            if orig_preload_max is not None:
-                logger.info("Deleting global max feature")
-                del self.dom0.features["preload-dispvm-max"]
+        orig_preload_threshold = self.dom0.features.get(
+            "preload-dispvm-threshold"
+        )
+        orig_preload_max = self.dom0.features.get("preload-dispvm-max")
+        if orig_preload_threshold is not None:
+            logger.info("Deleting threshold feature")
+            del self.dom0.features["preload-dispvm-threshold"]
+        if orig_preload_max is not None:
+            logger.info("Deleting global max feature")
+            del self.dom0.features["preload-dispvm-max"]
         try:
             if test.preload_max:
                 preload_max = test.preload_max
@@ -581,21 +580,19 @@ class TestRun:
                 logger.info("Deleting local max feature")
                 del self.dvm.features["preload-dispvm-max"]
                 self.wait_for_dispvm_destroy(old_preload)
-                if orig_preload_threshold is not None:
-                    logger.info(
-                        "Setting the original threshold feature: '%s'",
-                        orig_preload_threshold,
-                    )
-                    self.dom0.features["preload-dispvm-threshold"] = (
-                        orig_preload_threshold
-                    )
-                if orig_preload_max is not None:
-                    logger.info(
-                        "Setting the global max feature: '%s'", orig_preload_max
-                    )
-                    self.dom0.features["preload-dispvm-max"] = orig_preload_max
-                    if orig_preload_max != 0:
-                        asyncio.run(self.wait_preload(orig_preload_max))
+            if orig_preload_threshold is not None:
+                logger.info(
+                    "Setting the original threshold feature: '%s'",
+                    orig_preload_threshold,
+                )
+                self.dom0.features["preload-dispvm-threshold"] = (
+                    orig_preload_threshold
+                )
+            if orig_preload_max is not None:
+                logger.info(
+                    "Setting the global max feature: '%s'", orig_preload_max
+                )
+                self.dom0.features["preload-dispvm-max"] = orig_preload_max
             os.unlink(POLICY_FILE)
             if not os.getenv("QUBES_TEST_SKIP_TEARDOWN_SLEEP"):
                 logger.info("Load before sleep: '%s'", get_load())

--- a/tests/dispvm_perf.py
+++ b/tests/dispvm_perf.py
@@ -528,7 +528,12 @@ class TestRun:
                 f"{nogui_prefix} {target} allow\n"
             )
         if test.preload_max:
+            orig_preload_threshold = self.dom0.features.get(
+                "preload-dispvm-threshold"
+            )
             orig_preload_max = self.dom0.features.get("preload-dispvm-max")
+            if orig_preload_threshold is not None:
+                del self.dom0.features["preload-dispvm-threshold"]
             if orig_preload_max is not None:
                 del self.dom0.features["preload-dispvm-max"]
         try:
@@ -552,6 +557,10 @@ class TestRun:
                 old_preload = old_preload.split(" ") or []
                 del self.dvm.features["preload-dispvm-max"]
                 self.wait_for_dispvm_destroy(old_preload)
+                if orig_preload_threshold is not None:
+                    self.dom0.features["preload-dispvm-threshold"] = (
+                        orig_preload_threshold
+                    )
                 if orig_preload_max is not None:
                     self.dom0.features["preload-dispvm-max"] = orig_preload_max
                     if orig_preload_max != 0:


### PR DESCRIPTION
For: https://github.com/QubesOS/qubes-issues/issues/1512
For: https://github.com/QubesOS/qubes-core-admin/pull/708

---

- The SKIP_TEARDOWN variable remains the same, although it is not `tearDown()` anymore
- Sleep on `finally` clause, we already have the test configuration so it is easier to consider different factors for different delays, customizing to sleep less when possible and more when needed
- Some concurrent API tests were using wrong number of preloaded disposables
- When I meant that load was high, I was implying two things, the system load and the qubesd load, just log the system load

Currently running with 16GB of RAM the full test suite for Debian.