### PR TITLE
api/internal: invalidate SystemInfoCache on domain-add and domain-delete

### DIFF
--- a/qubes/api/internal.py
+++ b/qubes/api/internal.py
@@ -76,11 +76,13 @@ class SystemInfoCache:
     def on_domain_add(cls, subject, event, vm):
         # pylint: disable=unused-argument
         cls.register_events_vm(vm)
+        cls.cache = None
 
     @classmethod
     def on_domain_delete(cls, subject, event, vm):
         # pylint: disable=unused-argument
         cls.unregister_events_vm(vm)
+        cls.cache = None
 
     @classmethod
     def register_events_vm(cls, vm):


### PR DESCRIPTION
`SystemInfoCache` invalidates `cls.cache` for every event in `vm_events`
(via `event_handler`), but `on_domain_add` and `on_domain_delete` only
register / unregister the per-VM handlers - they never invalidate the cache
itself, and `vm_events` contains neither `domain-add` nor `domain-delete`.

As a result a freshly-created (or freshly-deleted) VM is missing from / stale
in the cached `system_info` until some other event happens to invalidate it.
While stale, qubes-qrexec-policy-daemon's `internal.GetSystemInfo` query
returns the old snapshot: a call naming a new VM logs
`target '...' does not exist, using @default instead`, and a deleted VM can
still be offered by a `@default` `ask` handler (e.g. qvm-copy).

Fix: invalidate the cache in both handlers, after (un)registering the per-VM
handlers. `domain-add` / `domain-delete` are app-level events; this is the
symmetric counterpart to how every `vm_events` entry already invalidates via
`event_handler`. Performance impact is negligible - these events are
infrequent relative to the per-VM events that already clear the cache.

Fixes QubesOS/qubes-issues#10911.
