### PR TITLE
Do not register 'testclass' device class outside of tests

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -45,6 +45,7 @@ unset dir
 
 PYTHONPATH=${TESTPYTHONPATH}${PYTHONPATH+":${PYTHONPATH}"}
 export PYTHONPATH
+export QUBES_TEST=1
 
 "${PYTHON}" setup.py egg_info --egg-base "${TESTPYTHONPATH}"
 "${PYTHON}" -m coverage run --rcfile=ci/coveragerc -m qubes.tests.run "$@"

--- a/setup.py
+++ b/setup.py
@@ -80,8 +80,9 @@ if __name__ == '__main__':
             'qubes.devices': [
                 'pci = qubes.ext.pci:PCIDevice',
                 'block = qubes.ext.block:BlockDevice',
+            ] + [
                 'testclass = qubes.tests.devices:TestDevice',
-            ],
+            ] if os.environ.get("QUBES_TEST") else [],
             'qubes.storage': [
                 'file = qubes.storage.file:FilePool',
                 'file-reflink = qubes.storage.reflink:ReflinkPool',


### PR DESCRIPTION
Now that more places (especially qvm-clone and ansible) properly lists
available device classes, it's no longer harmless to include 'testclass'
on production system. There is a mechanism to replace some entry point
with another for tests (`substitute_entry_points` context manager), but
unfortunately it can't be used here, as device classes are enumerated at
the qubes.api.admin import time, not test run time (as it's the case for
storage classes). Exclude it normally, and include only if
QUBES_TEST=1 variable is set - which is done in run-tests script.

The 'testclass' devices are used only in unit tests, so it's okay
to not include them in integration tests.

Reported at https://github.com/QubesOS/qubes-ansible/pull/6#issuecomment-3229326890