### PR TITLE
Add support for default standalone boot modes

### DIFF
--- a/qubes/ext/core_features.py
+++ b/qubes/ext/core_features.py
@@ -194,6 +194,16 @@ class CoreFeatures(qubes.ext.Extension):
             ) and hasattr(vm, "appvm_default_bootmode"):
                 bootmode_value = untrusted_feature_value
                 vm.features["boot-mode.appvm-default"] = bootmode_value
+        if "boot-mode.standalone-default" in untrusted_features:
+            untrusted_feature_value = untrusted_features[
+                "boot-mode.standalone-default"
+            ]
+            if (
+                f"boot-mode.kernelopts.{untrusted_feature_value}" in vm.features
+                or untrusted_feature_value == "default"
+            ):
+                bootmode_value = untrusted_feature_value
+                vm.features["boot-mode.standalone-default"] = bootmode_value
 
         # allow VMs to switch on anon-timezone, but do not permit dropping it
         if "anon-timezone" in untrusted_features:

--- a/qubes/storage/__init__.py
+++ b/qubes/storage/__init__.py
@@ -929,9 +929,13 @@ class Storage:
                 f"data"
             )
 
-        return await qubes.utils.coro_maybe(
+        import_rslt = await qubes.utils.coro_maybe(
             dst_volume.import_volume(src_volume)
         )
+        await self.vm.fire_event_async(
+            "domain-import-volume", name=dst_volume.name, source=src_volume
+        )
+        return import_rslt
 
 
 class VolumesCollection:

--- a/qubes/tests/ext.py
+++ b/qubes/tests/ext.py
@@ -1677,6 +1677,85 @@ class TC_00_CoreFeatures(qubes.tests.QubesTestCase):
             ],
         )
 
+    def test_058_bootmode_standalone_default_good(self):
+        del self.vm.template
+        self.loop.run_until_complete(
+            self.ext.qubes_features_request(
+                self.vm,
+                "features-request",
+                untrusted_features={
+                    "boot-mode.kernelopts.orig-mode": "test1",
+                    "boot-mode.kernelopts.new-mode": "test2",
+                    "boot-mode.standalone-default": "new-mode",
+                },
+            )
+        )
+        self.assertListEqual(
+            self.vm.mock_calls,
+            [
+                ("features.items", (), {}),
+                (
+                    "features.__setitem__",
+                    ("boot-mode.kernelopts.orig-mode", "test1"),
+                    {},
+                ),
+                (
+                    "features.__setitem__",
+                    ("boot-mode.kernelopts.new-mode", "test2"),
+                    {},
+                ),
+                (
+                    "features.__contains__",
+                    ("boot-mode.kernelopts.new-mode",),
+                    {},
+                ),
+                (
+                    "features.__setitem__",
+                    ("boot-mode.standalone-default", "new-mode"),
+                    {},
+                ),
+                ("features.get", ("qrexec", False), {}),
+                ("features.get", ("qrexec", False), {}),
+            ],
+        )
+
+    def test_059_bootmode_standalone_default_bad(self):
+        del self.vm.template
+        self.loop.run_until_complete(
+            self.ext.qubes_features_request(
+                self.vm,
+                "features-request",
+                untrusted_features={
+                    "boot-mode.kernelopts.orig-mode": "test1",
+                    "boot-mode.kernelopts.new-mode": "test2",
+                    "boot-mode.standalone-default": "missing-mode",
+                },
+            )
+        )
+        self.assertListEqual(
+            self.vm.mock_calls,
+            [
+                ("features.items", (), {}),
+                (
+                    "features.__setitem__",
+                    ("boot-mode.kernelopts.orig-mode", "test1"),
+                    {},
+                ),
+                (
+                    "features.__setitem__",
+                    ("boot-mode.kernelopts.new-mode", "test2"),
+                    {},
+                ),
+                (
+                    "features.__contains__",
+                    ("boot-mode.kernelopts.missing-mode",),
+                    {},
+                ),
+                ("features.get", ("qrexec", False), {}),
+                ("features.get", ("qrexec", False), {}),
+            ],
+        )
+
     def test_060_anon_timezone_set(self):
         del self.vm.template
         self.loop.run_until_complete(

--- a/qubes/tests/integ/storage.py
+++ b/qubes/tests/integ/storage.py
@@ -31,6 +31,7 @@ import qubes.tests.storage_reflink
 import qubes.tests.storage_zfs
 import qubes.utils
 import qubes.vm.appvm
+import qubes.vm.standalonevm
 
 
 class StorageTestMixin(object):
@@ -46,6 +47,16 @@ class StorageTestMixin(object):
             qubes.vm.appvm.AppVM, name=self.make_vm_name("vm2"), label="red"
         )
         self.loop.run_until_complete(self.vm2.create_on_disk())
