### PR TITLE
Remove StandardOutput setting from systemd units

### DIFF
--- a/linux/systemd/qubes-core.service
+++ b/linux/systemd/qubes-core.service
@@ -5,7 +5,6 @@ After=qubes-db-dom0.service libvirtd.service virtxend.socket xenconsoled.service
 
 [Service]
 Type=oneshot
-StandardOutput=syslog
 RemainAfterExit=yes
 # Needed to avoid rebooting before all VMs have shut down.
 TimeoutStopSec=180

--- a/linux/systemd/qubes-qmemman.service
+++ b/linux/systemd/qubes-qmemman.service
@@ -4,7 +4,6 @@ Description=Qubes memory management daemon
 [Service]
 Type=notify
 ExecStart=/usr/bin/qmemmand
-StandardOutput=syslog
 
 [Install]
 WantedBy=multi-user.target

--- a/linux/systemd/qubesd.service
+++ b/linux/systemd/qubesd.service
@@ -7,7 +7,6 @@ Before=systemd-user-sessions.service
 [Service]
 Type=notify
 ExecStart=/usr/bin/qubesd
-StandardOutput=syslog
 KillMode=process
 Restart=on-failure
 RestartSec=1s


### PR DESCRIPTION
When validating the units, I see this message:

        Standard output type syslog is obsolete, automatically updating
        to journal. Please update your unit file, and consider removing
        the setting altogether

---

Didn't test. Just doing as the message says.