### PR TITLE
tests: add missing test cleanup

### DIFF
--- a/qubes/tests/__init__.py
+++ b/qubes/tests/__init__.py
@@ -532,6 +532,10 @@ class QubesTestCase(unittest.TestCase):
         )
         self.skip_kernel_validation_patch.start()
 
+    def tearDown(self):
+        self.skip_kernel_validation_patch.stop()
+        super().tearDown()
+
     def cleanup_gc(self):
         # remove cached references to Qubes() object
         qubes.api.internal.SystemInfoCache.cache_for_app = None

--- a/qubes/tests/__init__.py
+++ b/qubes/tests/__init__.py
@@ -957,6 +957,12 @@ class SystemTestCase(QubesTestCase):
             obj_type = type(getattr(self, attr))
             if obj_type.__module__.startswith("qubes"):
                 delattr(self, attr)
+            elif issubclass(obj_type, list) and any(
+                type(obj).__module__.startswith("qubes")
+                for obj in getattr(self, attr)
+            ):
+                # remove also list of qubes objects
+                delattr(self, attr)
 
         # then trigger garbage collector to really destroy those objects
         gc.collect()

--- a/qubes/tests/rpc_import.py
+++ b/qubes/tests/rpc_import.py
@@ -69,6 +69,7 @@ if [ "$null" = true ]; then printf '\\0'; fi
     )
 
     def setUp(self):
+        super().setUp()
         self.tmpdir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, self.tmpdir)
         with open(


### PR DESCRIPTION
skip_kernel_validation_patch was not stopped, and keeps reference to
some objects.
