### PR TITLE
Propagate vm-config.net-* features through NetVM chain

### DIFF
--- a/qubes/tests/vm/mix/net.py
+++ b/qubes/tests/vm/mix/net.py
@@ -418,3 +418,35 @@ class TC_00_NetVMMixin(
                     ipaddress.IPv4Address("1.1." + ip),
                     vmid_to_ipv4("1.1", vmid),
                 )
+
+    def test_300_mtu_property_propagation(self):
+        """Test propagation of MTU property."""
+        from unittest.mock import MagicMock, PropertyMock
+
+        vm = self.get_vm()
+        self.setup_netvms(vm)
+        mock_qdb = MagicMock()
+
+        with (
+            patch("qubes.vm.qubesvm.QubesVM.is_running", lambda x: True),
+            patch("qubes.vm.mix.net.NetVMMixin.attach_network"),
+            patch("qubes.vm.mix.net.NetVMMixin.detach_network"),
+            patch("qubes.vm.qubesvm.QubesVM.create_qdb_entries"),
+            patch(
+                "qubes.vm.qubesvm.QubesVM.untrusted_qdb",
+                new_callable=PropertyMock,
+                return_value=mock_qdb,
+            ),
+        ):
+            vm.netvm = self.netvm1
+
+            self.netvm1.mtu = 1492
+            vm.fire_event("domain-qdb-create")
+            mock_qdb.write.assert_any_call("/vm-config/net-mtu", "1492")
+            mock_qdb.write.reset_mock()
+
+            self.netvm1.mtu = 1300
+            mock_qdb.write.assert_any_call("/vm-config/net-mtu", "1300")
+
+            del self.netvm1.mtu
+            mock_qdb.rm.assert_any_call("/vm-config/net-mtu")

--- a/qubes/vm/mix/net.py
+++ b/qubes/vm/mix/net.py
@@ -147,6 +147,13 @@ class NetVMMixin(qubes.events.Emitter):
         doc="IPv6 address of this domain.",
     )
 
+    mtu = qubes.property(
+        "mtu",
+        type=int,
+        default=None,
+        doc="Maximum Transmission Unit (MTU) for the virtual interface.",
+    )
+
     # CORE2: swallowed uses_default_netvm
     netvm = qubes.VMProperty(
         "netvm",
@@ -271,6 +278,17 @@ class NetVMMixin(qubes.events.Emitter):
     #
     # used in both
     #
+
+    @qubes.stateless_property
+    def effective_mtu(self):
+        """Effective MTU for this domain. Inherited from netvm if not
+        set explicitly."""
+        netvm = self
+        while netvm is not None:
+            if hasattr(netvm, "mtu") and netvm.mtu is not None:
+                return netvm.mtu
+            netvm = getattr(netvm, "netvm", None)
+        return None
 
     @qubes.stateless_property
     def dns(self):
@@ -785,3 +803,46 @@ class NetVMMixin(qubes.events.Emitter):
     def has_firewall(self):
         """Return `True` if there are some vm specific firewall rules set"""
         return os.path.exists(os.path.join(self.dir_path, self.firewall_conf))
+
+    @qubes.events.handler("domain-qdb-create")
+    def on_domain_qdb_create_mtu(self, event):
+        """Copies effective MTU to this VM's QubesDB."""
+        # pylint: disable=unused-argument
+        eff_mtu = self.effective_mtu
+        if eff_mtu is not None:
+            self.untrusted_qdb.write("/vm-config/net-mtu", str(eff_mtu))
+
+    @qubes.events.handler(
+        "property-set:mtu",
+        "property-reset:mtu",
+        "property-set:netvm",
+        "property-reset:netvm",
+    )
+    def on_property_set_mtu(
+        self, event, name, newvalue=None, oldvalue=None, **kwargs
+    ):
+        """Propagate mtu changes to connected VMs."""
+
+        # pylint: disable=unused-argument
+        def _update_descendants(netvm):
+            for vm in netvm.connected_vms:
+                if hasattr(vm, "mtu") and vm.mtu is not None:
+                    continue
+                if vm.is_running() and hasattr(vm, "untrusted_qdb"):
+                    eff_mtu = vm.effective_mtu
+                    if eff_mtu is not None:
+                        vm.untrusted_qdb.write(
+                            "/vm-config/net-mtu", str(eff_mtu)
+                        )
+                    else:
+                        vm.untrusted_qdb.rm("/vm-config/net-mtu")
+                _update_descendants(vm)
+
+        if self.is_running() and hasattr(self, "untrusted_qdb"):
+            if getattr(self, "mtu", None) is None or name == "mtu":
+                eff_mtu = self.effective_mtu
+                if eff_mtu is not None:
+                    self.untrusted_qdb.write("/vm-config/net-mtu", str(eff_mtu))
+                else:
+                    self.untrusted_qdb.rm("/vm-config/net-mtu")
+        _update_descendants(self)


### PR DESCRIPTION
This patch fixes the Qubes OS bug #10758, propagating vm-config.net-* features to the descendant qubes in the NetVM chain, thus making the vm-config.net-* features visible in the Qubes DB of the descendant qubes.

In the current implementation, if a NetVM has a vm-config.net-mtu, the descendant qubes will not inherit the vm-config.net-mtu automatically. However, the in-qube networking scripts of the descendant qubes read the configuration from the Qubes DB.

This patch introduces the propagation of the vm-config.net-* features from the NetVM chain to the descendant qubes. The propagation code has been introduced in the file qubes/vm/mix/net.py. The propagation code performs the following actions:

on domain-qdb-create: the qube inherits the effective vm-config.net-* features from the NetVM chain

on domain-feature-set:*, the vm-config.net-* features of the NetVM are propagated to the running descendant qubes, except when overridden

on domain-feature-delete:*, the descendants of the NetVM inherit the next upstream vm-config.net-* feature or delete the entry if there are no more upstream features

Fixes: https://github.com/QubesOS/qubes-issues/issues/10758