### PR TITLE
Fix devices and other behavior for remotevms

### DIFF
--- a/qubes/api/admin.py
+++ b/qubes/api/admin.py
@@ -1818,7 +1818,10 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
     async def vm_device_available(self, endpoint):
         devclass = endpoint
         try:
-            devices = self.dest.devices[devclass].get_exposed_devices()
+            if self.dest.klass == "RemoteVM":
+                devices = []
+            else:
+                devices = self.dest.devices[devclass].get_exposed_devices()
         except AttributeError as e:
             if e.name == "devices":
                 # shutdown in progress, return specific error
@@ -1854,9 +1857,12 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
     async def vm_device_list(self, endpoint):
         devclass = endpoint
         try:
-            device_assignments = list(
-                self.dest.devices[devclass].get_assigned_devices()
-            )
+            if self.dest.klass == "RemoteVM":
+                device_assignments = []
+            else:
+                device_assignments = list(
+                    self.dest.devices[devclass].get_assigned_devices()
+                )
         except AttributeError as e:
             if e.name == "devices":
                 # shutdown in progress, return specific error

--- a/qubes/ext/utils.py
+++ b/qubes/ext/utils.py
@@ -82,6 +82,8 @@ def device_list_change(
 
     to_attach: Dict[str, Dict] = {}
     for front_vm in vm.app.domains:
+        if front_vm.klass == "RemoteVM":
+            continue
         if not front_vm.is_running():
             continue
         for assignment in reversed(

--- a/qubes/features.py
+++ b/qubes/features.py
@@ -161,7 +161,7 @@ class Features(dict):
             raise NotImplementedError("app does not have features yet")
 
         assert isinstance(
-            self.subject, _vm.LocalVM
+            self.subject, _vm.BaseVM
         ), "recursive checks do not work for {}".format(
             type(self.subject).__name__
         )

--- a/qubes/vm/remotevm.py
+++ b/qubes/vm/remotevm.py
@@ -24,6 +24,12 @@ from qubes.vm import BaseVM
 
 
 class RemoteVM(BaseVM):
+    include_in_backups = qubes.property(
+        "include_in_backups",
+        type=bool,
+        default=False,
+        doc="If this domain is to be included in default backup.",
+    )
 
     relayvm = qubes.VMProperty(
         "relayvm",


### PR DESCRIPTION
- make remotevms not 'include in backups' by default
- make devices not crap out on remotevms