### PR TITLE
Wait for user session for preloaded disposables

### DIFF
--- a/qubes/tests/api_admin.py
+++ b/qubes/tests/api_admin.py
@@ -4022,6 +4022,7 @@ running and private volume snapshots are disabled. Backup will fail!\n"
         )
         self.vm.features["qrexec"] = "1"
         self.vm.features["supported-rpc.qubes.WaitForRunningSystem"] = "1"
+        self.vm.features["supported-rpc.qubes.WaitForSession"] = "1"
         self.vm.features["preload-dispvm-max"] = "1"
         for _ in range(10):
             if len(self.vm.get_feat_preload()) == 1:

--- a/qubes/tests/app.py
+++ b/qubes/tests/app.py
@@ -695,6 +695,7 @@ class TC_90_Qubes(qubes.tests.QubesTestCase):
         self.template.features["supported-rpc.qubes.WaitForRunningSystem"] = (
             True
         )
+        self.template.features["supported-rpc.qubes.WaitForSession"] = True
         self.appvm = self.app.add_new_vm(
             "AppVM",
             name="test-dvm",

--- a/qubes/tests/integ/backup.py
+++ b/qubes/tests/integ/backup.py
@@ -188,6 +188,7 @@ class BackupTestsMixin(object):
         self.loop.run_until_complete(testvm5.create_on_disk(pool=pool))
         testvm5.features["qrexec"] = True
         testvm5.features["supported-rpc.qubes.WaitForRunningSystem"] = True
+        testvm5.features["supported-rpc.qubes.WaitForSession"] = True
         testvm5.features["preload-dispvm-max"] = 0
         testvm5.features["preload-dispvm"] = ""
         vms.append(testvm5)

--- a/qubes/tests/integ/dispvm.py
+++ b/qubes/tests/integ/dispvm.py
@@ -451,7 +451,7 @@ class DispVMHelpersMixin:
         finally:
             logger.info("end")
 
-    async def run_preload(self):
+    async def run_preload(self, assert_stdout: bool = True):
         logger.info("start")
         appvm = self.disp_base
         dispvm = appvm.get_feat_preload()[0]
@@ -463,7 +463,8 @@ class DispVMHelpersMixin:
         self._test_event_handler_remove(dispvm, "domain-unpaused")
 
         stdout = await self.run_preload_proc()
-        self.assertEqual(stdout, dispvm_name)
+        if assert_stdout:
+            self.assertEqual(stdout, dispvm_name)
         test_cases = [
             (False, appvm.name, "domain-preload-dispvm-start", True),
             (True, appvm.name, "domain-preload-dispvm-used", True),
@@ -554,7 +555,9 @@ class TC_20_DispVMMixin(DispVMHelpersMixin):
         self.disp_base.features["gui"] = True
         self.disp_base.features["preload-dispvm-max"] = str(preload_max)
         await self.wait_preload(preload_max)
-        await self.run_preload()
+        self.preload_cmd.insert(1, "--service")
+        self.preload_cmd[-1] = "qubes.WaitForSession"
+        await self.run_preload(assert_stdout=False)
         logger.info("end")
 
     def test_014_preload_nogui(self):
@@ -569,7 +572,9 @@ class TC_20_DispVMMixin(DispVMHelpersMixin):
         self.disp_base.features["preload-dispvm-max"] = str(preload_max)
         await self.wait_preload(preload_max, wait_completion=False)
         self.preload_cmd.insert(1, "--no-gui")
-        await self.run_preload()
+        self.preload_cmd.insert(1, "--service")
+        self.preload_cmd[-1] = "qubes.WaitForRunningSystem"
+        await self.run_preload(assert_stdout=False)
         logger.info("end")
 
     @unittest.skipUnless(which("xdotool"), "xdotool not installed")

--- a/qubes/tests/vm/dispvm.py
+++ b/qubes/tests/vm/dispvm.py
@@ -155,6 +155,7 @@ class TC_00_DispVM(qubes.tests.QubesTestCase):
         self.appvm.template_for_dispvms = True
         orig_getitem = self.app.domains.__getitem__
         self.appvm.features["supported-rpc.qubes.WaitForRunningSystem"] = True
+        self.appvm.features["supported-rpc.qubes.WaitForSession"] = True
         self.appvm.features["preload-dispvm-max"] = "0"
         with mock.patch.object(
             self.app, "domains", wraps=self.app.domains
@@ -187,6 +188,7 @@ class TC_00_DispVM(qubes.tests.QubesTestCase):
         self.appvm.template_for_dispvms = True
 
         self.appvm.features["supported-rpc.qubes.WaitForRunningSystem"] = True
+        self.appvm.features["supported-rpc.qubes.WaitForSession"] = True
         self.appvm.features["preload-dispvm-max"] = "1"
         orig_getitem = self.app.domains.__getitem__
         with mock.patch.object(
@@ -253,6 +255,7 @@ class TC_00_DispVM(qubes.tests.QubesTestCase):
         mock_start.side_effect = self.mock_coro
         self.appvm.template_for_dispvms = True
         self.appvm.features["supported-rpc.qubes.WaitForRunningSystem"] = True
+        self.appvm.features["supported-rpc.qubes.WaitForSession"] = True
         orig_getitem = self.app.domains.__getitem__
         with mock.patch("qubes.events.Emitter.fire_event_async") as mock_events:
             self.appvm.features["preload-dispvm-max"] = "1"
@@ -296,6 +299,7 @@ class TC_00_DispVM(qubes.tests.QubesTestCase):
     def test_004_get_preload_max(self):
         self.assertEqual(qubes.vm.dispvm.get_preload_max(self.appvm), None)
         self.appvm.features["supported-rpc.qubes.WaitForRunningSystem"] = True
+        self.appvm.features["supported-rpc.qubes.WaitForSession"] = True
         self.appvm.features["preload-dispvm-max"] = 1
         self.assertEqual(qubes.vm.dispvm.get_preload_max(self.appvm), 1)
         self.assertEqual(qubes.vm.dispvm.get_preload_max(self.adminvm), None)
@@ -312,9 +316,11 @@ class TC_00_DispVM(qubes.tests.QubesTestCase):
         self.assertEqual(get_preload_templates(self.app), [])
 
         self.appvm.features["supported-rpc.qubes.WaitForRunningSystem"] = True
+        self.appvm.features["supported-rpc.qubes.WaitForSession"] = True
         self.appvm_alt.features["supported-rpc.qubes.WaitForRunningSystem"] = (
             True
         )
+        self.appvm_alt.features["supported-rpc.qubes.WaitForSession"] = True
         self.appvm.features["preload-dispvm-max"] = 1
         self.appvm_alt.features["preload-dispvm-max"] = 0
         self.assertEqual(get_preload_templates(self.app), [self.appvm])
@@ -670,6 +676,7 @@ class TC_00_DispVM(qubes.tests.QubesTestCase):
             self.appvm.create_on_disk(pool="alternative")
         )
         self.appvm.features["supported-rpc.qubes.WaitForRunningSystem"] = True
+        self.appvm.features["supported-rpc.qubes.WaitForSession"] = True
         self.appvm.features["preload-dispvm-max"] = "1"
         orig_getitem = self.app.domains.__getitem__
         with mock.patch.object(

--- a/qubes/tests/vm/mix/dvmtemplate.py
+++ b/qubes/tests/vm/mix/dvmtemplate.py
@@ -84,6 +84,7 @@ class TC_00_DVMTemplateMixin(
         self.appvm.features["qrexec"] = True
         self.appvm.features["gui"] = False
         self.appvm.features["supported-rpc.qubes.WaitForRunningSystem"] = True
+        self.appvm.features["supported-rpc.qubes.WaitForSession"] = True
         self.app.domains[self.appvm.name] = self.appvm
         self.app.domains[self.appvm] = self.appvm
         self.app.default_dispvm = self.appvm
@@ -163,9 +164,13 @@ class TC_00_DVMTemplateMixin(
         self.appvm.features["qrexec"] = True
         self.appvm.features["gui"] = False
         self.appvm.features["supported-rpc.qubes.WaitForRunningSystem"] = False
+        self.appvm.features["supported-rpc.qubes.WaitForSession"] = False
         with self.assertRaises(qubes.exc.QubesValueError):
             self.appvm.features["preload-dispvm-max"] = "1"
         self.appvm.features["supported-rpc.qubes.WaitForRunningSystem"] = True
+        with self.assertRaises(qubes.exc.QubesValueError):
+            self.appvm.features["preload-dispvm-max"] = "1"
+        self.appvm.features["supported-rpc.qubes.WaitForSession"] = True
         self.appvm.features["preload-dispvm-max"] = "1"
         cases_invalid = ["a", "-1", "1 1"]
         for value in cases_invalid:
@@ -458,5 +463,6 @@ class TC_00_DVMTemplateMixin(
     def test_100_get_preload_templates(self):
         print(qubes.vm.dispvm.get_preload_templates(self.app))
         self.appvm.features["supported-rpc.qubes.WaitForRunningSystem"] = True
+        self.appvm.features["supported-rpc.qubes.WaitForSession"] = True
         self.appvm.features["preload-dispvm-max"] = 1
         self.assertEqual(qubes.vm.dispvm.get_preload_max(self.appvm), 1)

--- a/qubes/vm/dispvm.py
+++ b/qubes/vm/dispvm.py
@@ -506,8 +506,7 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
             await asyncio.wait_for(
                 self.run_service_for_stdio(
                     service,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
+                    stderr=subprocess.STDOUT,
                 ),
                 timeout=timeout,
             )
@@ -519,12 +518,13 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
                 "startup. To debug, run the following on a new disposable of "
                 "'%s': %s" % (service, timeout, self.template, debug_msg)
             )
-        except (subprocess.CalledProcessError, qubes.exc.QubesException):
-            debug_msg = "systemctl --failed"
+        except subprocess.CalledProcessError as e:
             raise qubes.exc.QubesException(
-                "Error on call to '%s' during preload startup. To debug, "
-                "disable preloading from '%s' and run the following on a new "
-                "disposable: %s" % (service, self.template, debug_msg)
+                "Error on call to '%s' during preload startup: %s"
+                % (
+                    service,
+                    qubes.utils.sanitize_stderr_for_log(e.stdout),
+                )
             )
 
     @qubes.events.handler("domain-start")

--- a/qubes/vm/dispvm.py
+++ b/qubes/vm/dispvm.py
@@ -512,7 +512,10 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
             )
             self.log.info("Preload startup completed '%s'", service)
         except asyncio.TimeoutError:
-            debug_msg = "systemd-analyze blame"
+            if service == "qubes.WaitForSession":
+                debug_msg = "systemd-analyze --user blame"
+            else:
+                debug_msg = "systemd-analyze blame"
             raise qubes.exc.QubesException(
                 "Timed out call to '%s' after '%d' seconds during preload "
                 "startup. To debug, run the following on a new disposable of "
@@ -546,6 +549,14 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
         if not self.preload_requested:
             timeout = self.qrexec_timeout
             services = ["qubes.WaitForRunningSystem"]
+            if (
+                self.guivm
+                and self.features.check_with_template("gui", False)
+                and self.features.check_with_template(
+                    "supported-feature.late-gui-daemon", False
+                )
+            ):
+                services.append("qubes.WaitForSession")
             start_tasks = []
             for service in services:
                 start_tasks.append(

--- a/qubes/vm/mix/dvmtemplate.py
+++ b/qubes/vm/mix/dvmtemplate.py
@@ -19,7 +19,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 import asyncio
-from typing import Optional, Union, Iterator
+from typing import Optional, Union, Iterator, Tuple
 
 import qubes.config
 import qubes.events
@@ -223,10 +223,11 @@ class DVMTemplateMixin(qubes.events.Emitter):
         if not self.features.check_with_template("qrexec", None):
             raise qubes.exc.QubesValueError("Qube does not support qrexec")
 
-        service = "qubes.WaitForRunningSystem"
-        if not self.supports_preload():
+        supported, missing_services = self.supports_preload()
+        if not supported:
             raise qubes.exc.QubesValueError(
-                "Qube does not support the RPC '%s'" % service
+                "Qube does not support the RPC(s) '%s'"
+                % ", ".join(missing_services)
             )
 
         value = value or "0"
@@ -486,11 +487,12 @@ class DVMTemplateMixin(qubes.events.Emitter):
         if delay:
             event_log += " with a delay of %s second(s)" % f"{delay:.1f}"
         self.log.info(event_log)
-        service = "qubes.WaitForRunningSystem"
-        if not self.supports_preload():
+
+        supported, missing_services = self.supports_preload()
+        if not supported:
             raise qubes.exc.QubesValueError(
-                "Qube does not support the RPC '%s' but tried to preload, "
-                "check if template is outdated" % service
+                "Qube does not support the RPC(s) '%s' but tried to preload, "
+                "check if template is outdated" % ", ".join(missing_services)
             )
         if delay:
             await asyncio.sleep(abs(delay))
@@ -796,15 +798,21 @@ class DVMTemplateMixin(qubes.events.Emitter):
                     dispvm = self.app.domains[unwanted_disp]
                     asyncio.ensure_future(dispvm.cleanup())
 
-    def supports_preload(self) -> bool:
+    def supports_preload(self) -> Tuple[bool, list]:
         """
-        Check if the necessary RPC is supported.
+        Check if the necessary RPCs are supported.
 
-        :rtype: bool
+        The first returned value indicates success while the second value is
+        non empty and contains the missing services if they are not supported.
+
+        :rtype: (bool, list)
         """
         assert isinstance(self, qubes.vm.BaseVM)
-        service = "qubes.WaitForRunningSystem"
-        supported_service = "supported-rpc." + service
-        if self.features.check_with_template(supported_service, False):
-            return True
-        return False
+        supported = True
+        missing_services = []
+        for service in ["qubes.WaitForRunningSystem", "qubes.WaitForSession"]:
+            feature = "supported-rpc." + service
+            if not self.features.check_with_template(feature, False):
+                missing_services.append(service)
+                supported = False
+        return (supported, missing_services)

--- a/tests/dispvm_perf.py
+++ b/tests/dispvm_perf.py
@@ -928,6 +928,8 @@ class TestRun:
                 self.dvm.features["preload-dispvm-delay"] = str(
                     test.preload_delay
                 )
+            if not test.gui:
+                self.dvm.guivm = None
             if test.preload_max:
                 preload_max = test.preload_max
                 logger.info("Setting local max feature: '%s'", preload_max)


### PR DESCRIPTION
With the GUI agent patch, it can start before the GUI daemon connects, allowing the user session to complete. Wait both services to guarantee no enabled user or system service tries to start after the preload is used.

Requires: https://github.com/QubesOS/qubes-gui-agent-linux/pull/251
Requires: https://github.com/QubesOS/qubes-gui-agent-linux/pull/255
Requires: https://github.com/QubesOS/qubes-core-agent-linux/pull/647
Requires: https://github.com/QubesOS/qubes-core-qrexec/pull/229
Fixes: https://github.com/QubesOS/qubes-issues/issues/9940
For: https://github.com/QubesOS/qubes-issues/issues/1512