### PR TITLE
replace `random` with `secrets`

### DIFF
--- a/qubes/storage/zfs.py
+++ b/qubes/storage/zfs.py
@@ -7,7 +7,7 @@ import contextlib
 import dataclasses
 import logging
 import os
-import random
+import secrets
 import shlex
 import shutil
 import string
@@ -81,7 +81,7 @@ def get_random_string(
     length: int,
     character_set: str = string.ascii_lowercase,
 ) -> str:
-    return "".join(random.choice(character_set) for _ in range(length))
+    return "".join(secrets.choice(character_set) for _ in range(length))
 
 
 T = TypeVar("T")

--- a/qubes/utils.py
+++ b/qubes/utils.py
@@ -23,8 +23,8 @@
 import asyncio
 import hashlib
 import logging
-import random
 import re
+import secrets
 import string
 import os
 import os.path
@@ -186,7 +186,7 @@ def get_entry_point_one(group, name):
 def random_string(length=5):
     """Return random string consisting of ascii_leters and digits"""
     return "".join(
-        random.choice(string.ascii_letters + string.digits)
+        secrets.choice(string.ascii_letters + string.digits)
         for _ in range(length)
     )
 


### PR DESCRIPTION
This PR replaces the `random` module that uses an algorithm that is not a suitable CSPRNG (https://docs.python.org/3/library/random.html) with pythons `secrets` module.

The function `random_string` is called by the qubes admin api that generates a token https://github.com/QubesOS/qubes-core-admin/blob/2488f2b19385b4c30dd1f18aecf0252a82732828/qubes/api/admin.py#L470 where i am not sure if it is supposed to be secret.

The change in zfs.py does not seem to have any security impact, but to prevent calling it in the future to generate values that are supposed to be secret i changed it along.