### PR TITLE
Skip running check for untrusted_qdb access

### DIFF
--- a/qubes/app.py
+++ b/qubes/app.py
@@ -1233,6 +1233,15 @@ class Qubes(qubes.PropertyHolder):
 
         for vm in self.domains:
             vm.events_enabled = True
+            if (
+                not self.vmm.offline_mode
+                and isinstance(vm, qubes.vm.qubesvm.QubesVM)
+                and not vm.untrusted_qdb
+                and vm.is_running()
+            ):
+                import qubesdb  # pylint: disable=import-error
+
+                vm._qdb_connection = qubesdb.QubesDB(vm.name)
             vm.fire_event("domain-load")
 
         # get a file timestamp (before closing it - still holding the lock!),

--- a/qubes/ext/audio.py
+++ b/qubes/ext/audio.py
@@ -36,13 +36,13 @@ class AUDIO(qubes.ext.Extension):
     @staticmethod
     def set_qubesdb_audiovm(vm):
         # Ensure that qube is ready
-        if not vm.is_running():
+        if not getattr(vm, "untrusted_qdb"):
             return
 
         # Add AudioVM Xen ID for gui-agent
         audiovm = getattr(vm, "audiovm", None)
         if audiovm is not None:
-            if audiovm != vm and audiovm.is_running():
+            if audiovm != vm and getattr(audiovm, "untrusted_qdb"):
                 vm.untrusted_qdb.write(
                     "/qubes-audio-domain-xid", str(audiovm.xid)
                 )
@@ -62,7 +62,7 @@ class AUDIO(qubes.ext.Extension):
             subject.tags.add(audiovm)
 
         # It is needed to filter these events because
-        # vm.is_running() is not yet available.
+        # getattr(vm, "untrusted_qdb") is not yet available.
         if event not in ("domain-init", "domain-load"):
             self.set_qubesdb_audiovm(subject)
 
