### PR TITLE
ext/block: fix reporting which device is attached

### DIFF
--- a/qubes/ext/block.py
+++ b/qubes/ext/block.py
@@ -360,7 +360,9 @@ class BlockDeviceExtension(qubes.ext.Extension):
                 info = _try_get_block_device_info(vm.app, disk)
                 if not info:
                     continue
-                _backend_domain, port_id = info
+                backend_domain, port_id = info
+                if backend_domain != vm_:
+                    continue
 
                 result[port_id] = vm
         return result


### PR DESCRIPTION
The get_device_attachments() function is supposed to handle devices of a
specific VM, but it reported them from all the VMs. If there were
devices with the same port_id but in different backend VMs, it could
result in wrong device being reported as attached.
This especially affected events about attach/detach, which can confuse
devices widget.

Fix it be actually checking what is the backend VM of a given device.

Fixes QubesOS/qubes-issues#10803