### PR TITLE
Fetch more journal logs after failed calls

### DIFF
--- a/qubes/tests/integ/network.py
+++ b/qubes/tests/integ/network.py
@@ -156,7 +156,7 @@ class VmNetworkingMixin:
                     vm, "systemctl --no-pager status xendriverdomain"
                 )
                 self._run_cmd_and_log_output(
-                    vm, "journalctl --no-pager --since '10 seconds ago'"
+                    vm, "journalctl --no-pager --since '30 seconds ago'"
                 )
                 self._run_cmd_and_log_output(
                     vm, "cat /var/log/xen/xen-hotplug.log"


### PR DESCRIPTION
For: https://github.com/QubesOS/qubes-issues/issues/10740

---

Journal was too short last time (openqa call linked on the issue above) or it is just that qrexec-agent doesn't logg calls made by non-root user...