### PR TITLE
Allow VMs to request the anon-timezone feature

### DIFF
--- a/qubes/ext/core_features.py
+++ b/qubes/ext/core_features.py
@@ -194,6 +194,12 @@ class CoreFeatures(qubes.ext.Extension):
             ) and hasattr(vm, "appvm_default_bootmode"):
                 bootmode_value = untrusted_feature_value
                 vm.features["boot-mode.appvm-default"] = bootmode_value
+
+        # allow VMs to switch on anon-timezone, but do not permit dropping it
+        if "anon-timezone" in untrusted_features:
+            untrusted_value = untrusted_features["anon-timezone"]
+            if untrusted_value == "1":
+                vm.features["anon-timezone"] = True
         del untrusted_features
 
         # default user for qvm-run etc

--- a/qubes/tests/ext.py
+++ b/qubes/tests/ext.py
@@ -1677,6 +1677,47 @@ class TC_00_CoreFeatures(qubes.tests.QubesTestCase):
             ],
         )
 
+    def test_060_anon_timezone_set(self):
+        del self.vm.template
+        self.loop.run_until_complete(
+            self.ext.qubes_features_request(
+                self.vm,
+                "features-request",
+                untrusted_features={
+                    "anon-timezone": "1",
+                },
+            )
+        )
+        self.assertListEqual(
+            self.vm.mock_calls,
+            [
+                ("features.items", (), {}),
+                ("features.__setitem__", ("anon-timezone", True), {}),
+                ("features.get", ("qrexec", False), {}),
+                ("features.get", ("qrexec", False), {}),
+            ],
+        )
+
+    def test_061_anon_timezone_prevent_unset(self):
+        del self.vm.template
+        self.loop.run_until_complete(
+            self.ext.qubes_features_request(
+                self.vm,
+                "features-request",
+                untrusted_features={
+                    "anon-timezone": "0",
+                },
+            )
+        )
+        self.assertListEqual(
+            self.vm.mock_calls,
+            [
+                ("features.items", (), {}),
+                ("features.get", ("qrexec", False), {}),
+                ("features.get", ("qrexec", False), {}),
+            ],
+        )
+
     def test_100_servicevm_feature(self):
         self.vm.provides_network = True
         self.ext.set_servicevm_feature(self.vm)


### PR DESCRIPTION
This will allow virtual machines to hide dom0's timezone from themselves irreversibly. To prevent malware within a VM from undoing the feature once it's set, allow VMs to request the feature but do not let them drop it thereafter.

Fixes: https://github.com/QubesOS/qubes-issues/issues/8381