### PR TITLE
lvm: really suppress logs on stdout

### DIFF
--- a/qubes/storage/lvm.py
+++ b/qubes/storage/lvm.py
@@ -235,6 +235,7 @@ _init_cache_cmd = [
     _lvm,
     "lvs",
     "--quiet",
+    "--quiet",
     "--noheadings",
     "-o",
     "vg_name,pool_lv,name,lv_size,data_percent,lv_attr,origin,lv_metadata_size,"


### PR DESCRIPTION
Warnings on stdout are suppressed in silent mode, not just quiet. Use
--quiet twice to enable silent mode. See referenced commit for more
details.

Fixes: 1ae6bae5 "lvm: suppress logs on stdout when expecting json output"
Fixes QubesOS/qubes-issues#10023