### PR TITLE
Fix loading ephemeral_volatile pool property from qubes.xml

### DIFF
--- a/qubes/storage/__init__.py
+++ b/qubes/storage/__init__.py
@@ -1005,7 +1005,7 @@ class Pool:
         self._volumes_collection = VolumesCollection(self)
         self.name = name
         self.revisions_to_keep = revisions_to_keep
-        self.ephemeral_volatile = ephemeral_volatile
+        self.ephemeral_volatile = qubes.utils.parse_bool(ephemeral_volatile)
 
     def __eq__(self, other):
         if isinstance(other, Pool):

--- a/qubes/tests/app.py
+++ b/qubes/tests/app.py
@@ -840,6 +840,27 @@ class TC_89_QubesEmpty(qubes.tests.QubesTestCase):
             app.close()
             del app
 
+    def test_200_load_pools(self):
+        qubes_xml = """<?xml version="1.0" encoding="utf-8" ?>
+        <qubes version="3.0">
+            <labels>
+                <label id="label-1" color="{old_gray}">gray</label>
+            </labels>
+            <pools>
+              <pool driver="file" dir_path="/tmp/qubes-test" name="default" ephemeral_volatile="False"/>
+            </pools>
+            <domains>
+            </domains>
+        </qubes>
+        """
+        with open("/tmp/qubestest.xml", "w", encoding="ascii") as xml_file:
+            xml_file.write(qubes_xml)
+        app = qubes.Qubes("/tmp/qubestest.xml", offline_mode=True)
+        self.assertEqual(app.pools["default"].ephemeral_volatile, False)
+        self.assertEqual(app.pools["default"].dir_path, "/tmp/qubes-test")
+        app.close()
+        del app
+
 
 class TC_90_Qubes(qubes.tests.QubesTestCase):
     def setUp(self):

--- a/qubes/utils.py
+++ b/qubes/utils.py
@@ -159,6 +159,17 @@ def size_to_human(size):
     return str(round(size / (1024.0 * 1024 * 1024), 1)) + " GiB"
 
 
+def parse_bool(value):
+    """Deserialize bool property, handling usual encodings"""
+    if isinstance(value, bool):
+        return value
+    if value in ("True", "1", "on"):
+        return True
+    if value in ("False", "0", "off", ""):
+        return False
+    raise ValueError(f"invalid bool: {value}")
+
+
 def urandom(size):
     rand = os.urandom(size)
     if rand is None:


### PR DESCRIPTION

  Similarly to ce22ff42 "Fix bug in qubesvm.py incorrectly treating
  "False" config values as True", properly saving False values caused also
  interpreting loaded "False" string as True bool. Fix this by adding a
  helper function for deserializing bool properties.
  
  For now, it's used only for ephemeral_volatile, as it's the only bool
  property of a pool. Volumes and VMs already have their own handling of
  bool properties.
  

tests: check if pool properties are correctly loaded from the xml
  