### PR TITLE
ext/pci: fix crash on devices with non-standard PCI segment

### DIFF
--- a/qubes/ext/pci.py
+++ b/qubes/ext/pci.py
@@ -153,7 +153,10 @@ class PCIDevice(qubes.device_protocol.DeviceInfo):
             dev_match = self._libvirt_regex.match(libvirt_name)
             if not dev_match:
                 raise UnsupportedDevice(libvirt_name)
-            port_id = sbdf_to_path(libvirt_name)
+            try:
+                port_id = sbdf_to_path(libvirt_name)
+            except (AssertionError, ValueError, KeyError):
+                raise UnsupportedDevice(libvirt_name)
             port = Port(
                 backend_domain=port.backend_domain,
                 port_id=port_id,


### PR DESCRIPTION
**Summary**
On Dell Latitude 5420 (and likely other Tiger Lake laptops), Intel VMD (Volume Management Device) is enabled by default in BIOS. VMD creates a virtual PCI segment 10000: for the storage devices it manages:

```
10000:e0:17.0 SATA controller: Intel Corporation Tiger Lake-LP SATA Controller (rev 20)
10000:e0:1d.0 PCI bridge: Intel Corporation Tiger Lake-LP PCI Express Root Port #9 (rev 20)
```

When qubesd enumerates PCI devices, sbdf_to_path() hits an AssertionError on these devices because their bus topology doesn't match the expected hierarchy. This crashes the entire admin.vm.device.pci.Available API call, making qvm-pci unusable.

Full lspci on this machine:
```bash
[root@dom0 ~]# lspci
0000:00:00.0 Host bridge: Intel Corporation Tiger Lake-UP3/H35 4 cores Host Bridge/DRAM Registers (rev 01)
0000:00:02.0 VGA compatible controller: Intel Corporation TigerLake-LP GT2 [Iris Xe Graphics] (rev 01)
0000:00:04.0 Signal processing controller: Intel Corporation TigerLake-LP Dynamic Tuning Processor Participant (rev 01)
0000:00:07.0 PCI bridge: Intel Corporation Tiger Lake-LP Thunderbolt 4 PCI Express Root Port #0 (rev 01)
0000:00:07.1 PCI bridge: Intel Corporation Tiger Lake-LP Thunderbolt 4 PCI Express Root Port #1 (rev 01)
0000:00:0d.0 USB controller: Intel Corporation Tiger Lake-LP Thunderbolt 4 USB Controller (rev 01)
0000:00:0d.2 USB controller: Intel Corporation Tiger Lake-LP Thunderbolt 4 NHI #0 (rev 01)
0000:00:0e.0 RAID bus controller: Intel Corporation Volume Management Device NVMe RAID Controller
0000:00:12.0 Serial controller: Intel Corporation Tiger Lake-LP Integrated Sensor Hub (rev 20)
0000:00:14.0 USB controller: Intel Corporation Tiger Lake-LP USB 3.2 Gen 2x1 xHCI Host Controller (rev 20)
0000:00:14.2 RAM memory: Intel Corporation Tiger Lake-LP Shared SRAM (rev 20)
0000:00:14.3 Network controller: Intel Corporation Wi-Fi 6 AX201 (rev 20)
0000:00:15.0 Serial bus controller: Intel Corporation Tiger Lake-LP Serial IO I2C Controller #0 (rev 20)
0000:00:15.1 Serial bus controller: Intel Corporation Tiger Lake-LP Serial IO I2C Controller #1 (rev 20)
0000:00:16.0 Communication controller: Intel Corporation Tiger Lake-LP Management Engine Interface (rev 20)
0000:00:16.3 Serial controller: Intel Corporation Tiger Lake-LP Active Management Technology - SOL (rev 20)
0000:00:17.0 System peripheral: Intel Corporation RST VMD Managed Controller
0000:00:1c.0 PCI bridge: Intel Corporation Tiger Lake-LP PCI Express Root Port #7 (rev 20)
0000:00:1d.0 System peripheral: Intel Corporation RST VMD Managed Controller
0000:00:1f.0 ISA bridge: Intel Corporation Tiger Lake-LP LPC Controller (rev 20)
0000:00:1f.3 Audio device: Intel Corporation Tiger Lake-LP Smart Sound Technology Audio Controller (rev 20)
0000:00:1f.4 SMBus: Intel Corporation Tiger Lake-LP SMBus Controller (rev 20)
0000:00:1f.5 Serial bus controller: Intel Corporation Tiger Lake-LP SPI Controller (rev 20)
0000:00:1f.6 Ethernet controller: Intel Corporation Ethernet Connection (13) I219-LM (rev 20)
0000:01:00.0 PCI bridge: Intel Corporation JHL7440 Thunderbolt 3 Bridge [Titan Ridge DD 2018] (rev 06)
0000:02:02.0 PCI bridge: Intel Corporation JHL7440 Thunderbolt 3 Bridge [Titan Ridge DD 2018] (rev 06)
0000:02:04.0 PCI bridge: Intel Corporation JHL7440 Thunderbolt 3 Bridge [Titan Ridge DD 2018] (rev 06)
0000:03:00.0 USB controller: Intel Corporation JHL7440 Thunderbolt 3 USB Controller [Titan Ridge DD 2018] (rev 06)
0000:71:00.0 Unassigned class [ff00]: Realtek Semiconductor Co., Ltd. RTS525A PCI Express Card Reader (rev 01)
10000:e0:17.0 SATA controller: Intel Corporation Tiger Lake-LP SATA Controller (rev 20)
10000:e0:1d.0 PCI bridge: Intel Corporation Tiger Lake-LP PCI Express Root Port #9 (rev 20)
10000:e1:00.0 Non-Volatile memory controller: Sandisk Corp IX SN530 NVMe SSD / microSD Express Card (DRAM-less) (rev 01)
```

**Fix**
Catch the AssertionError from sbdf_to_path() in PCIDevice.__init__ and convert it to UnsupportedDevice. The existing handler in on_device_list_pci already skips unsupported devices gracefully with a warning log. VMD-managed devices cannot be passed through to VMs via standard PCI passthrough anyway, so skipping them is the correct behavior.

This patch fixes qvm-pci, but also qubes-global-config, which needs to load the PCI device list first.

Closes https://github.com/QubesOS/qubes-issues/issues/10847