+        self.standalone_vm1 = self.app.add_new_vm(
+            qubes.vm.standalonevm.StandaloneVM,
+            name=self.make_vm_name("standalone-vm1"),
+            label="red",
+        )
+        self.standalone_vm1.clone_properties(self.app.default_template)
+        self.standalone_vm1.features.update(self.app.default_template.features)
+        self.loop.run_until_complete(
+            self.standalone_vm1.clone_disk_files(self.app.default_template)
+        )
         self.pool = None
         self.init_pool()
         self.app.save()
@@ -484,6 +495,29 @@ class StorageTestMixin(object):
             "head -c 7 /dev/xvde", user="root"
         )
         self.assertEqual(stdout, b"test123")
+
+    def test_007_standalone_clone_boot_mode_transition(self):
+        return self.loop.run_until_complete(
+            self._test_007_standalone_clone_boot_mode_transition()
+        )
+
+    async def _test_007_standalone_clone_boot_mode_transition(self):
+        self.standalone_vm1.features["boot-mode.kernelopts.orig-mode"] = "test1"
+        self.standalone_vm1.features["boot-mode.kernelopts.new-mode"] = "test2"
+        self.standalone_vm1.features["boot-mode.active"] = "orig-mode"
+        self.standalone_vm1.features["boot-mode.standalone-default"] = (
+            "new-mode"
+        )
+        template_rootvol = self.app.default_template.storage.get_volume("root")
+        standalone_vm1_rootvol = self.standalone_vm1.storage.get_volume("root")
+        await qubes.utils.coro_maybe(
+            self.standalone_vm1.storage.import_volume(
+                standalone_vm1_rootvol, template_rootvol
+            )
+        )
+        self.assertEqual(
+            self.standalone_vm1.features["boot-mode.active"], "new-mode"
+        )
 
 
 class StorageFile(StorageTestMixin, qubes.tests.SystemTestCase):

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -668,6 +668,15 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.LocalVM):
             :param event: Event name (``'domain-tag-delete:' tag``)
             :param tag: tag name
 
+        .. event:: domain-import-volume (subject, event, name, source)
+
+            A volume has been imported.
+
+            :param subject: Event emitter (the qube object)
+            :param event: Event name (``'domain-import-volume'``)
+            :param name: Destination volume name
+            :param source: Source volume
+
         .. event:: features-request (subject, event, *, untrusted_features)
 
             The domain is performing a features request.

--- a/qubes/vm/standalonevm.py
+++ b/qubes/vm/standalonevm.py
@@ -62,3 +62,15 @@ class StandaloneVM(
             },
         }
         super().__init__(*args, **kwargs)
+
+    @qubes.events.handler("domain-import-volume")
+    def on_domain_import_volume(self, event, name, source):
+        # pylint: disable=unused-argument
+        if name != "root":
+            return
+        if "boot-mode.standalone-default" in self.features:
+            bootmode_value = self.features["boot-mode.standalone-default"]
+            if bootmode_value == "default":
+                self.features["boot-mode.active"] = "default"
+            if f"boot-mode.kernelopts.{bootmode_value}" in self.features:
+                self.features["boot-mode.active"] = bootmode_value


### PR DESCRIPTION
When a standalone is cloned from a template, the usual default boot mode of the standalone is the same as the boot mode the template originally used. In some instances this is undesirable; Kicksecure for instance puts its templates into a "sysmaint" boot mode that impairs standalone functionality.

To fix this, add a new qvm-feature, "boot-mode.standalone-default", which states which boot mode a standalone should be switched to when its root volume is cloned from any other VM. (Note that cloning a standalone from another standalone will switch it to the boot mode specified by "boot-mode.standalone-default", cloning a template isn't the only way to trigger this.)

Allows fixing https://github.com/QubesOS/qubes-issues/issues/10514, but does not fix this bug by itself.

I've tested the main code of this on my R4.3 machine, and it seems to work. The test code is untested though, and I'd be surprised if the integration tests are actually correct as-is. Note also that I *only* implemented integration tests for the actual "change boot mode on root volume clone" part of this, since I couldn't figure out how to sanely implement normal tests. Thus coverage.py will probably be unhappy with this.