### PR TITLE
Fix bug in storage/__init__.py dropping "False" config values

### DIFF
--- a/qubes/storage/__init__.py
+++ b/qubes/storage/__init__.py
@@ -1115,6 +1115,8 @@ def _sanitize_config(config):
         if isinstance(value, bool):
             if value:
                 result[key] = "True"
+            else:
+                result[key] = "False"
         else:
             result[key] = str(value)
     return result


### PR DESCRIPTION
The _sanitize_config function drops "False" values from the config, resulting in properties such as rw="False" disappearing. As a consequence, the default value of "True" gets reassigned to them. Similar to #829, but does not have any practical consequences I can think of beyond having the correct/expected behavior for the "False" values.

To reproduce:
```sh
[user@dom0 ~]$ sudo systemctl stop qubesd
[user@dom0 ~]$ sudo nano /var/lib/qubes/qubes.xml # Set rw="False" for any domU volume
[user@dom0 ~]$ sudo systemctl start qubesd 
[user@dom0 ~]$ # At this stage, rw="False" is still present
[user@dom0 ~]$ # Now, make any edit to the domU - the simplest example is to change the vCPU count, and then apply it
[user@dom0 ~]$ # Then, rw="False" will fully disappear in qubes.xml
[user@dom0 ~]$ sudo systemctl restart qubesd 
[user@dom0 ~]$ # Now, make another edit to the domU to trigger a fresh save
[user@dom0 ~]$ # Now rw="True" appears in qubes.xml
```

Pinging @marmarek for review.