### PR TITLE
tests: do not fail dispvm+thunderbird test early if TB is not installed

### DIFF
--- a/qubes/tests/integ/dispvm.py
+++ b/qubes/tests/integ/dispvm.py
@@ -932,15 +932,19 @@ class TC_20_DispVMMixin(DispVMHelpersMixin):
         self.loop.run_until_complete(self.testvm1.create_on_disk())
         self.app.save()
 
+        apps_list = self._get_apps_list(self.template)
         app_id = "mozilla-thunderbird"
         if "debian" in self.template or "whonix" in self.template:
             app_id = "thunderbird"
         # F40+ has org.mozilla.thunderbird
-        if "org.mozilla.thunderbird" in self._get_apps_list(self.template):
+        if "org.mozilla.thunderbird" in apps_list:
             app_id = "org.mozilla.thunderbird"
         # F41+ has net.thunderbird.Thunderbird
-        if "net.thunderbird.Thunderbird" in self._get_apps_list(self.template):
+        if "net.thunderbird.Thunderbird" in apps_list:
             app_id = "net.thunderbird.Thunderbird"
+
+        if not app_id in apps_list:
+            self.skipTest(f"{app_id} not installed in {self.template}")
 
         self.testvm1.features["service.app-dispvm." + app_id] = "1"
         self.loop.run_until_complete(self.testvm1.start())


### PR DESCRIPTION
Checking if Thunderbird is installed is done later. Do not fail on
preparing its configuration - make it work also if /etc/thunderbird/pref
isn't pre-existing.

If TB is not installed, the test will be recorded as skipped anyway (so
the file won't be used), but create the dir anyway. This will allow
working with distributions not pre-creating that directory (if any).
