### PR TITLE
Add label to system_info

### DIFF
--- a/qubes/api/internal.py
+++ b/qubes/api/internal.py
@@ -53,6 +53,8 @@ class SystemInfoCache:
         "property-reset:default_dispvm",
         "property-set:icon",
         "property-reset:icon",
+        "property-set:label",
+        "property-reset:label",
         "property-set:guivm",
         "property-reset:guivm",
         "property-set:relayvm",

--- a/qubes/api/internal.py
+++ b/qubes/api/internal.py
@@ -131,6 +131,7 @@ class SystemInfoCache:
                         else None
                     ),
                     "icon": str(domain.label.icon),
+                    "label": str(domain.label.color),
                     "guivm": (
                         domain.guivm.name
                         if getattr(domain, "guivm", None)

--- a/qubes/tests/api_internal.py
+++ b/qubes/tests/api_internal.py
@@ -221,6 +221,7 @@ class TC_00_API_Misc(qubes.tests.QubesTestCase):
         self.dom0.default_dispvm = None
         self.dom0.template_for_dispvms = False
         self.dom0.label.icon = "icon-dom0"
+        self.dom0.label.color = "0xffffff"
         self.dom0.get_power_state.return_value = "Running"
         self.dom0.uuid = uuid.UUID("00000000-0000-0000-0000-000000000000")
         del self.dom0.guivm
@@ -232,6 +233,7 @@ class TC_00_API_Misc(qubes.tests.QubesTestCase):
         vm.default_dispvm = vm
         vm.template_for_dispvms = True
         vm.label.icon = "icon-vm"
+        vm.label.color = "0xcc0000"
         vm.guivm = vm
         vm.get_power_state.return_value = "Halted"
         vm.uuid = TEST_UUID
@@ -246,6 +248,7 @@ class TC_00_API_Misc(qubes.tests.QubesTestCase):
                     "template_for_dispvms": False,
                     "icon": "icon-dom0",
                     "internal": None,
+                    "label": "0xffffff",
                     "guivm": None,
                     "power_state": "Running",
                     "relayvm": None,
@@ -259,6 +262,7 @@ class TC_00_API_Misc(qubes.tests.QubesTestCase):
                     "template_for_dispvms": True,
                     "icon": "icon-vm",
                     "internal": 1,
+                    "label": "0xcc0000",
                     "guivm": "vm",
                     "power_state": "Halted",
                     "relayvm": None,


### PR DESCRIPTION
This is necessary to display qube colors in qrexec-policy-graph (https://github.com/QubesOS/qubes-core-qrexec/pull/222).