### PR TITLE
Skip backup of undesirable preload feature

### DIFF
--- a/qubes/backup.py
+++ b/qubes/backup.py
@@ -833,6 +833,12 @@ class Backup:
             backup_app.domains[qid].features["backup-content"] = True
             backup_app.domains[qid].features["backup-path"] = vm_info.subdir
             backup_app.domains[qid].features["backup-size"] = vm_info.size
+            for feature in backup_app.domains[qid].features.copy():
+                if (
+                    feature.startswith("preload-dispvm")
+                    and feature != "preload-dispvm-max"
+                ):
+                    del backup_app.domains[qid].features[feature]
 
             # VM running private volumes without snapshoting them
             # (revision_to_keep = -1) must be powered off to be backup


### PR DESCRIPTION
For: https://github.com/QubesOS/qubes-issues/issues/1512

Tested the backup and restoration manually, no integ tests yet. If backing up a disposable template without this PR, an error message appears during the restoration:

> Error setting default-dvm.features[preload-dispvm] to dispN: Invalid preload-dispvm value: can't increment qube count(3) is either bigger than old count (0) or preload-dispvm-max (0)

Even if the preload-dispvm-max feature was restored before the preload-dispvm, it would fail with another message of disposable doesn't exist or not descendant of the disposable template. Later on, the qubes are preloaded according to the max.

It doesn't fail the backup though, but removing this error message is better and also still preloads the max when the restoration completes.