### PR TITLE
Inform how to debug failed preload startup

### DIFF
--- a/qubes/vm/dispvm.py
+++ b/qubes/vm/dispvm.py
@@ -373,11 +373,13 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
         except asyncio.TimeoutError:
             raise qubes.exc.QubesException(
                 "Timed out call to '%s' after '%d' seconds during preload "
-                "startup" % (service, timeout)
+                "startup" % (rpc, timeout)
             )
         except (subprocess.CalledProcessError, qubes.exc.QubesException):
             raise qubes.exc.QubesException(
-                "Error on call to '%s' during preload startup" % service
+                "Error on call to '%s' during preload startup. To debug, run "
+                "the following on a new disposable of '%s': systemctl "
+                "--failed" % (rpc, self.template)
             )
 
         if not self.preload_requested:

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -1548,6 +1548,10 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.LocalVM):
 
             except Exception as exc:  # pylint: disable=bare-except
                 self.log.error("Start failed: %s", str(exc))
+                # let anyone receiving domain-pre-start know that startup failed
+                await self.fire_event_async(
+                    "domain-start-failed", reason=str(exc)
+                )
                 # This avoids losing the exception if an exception is
                 # raised in self.kill(), because the vm is not
                 # running or paused
@@ -1555,11 +1559,6 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.LocalVM):
                     await self.kill()
                 except qubes.exc.QubesVMNotStartedError:
                     pass
-
-                # let anyone receiving domain-pre-start know that startup failed
-                await self.fire_event_async(
-                    "domain-start-failed", reason=str(exc)
-                )
                 raise
 
         return self


### PR DESCRIPTION
The "domain-start-failed" has to be fired before the domain is killed, as the qube is unregistered from clients when it is removed/powered off.

Fixes: https://github.com/QubesOS/qubes-issues/issues/10200
For: https://github.com/QubesOS/qubes-issues/issues/1512