### PR TITLE
Inform clients about suspend

### DIFF
--- a/qubes/app.py
+++ b/qubes/app.py
@@ -1687,6 +1687,15 @@ class Qubes(qubes.PropertyHolder):
 
         if event == libvirt.VIR_DOMAIN_EVENT_STOPPED:
             vm.on_libvirt_domain_stopped()
+        elif event == libvirt.VIR_DOMAIN_EVENT_PMSUSPENDED:
+            try:
+                vm.fire_event("domain-suspended")
+            except Exception:  # pylint: disable=broad-except
+                self.log.exception(
+                    "Uncaught exception from domain-suspended handler "
+                    "for domain %s",
+                    vm.name,
+                )
         elif event == libvirt.VIR_DOMAIN_EVENT_SUSPENDED:
             try:
                 vm.fire_event("domain-paused")

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -447,6 +447,15 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.LocalVM):
             :param subject: Event emitter (the qube object)
             :param event: Event name (``'domain-unpaused'``)
 
+        .. event:: domain-suspended (subject, event)
+
+            Fired when the domain has been suspended.
+
+            Handler for this event may be asynchronous.
+
+            :param subject: Event emitter (the qube object)
+            :param event: Event name (``'domain-suspended'``)
+
         .. event:: domain-resumed (subject, event)
 
             Fired when the domain has been resumed from suspend.


### PR DESCRIPTION
Since there is "resume", and there is a moment when resuming that domain might still be suspended, or event suspending a domain on purposed, allow clients to know the domain state.

For: https://github.com/QubesOS/qubes-core-admin-client/pull/333