### PR TITLE
vm: update only network QDB entries on netvm change

### DIFF
--- a/qubes/tests/vm/mix/net.py
+++ b/qubes/tests/vm/mix/net.py
@@ -129,7 +129,7 @@ class TC_00_NetVMMixin(
             patch("qubes.vm.qubesvm.QubesVM.is_running", lambda x: True),
             patch("qubes.vm.mix.net.NetVMMixin.attach_network") as mock_attach,
             patch("qubes.vm.mix.net.NetVMMixin.detach_network") as mock_detach,
-            patch("qubes.vm.qubesvm.QubesVM.create_qdb_entries"),
+            patch("qubes.vm.qubesvm.QubesVM.update_qdb_netvm_entries"),
         ):
 
             with self.subTest("setting netvm to none"):
@@ -167,7 +167,7 @@ class TC_00_NetVMMixin(
             patch("qubes.vm.qubesvm.QubesVM.is_paused", lambda x: True),
             patch("qubes.vm.mix.net.NetVMMixin.attach_network") as mock_attach,
             patch("qubes.vm.mix.net.NetVMMixin.detach_network") as mock_detach,
-            patch("qubes.vm.qubesvm.QubesVM.create_qdb_entries"),
+            patch("qubes.vm.qubesvm.QubesVM.update_qdb_netvm_entries"),
             patch("qubes.vm.qubesvm.QubesVM.run_service_for_stdio"),
         ):
 

--- a/qubes/vm/mix/net.py
+++ b/qubes/vm/mix/net.py
@@ -647,8 +647,9 @@ class NetVMMixin(qubes.events.Emitter):
             newvalue.reload_connected_ips()
 
         if self.is_running():
-            # refresh IP, DNS etc
-            self.create_qdb_entries()
+            # refresh only network-related entries to avoid resetting
+            # unrelated QubesDB entries such as keyboard layout
+            self.update_qdb_netvm_entries()
             if not self.is_paused():
                 self.attach_network()
 

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -2812,25 +2812,7 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.LocalVM):
             for i, addr in zip(("primary", "secondary"), self.dns):
                 self.untrusted_qdb.write("/qubes-netvm-{}-dns".format(i), addr)
 
-        if self.netvm is not None:
-            self.untrusted_qdb.write("/qubes-mac", str(self.mac))
-            self.untrusted_qdb.write("/qubes-ip", str(self.visible_ip))
-            self.untrusted_qdb.write(
-                "/qubes-netmask", str(self.visible_netmask)
-            )
-            self.untrusted_qdb.write(
-                "/qubes-gateway", str(self.visible_gateway)
-            )
-
-            for i, addr in zip(("primary", "secondary"), self.dns):
-                self.untrusted_qdb.write("/qubes-{}-dns".format(i), str(addr))
-
-            if self.visible_ip6:  # pylint: disable=using-constant-test
-                self.untrusted_qdb.write("/qubes-ip6", str(self.visible_ip6))
-            if self.visible_gateway6:  # pylint: disable=using-constant-test
-                self.untrusted_qdb.write(
-                    "/qubes-gateway6", str(self.visible_gateway6)
-                )
+        self.update_qdb_netvm_entries()
 
         tzname = qubes.utils.get_timezone()
         if tzname and not self.features.check_with_template(
@@ -2859,6 +2841,41 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.LocalVM):
                 )
 
         self.fire_event("domain-qdb-create")
+
+    def update_qdb_netvm_entries(self):
+        """Update only network-related QubesDB entries.
+        Called on NetVM changes to avoid resetting unrelated entries
+        such as keyboard layout. See QubesOS/qubes-issues#9892"""
+        if self.netvm is not None:
+            self.untrusted_qdb.write("/qubes-mac", str(self.mac))
+            self.untrusted_qdb.write("/qubes-ip", str(self.visible_ip))
+            self.untrusted_qdb.write(
+                "/qubes-netmask", str(self.visible_netmask)
+            )
+            self.untrusted_qdb.write(
+                "/qubes-gateway", str(self.visible_gateway)
+            )
+            for i, addr in zip(("primary", "secondary"), self.dns):
+                self.untrusted_qdb.write("/qubes-{}-dns".format(i), str(addr))
+            if self.visible_ip6:
+                self.untrusted_qdb.write("/qubes-ip6", str(self.visible_ip6))
+            if self.visible_gateway6:
+                self.untrusted_qdb.write(
+                    "/qubes-gateway6", str(self.visible_gateway6)
+                )
+        else:
+            # netvm set to None — remove network entries
+            for key in (
+                "/qubes-mac",
+                "/qubes-ip",
+                "/qubes-netmask",
+                "/qubes-gateway",
+                "/qubes-primary-dns",
+                "/qubes-secondary-dns",
+                "/qubes-ip6",
+                "/qubes-gateway6",
+            ):
+                self.untrusted_qdb.rm(key)
 
     # TODO async; update this in constructor
     def _update_libvirt_domain(self):


### PR DESCRIPTION
Fixes QubesOS/qubes-issues#9892

When netvm changes, on_property_set_netvm() called create_qdb_entries() which fires domain-qdb-create and rewrites all QubesDB entries including /keyboard-layout, resetting any custom layout set by the user.

Add update_qdb_netvm_entries() in QubesVM that writes only the network-related QubesDB entries (IP, gateway, netmask, DNS, MAC). Use this in on_property_set_netvm() instead of create_qdb_entries().