### PR TITLE
Increase dom0 scheduling weight

### DIFF
--- a/linux/aux-tools/startup-misc.sh
+++ b/linux/aux-tools/startup-misc.sh
@@ -7,6 +7,7 @@ DOM0_MAXMEM=$(/usr/sbin/xl list 0 | tail -1 | awk '{ print $3 }')
 xenstore-write /local/domain/0/memory/static-max $[ $DOM0_MAXMEM * 1024 ]
 
 xl sched-credit -d 0 -w 2000
+xl sched-credit2 -d 0 -w 2000
 cp /var/lib/qubes/qubes.xml /var/lib/qubes/backup/qubes-$(date +%F-%T).xml
 
 /usr/lib/qubes/cleanup-dispvms


### PR DESCRIPTION
Dom0 is responsible for the UI and for critical background activities. In particular, it is on the critical path for VM start.  Therefore, it should be prioritized over all other VMs to avoid priority inversion.

Dom0 has been intended to have additional credit since a17989470afc ("Initial public commit."), but nowadays Xen uses the credit2 scheduler, so changing the parameters of the credit scheduler has no effect.

Fixes: QubesOS/qubes-issues#10778