@@ -71,7 +71,7 @@ class AUDIO(qubes.ext.Extension):
         attached_vms = [
             domain
             for domain in self.attached_vms(vm)
-            if domain.is_running() and not getattr(domain, "is_preload", False)
+            if not getattr(domain, "is_preload", False) and domain.is_running()
         ]
         if attached_vms and not kwargs.get("force", False):
             raise qubes.exc.QubesVMInUseError(
@@ -95,7 +95,7 @@ class AUDIO(qubes.ext.Extension):
 
     @staticmethod
     async def set_stubdom_audiovm_domid(qube, audiovm):
-        if not qube.is_running():
+        if not getattr(qube, "untrusted_qdb"):
             return
         if audiovm:
             audiovm_xid = audiovm.xid

--- a/qubes/ext/block.py
+++ b/qubes/ext/block.py
@@ -92,7 +92,7 @@ class BlockDevice(qubes.device_protocol.DeviceInfo):
         return self._serial
 
     def _load_lazily_name_and_serial(self):
-        if not self.backend_domain.is_running():
+        if not getattr(self.backend_domain, "untrusted_qdb"):
             return "unknown", "unknown"
         untrusted_desc = self.backend_domain.untrusted_qdb.read(
             f"/qubes-block-devices/{self.port_id}/desc"
@@ -124,7 +124,7 @@ class BlockDevice(qubes.device_protocol.DeviceInfo):
     def mode(self):
         """Device mode, either 'w' for read-write, or 'r' for read-only"""
         if self._mode is None:
-            if not self.backend_domain.is_running():
+            if not getattr(self.backend_domain, "untrusted_qdb"):
                 return "w"
             untrusted_mode = self.backend_domain.untrusted_qdb.read(
                 "/qubes-block-devices/{}/mode".format(self.port_id)
@@ -144,7 +144,7 @@ class BlockDevice(qubes.device_protocol.DeviceInfo):
     def size(self):
         """Device size in bytes"""
         if self._size is None:
-            if not self.backend_domain.is_running():
+            if not getattr(self.backend_domain, "untrusted_qdb"):
                 return None
             untrusted_size = self.backend_domain.untrusted_qdb.read(
                 "/qubes-block-devices/{}/size".format(self.port_id)
@@ -183,7 +183,7 @@ class BlockDevice(qubes.device_protocol.DeviceInfo):
         partition of an usb stick), the parent device id should be here.
         """
         if self._parent is None:
-            if not self.backend_domain or not self.backend_domain.is_running():
+            if not self.backend_domain or not getattr(self.backend_domain, "untrusted_qdb"):
                 return None
             untrusted_parent_info = self.backend_domain.untrusted_qdb.read(
                 f"/qubes-block-devices/{self.port_id}/parent"
@@ -216,10 +216,10 @@ class BlockDevice(qubes.device_protocol.DeviceInfo):
         """
         Warning: this property is time-consuming, do not run in loop!
         """
-        if not self.backend_domain or not self.backend_domain.is_running():
+        if not self.backend_domain or not getattr(self.backend_domain, "untrusted_qdb"):
             return None
         for vm in self.backend_domain.app.domains:
-            if not vm.is_running():
+            if not getattr(vm, "untrusted_qdb"):
                 continue
             if self._is_attached_to(vm):
                 return vm
@@ -348,7 +348,7 @@ class BlockDeviceExtension(qubes.ext.Extension):
     def get_device_attachments(vm_):
         result = {}
         for vm in vm_.app.domains:
-            if not vm.is_running() or isinstance(vm, RemoteVM):
+            if not getattr(vm, "untrusted_qdb") or isinstance(vm, RemoteVM):
                 continue
 
             if vm.app.vmm.offline_mode:
@@ -390,7 +390,7 @@ class BlockDeviceExtension(qubes.ext.Extension):
     def on_device_list_block(self, vm, event):
         # pylint: disable=unused-argument
 
-        if not vm.is_running():
+        if not getattr(vm, "untrusted_qdb"):
             return
         untrusted_qubes_devices = vm.untrusted_qdb.list("/qubes-block-devices/")
         untrusted_idents = set(
@@ -415,7 +415,7 @@ class BlockDeviceExtension(qubes.ext.Extension):
     @qubes.ext.handler("device-get:block")
     def on_device_get_block(self, vm, event, port_id):
         # pylint: disable=unused-argument
-        if not vm.is_running():
+        if not getattr(vm, "untrusted_qdb"):
             return
         if not vm.app.vmm.offline_mode:
             device_info = self.device_get(vm, port_id)
@@ -425,7 +425,7 @@ class BlockDeviceExtension(qubes.ext.Extension):
     @qubes.ext.handler("device-list-attached:block")
     def on_device_list_attached(self, vm, event, **kwargs):
         # pylint: disable=unused-argument
-        if not vm.is_running():
+        if not getattr(vm, "untrusted_qdb"):
             return
 
         system_disks = SYSTEM_DISKS
@@ -481,7 +481,7 @@ class BlockDeviceExtension(qubes.ext.Extension):
         """
         Find unused block frontend device node for <target dev=.../> parameter
         """
-        assert vm.is_running()
+        assert getattr(vm, "untrusted_qdb")
 
         xml = vm.libvirt_domain.XMLDesc()
         parsed_xml = lxml.etree.fromstring(xml)
@@ -549,7 +549,7 @@ class BlockDeviceExtension(qubes.ext.Extension):
                 "This device can be attached only read-only"
             )
 
-        if not vm.is_running():
+        if not getattr(vm, "untrusted_qdb"):
             print(
                 f"Can not attach device, qube {vm.name} is not running.",
                 file=sys.stderr,
@@ -571,7 +571,7 @@ class BlockDeviceExtension(qubes.ext.Extension):
                 )
             )
 
-        if not device.backend_domain.is_running():
+        if not getattr(device.backend_domain, "untrusted_qdb"):
             raise qubes.exc.QubesVMNotRunningError(
                 device.backend_domain,
                 f"Domain {device.backend_domain.name} needs to be running "
@@ -688,7 +688,7 @@ class BlockDeviceExtension(qubes.ext.Extension):
     @qubes.ext.handler("device-pre-detach:block")
     def on_device_pre_detached_block(self, vm, event, port):
         # pylint: disable=unused-argument
-        if not vm.is_running():
+        if not getattr(vm, "untrusted_qdb"):
             return
 
         # need to enumerate attached devices to find frontend_dev option (at

--- a/qubes/ext/custom_persist.py
+++ b/qubes/ext/custom_persist.py
@@ -115,7 +115,7 @@ class CustomPersist(qubes.ext.Extension):
         self._check_key(self._extract_key_from_feature(feature))
         self._check_value(value)
 
-        if not vm.is_running():
+        if not getattr(vm, "untrusted_qdb"):
             return
 
         self._write_db_value(feature, value, vm)
@@ -124,7 +124,7 @@ class CustomPersist(qubes.ext.Extension):
     def on_domain_feature_delete(self, vm, event, feature):
         """Update /persist/ QubesDB tree in runtime"""
         # pylint: disable=unused-argument
-        if not vm.is_running():
+        if not getattr(vm, "untrusted_qdb"):
             return
         if not feature.startswith(FEATURE_PREFIX):
             return

--- a/qubes/ext/gui.py
+++ b/qubes/ext/gui.py
@@ -84,7 +84,7 @@ class GUI(qubes.ext.Extension):
 
     @qubes.ext.handler("property-reset:keyboard_layout")
     def on_keyboard_reset(self, vm, event, name, oldvalue=None):
-        if not vm.is_running():
+        if not getattr(vm, "untrusted_qdb"):
             return
         kbd_layout = vm.keyboard_layout
         vm.untrusted_qdb.write("/keyboard-layout", kbd_layout)
@@ -93,7 +93,7 @@ class GUI(qubes.ext.Extension):
     def on_keyboard_set(self, vm, event, name, newvalue, oldvalue=None):
         if newvalue == oldvalue:
             return
-        if vm.is_running():
+        if getattr(vm, "untrusted_qdb"):
             vm.untrusted_qdb.write("/keyboard-layout", newvalue)
         attached_vms = [
             domain
@@ -133,7 +133,7 @@ class GUI(qubes.ext.Extension):
         if guivm:
             if vm != vm.guivm:
                 vm.untrusted_qdb.write("/keyboard-layout", vm.keyboard_layout)
-                if vm.guivm.is_running():
+                if getattr(vm.guivm, "untrusted_qdb"):
                     vm.untrusted_qdb.write(
                         "/qubes-gui-domain-xid", str(vm.guivm.xid)
                     )
@@ -160,7 +160,7 @@ class GUI(qubes.ext.Extension):
     @qubes.ext.handler("domain-start")
     async def on_domain_start(self, vm, event, **kwargs):
         attached_vms = [
-            domain for domain in self.attached_vms(vm) if domain.is_running()
+            domain for domain in self.attached_vms(vm) if getattr(domain, "untrusted_qdb")
         ]
         for attached_vm in attached_vms:
             gui = bool(attached_vm.features.get("gui", True))

--- a/qubes/ext/r3compatibility.py
+++ b/qubes/ext/r3compatibility.py
@@ -74,7 +74,7 @@ class R3Compatibility(qubes.ext.Extension):
     @qubes.ext.handler("firewall-changed")
     def on_firewall_changed(self, vm, event):
         # pylint: disable=unused-argument
-        if vm.is_running() and vm.netvm:
+        if getattr(vm, "untrusted_qdb") and vm.netvm:
             self.write_iptables_qubesdb_entry(vm.netvm)
 
     def write_iptables_qubesdb_entry(self, firewallvm):

--- a/qubes/ext/services.py
+++ b/qubes/ext/services.py
@@ -156,7 +156,7 @@ class ServicesExtension(qubes.ext.Extension):
             # balancing state anymore
             del vm.features["service.meminfo-writer"]
 
-        if not vm.is_running():
+        if not getattr(vm, "untrusted_qdb"):
             return
         if not feature.startswith("service."):
             return
@@ -181,7 +181,7 @@ class ServicesExtension(qubes.ext.Extension):
     def on_domain_feature_delete(self, vm, event, feature):
         """Update /qubes-service/ QubesDB tree in runtime"""
         # pylint: disable=unused-argument
-        if not vm.is_running():
+        if not getattr(vm, "untrusted_qdb"):
             return
         if not feature.startswith("service."):
             return

--- a/qubes/ext/utils.py
+++ b/qubes/ext/utils.py
@@ -82,7 +82,7 @@ def device_list_change(
 
     to_attach: Dict[str, Dict] = {}
     for front_vm in vm.app.domains:
-        if not front_vm.is_running():
+        if not getattr(front_vm, "untrusted_qdb"):
             continue
         for assignment in reversed(
             sorted(front_vm.devices[devclass].get_assigned_devices())

--- a/qubes/ext/vm_config.py
+++ b/qubes/ext/vm_config.py
@@ -67,7 +67,7 @@ class VMConfig(qubes.ext.Extension):
                 "Config name must start with an ASCII letter"
             )
 
-        if not vm.is_running():
+        if not getattr(vm, "untrusted_qdb"):
             return
 
         vm.untrusted_qdb.write("/vm-config/" + config, str(value))
@@ -76,7 +76,7 @@ class VMConfig(qubes.ext.Extension):
     def on_domain_feature_delete(self, vm, event, feature):
         """Update /vm-config/ QubesDB tree in runtime"""
         # pylint: disable=unused-argument
-        if not vm.is_running():
+        if not getattr(vm, "untrusted_qdb"):
             return
         if not feature.startswith(PREFIX):
             return

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -1002,10 +1002,10 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.LocalVM):
 
     @qubes.stateless_property
     def stubdom_xid(self) -> int:
-        if not self.is_running():
+        if self.app.vmm.xs is None:
             return -1
 
-        if self.app.vmm.xs is None:
+        if not self.is_running():
             return -1
 
         stubdom_xid_str = self.app.vmm.xs.read(
@@ -1084,11 +1084,6 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.LocalVM):
     @property
     def untrusted_qdb(self):
         """QubesDB handle for this domain."""
-        if self._qdb_connection is None:
-            if self.is_running():
-                import qubesdb  # pylint: disable=import-error
-
-                self._qdb_connection = qubesdb.QubesDB(self.name)
         return self._qdb_connection
 
     @property


### PR DESCRIPTION
One access doesn't takes few nanoseconds, but when looping through domains multiple times, this blocking operation can impact the responsiveness of qubesd.

For: https://github.com/QubesOS/qubes-issues/issues/9902
For: https://github.com/QubesOS/qubes-issues/issues/10569
For: https://github.com/QubesOS/qubes-issues/issues/10648