### PR TITLE
devices: prevent attaching devices to dom0 without `--force` flag

### DIFF
--- a/qubes/devices.py
+++ b/qubes/devices.py
@@ -182,6 +182,11 @@ class DeviceCollection:
         Attach device to domain.
         """
 
+        if self._vm.name == "dom0" and not assignment.options.get("force"):
+            raise qubes.exc.QubesValueError(
+                "Attaching device to dom0 requires setting --force"
+            )
+
         if assignment.devclass != self._bus:
             raise ProtocolError(
                 f"Trying to attach {assignment.devclass} device "

--- a/qubes/tests/devices.py
+++ b/qubes/tests/devices.py
@@ -133,6 +133,22 @@ class TC_00_DeviceCollection(qubes.tests.QubesTestCase):
                 self.collection.attach(self.assignment)
             )
 
+    def test_002a_attach_to_dom0_blocked(self):
+        self.emitter.name = "dom0"
+        self.emitter.running = True
+        with self.assertRaises(qubes.exc.QubesValueError):
+            self.loop.run_until_complete(
+                self.collection.attach(self.assignment)
+            )
+
+    def test_002b_attach_to_dom0_with_force(self):
+        self.emitter.name = "dom0"
+        self.emitter.running = True
+        self.assignment.options = {"force": "yes"}
+        self.loop.run_until_complete(self.collection.attach(self.assignment))
+        self.assertEventFired(self.emitter, "device-pre-attach:testclass")
+        self.assertEventFired(self.emitter, "device-attach:testclass")
+
     def test_003_detach(self):
         self.attach()
         self.loop.run_until_complete(


### PR DESCRIPTION
fixes: https://github.com/QubesOS/qubes-issues/issues/10825

related: https://github.com/QubesOS/qubes-core-admin-client/pull/466