### PR TITLE
Speed disposable performance tests without a GUI

### DIFF
--- a/tests/dispvm_perf.py
+++ b/tests/dispvm_perf.py
@@ -928,6 +928,8 @@ class TestRun:
                 self.dvm.features["preload-dispvm-delay"] = str(
                     test.preload_delay
                 )
+            if not test.gui:
+                self.dvm.guivm = None
             if test.preload_max:
                 preload_max = test.preload_max
                 logger.info("Setting local max feature: '%s'", preload_max)


### PR DESCRIPTION
Without having a GUIVM or GUI feature disabled, appmenus are not handled. This can considerably speed up the tests and lead to a better performance overall.

For: https://github.com/QubesOS/qubes-issues/issues/1512

---

This was already included in https://github.com/QubesOS/qubes-core-admin/pull/757/changes, but I was expecting it to be merged. As this fix was bundled with a feature PR, it wasn't solved.

---

Look how weird the creation stage is for nogui: https://openqa.qubes-os.org/tests/169531/file/system_tests-dispvm_perf-debian-13-xfce_graph_02_stage_stack_1_until_total.png.