### PR TITLE
Disable notification for denied property.GetAll call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,6 +195,8 @@ endif
 	mkdir -p $(DESTDIR)/usr/libexec/qubes
 	install -m 0644 qubes-rpc-policy/90-default.policy \
 		$(DESTDIR)/etc/qubes/policy.d/90-default.policy
+	install -m 0644 qubes-rpc-policy/91-admin-default-deny.policy \
+		$(DESTDIR)/etc/qubes/policy.d/91-admin-default-deny.policy
 	install -m 0644 qubes-rpc-policy/85-admin-backup-restore.policy \
 		$(DESTDIR)/etc/qubes/policy.d/85-admin-backup-restore.policy
 	cp qubes-rpc/qubes.FeaturesRequest $(DESTDIR)/etc/qubes-rpc/

--- a/qubes-rpc-policy/91-admin-default-deny.policy
+++ b/qubes-rpc-policy/91-admin-default-deny.policy
@@ -1,0 +1,12 @@
+## Do not modify this file, create a new policy file with a lower number in the
+## filename instead. For example `30-user.policy`.
+
+## Default action is deny anyway, but add notify=no, as GetAll is expected to
+## be called if some properties are allowed but not all, so mute the spurious
+## notification
+
+admin.vm.property.GetAll * @anyvm @anyvm   deny notify=no
+admin.vm.property.GetAll * @anyvm @adminvm deny notify=no
+
+admin.property.GetAll    * @anyvm @anyvm   deny notify=no
+admin.property.GetAll    * @anyvm @adminvm deny notify=no

--- a/rpm_spec/core-dom0.spec.in
+++ b/rpm_spec/core-dom0.spec.in
@@ -597,6 +597,7 @@ done
 %attr(0664,root,qubes) %config /etc/qubes/policy.d/85-admin-backup-restore.policy
 %attr(0664,root,qubes) %config /etc/qubes/policy.d/90-admin-default.policy
 %attr(0664,root,qubes) %config /etc/qubes/policy.d/90-default.policy
+%attr(0664,root,qubes) %config /etc/qubes/policy.d/91-admin-default-deny.policy
 %attr(0664,root,qubes) %config(noreplace) /etc/qubes/policy.d/include/admin-global-ro
 %attr(0664,root,qubes) %config(noreplace) /etc/qubes/policy.d/include/admin-global-rwx
 %attr(0664,root,qubes) %config(noreplace) /etc/qubes/policy.d/include/admin-local-ro


### PR DESCRIPTION
It's expected to be denied when some properties are allowed but not all.

QubesOS/qubes-issues#10534
