### PR TITLE
Fix bug in qubesvm.py incorrectly treating "False" config values as True

### DIFF
--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -1134,6 +1134,8 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.LocalVM):
                         # pylint: disable=no-member
                         if value == "True":
                             value = True
+                        elif value == "False":
+                            value = False
                         try:
                             self.volume_config[name][key] = value
                         except KeyError:


### PR DESCRIPTION
The code in [qubesvm.py](qubes/vm/qubesvm.py) on lines ~1128-1150 incorrectly treats configuration values which are set to "False" in the XML. The "True" case is explicitly handled correctly,
```python
if value == "True"
    value = True
```
but the "False" case falls through to
```python
self.volume_config[name][key] = value
```
and since `bool("False") == True`, this will result in incorrect behavior. I discovered this when analyzing suspiciously no-op behavior of `rw="False"` in the qubes.xml configuration. The fix is simple, but it might have unintended side effects if someone relies on the buggy behavior. It is, of course, up to your discretion whether this is a problem.

Specifically, the behavioral changes are:
| Volume | snap_on_start | save_on_stop | rw | Before | After | Confirmed? |
|---|---|---|---|---|---|---|
| root (AppVM/DispVM) | True | False | False | Uses dm-snapshot root-cow.img | Uses /dev/xvdc volatile.img via qubes_cow_setup.sh. root-cow.img is still created but is rudimentary. | Yes, tested on sys-firewall and sys-net.[^1] |
| private (DispVM) | True | False | False | Accumulates writes into private-cow.img, discards on stop | Crashes or experiences degraded functionality since qubes_cow_setup.sh does not handle readonly /rw.[^2] private-cow.img becomes rudimentary. | Yes, tested on sys-firewall. It starts, but I cannot even open the terminal. No functionality. |
| private (AppVM) | False | True | False | Accumulates writes into private-cow.img, saves on stop | Crashes or experiences degraded functionality since qubes_cow_setup.sh does not handle readonly /rw. private-cow.img becomes rudimentary. | Yes, tested on sys-net. Same results as above. |
| volatile | False | False | False | Written directly | Crashes, since it would attempt to set up swap on a readonly partition. | Confirmed with both sys-net and sys-firewall: `Cannot connect to qrexec agent for 60 seconds, see /var/log/xen/console/guest-sys-firewall.log for details.`[^3] |

With all of this in mind, this seems to be a much bigger change than anticipated. However, as far as I understand `rw="False"` is NOT used anywhere in Qubes by default. Therefore, even if this change is merged we would not be altering any default setups, and given that nobody has fixed this yet I don't think many people are using the `rw` functionality in general. If you think this is worth a proper discussion, I'm ready to continue in `qubes-devel`.

[^1]: Causes a `FileNotFoundError: [Errno 2] No such file or directory: '/var/lib/qubes/vm-templates/TEMPLATE_NAME/root-cow.img'` upon attempting to kill the qube IF after starting it, qubesd is restarted. Full sequence to reproduce: `qvm-start sys-firewall && sudo systemctl restart qubesd && qvm-kill sys-firewall`. Not unique to sys-firewall, similar issue occurs with sys-net.

[^2]: I propose that this could be resolved by extending qubes_cow_setup.sh to handle /dev/xvdb (private /rw).

[^3]: I propose that this could be resolved by falling back to a RAM device backed by domU memory.
