### PR TITLE
Explicit key size to silence cryptsetup warning

### DIFF
--- a/qubes/storage/__init__.py
+++ b/qubes/storage/__init__.py
@@ -238,6 +238,7 @@ class Volume:
         await qubes.utils.cryptsetup(
             "--key-file=/dev/urandom",
             "--cipher=aes-xts-plain64",
+            "--key-size=256",
             "--type=plain",
             "--",
             "open",


### PR DESCRIPTION
We trust cryptsetup to provide sane defaults, but being implicit logs the following warning for every ephemeral volume on qube startup:

        WARNING: Using default options for cipher (aes-xts-plain64, key
        size 256 bits) that could be incompatible with older versions.
        For plain mode, always use options --cipher, --key-size and if
        no keyfile or keyring is used, then also --hash.

This is the reason why "--cipher" and "--key-size" are specified. A better solution would be to silence the warning and be implicit, as we don't care about the key for this volume, we'd always get the new cryptsetup default, but I didn't find a way to silence this warning.

Fixes: https://github.com/qubesos/qubes-issues/issues/10989