### PR TITLE
Clean up distinguished but equivalent path in `vmid_to_ipv4`

### DIFF
--- a/qubes/vm/mix/net.py
+++ b/qubes/vm/mix/net.py
@@ -108,13 +108,10 @@ class StrSerializableTuple(tuple):
 
 
 def vmid_to_ipv4(prefix, vmid):
+    if vmid not in range(1, 256 * 254 + 1):
+        raise ValueError("vmid out of range")
     # avoid .0 and .255 addresses, it may trip some heuristics
     # if OS assumes /24 netmask
-    # preserve unchanged IPs for low vmid
-    if vmid < 255:
-        return ipaddress.IPv4Address(
-            "{}.{}.{}".format(prefix, (vmid >> 8) & 0xFF, vmid & 0xFF)
-        )
     # don't reserve first .1 for vmid 0, as it is invalid
     vmid -= 1
     return ipaddress.IPv4Address(


### PR DESCRIPTION
For all `vmid`s from 1 to 254, `(vmid >> 8, vmid & 0xff) == ((vmid - 1) // 254, (vmid - 1) % 254 + 1) == (0, vmid)`.

(Happened to come across this while working on something else and figured I’d put the patch up.)