### PR TITLE
Memoize API methods

### DIFF
--- a/qubes/api/__init__.py
+++ b/qubes/api/__init__.py
@@ -231,7 +231,9 @@ class AbstractQubesAPI:
         self.EXC_ARG_NOT_IN_DEST_VOLUMES = "{} volumes".format(self.dest.name)
 
     @classmethod
+    @functools.cache
     def list_methods(cls, select_method=None):
+        result = []
         for attr in dir(cls):
             func = getattr(cls, attr)
             if not callable(func):
@@ -245,7 +247,8 @@ class AbstractQubesAPI:
 
             for mname, endpoint in rpcnames:
                 if select_method is None or mname == select_method:
-                    yield (func, mname, endpoint)
+                    result.append((func, mname, endpoint))
+        return result
 
     def execute(self, *, untrusted_payload):
         """Execute management operation.

--- a/qubes/api/__init__.py
+++ b/qubes/api/__init__.py
@@ -232,8 +232,8 @@ class AbstractQubesAPI:
 
     @classmethod
     @functools.cache
-    def list_all_methods(cls) -> list[tuple]:
-        result = []
+    def list_all_methods(cls) -> dict[str, list[tuple]]:
+        result: dict[str, list[tuple]] = {}
         for attr in dir(cls):
             func = getattr(cls, attr)
             if not callable(func):
@@ -244,16 +244,24 @@ class AbstractQubesAPI:
             except AttributeError:
                 continue
             for mname, endpoint in rpcnames:
-                result.append((func, mname, endpoint))
+                result.setdefault(mname, []).append((func, endpoint))
         return result
 
     @classmethod
     @functools.cache
     def list_methods(cls, select_method=None) -> list[tuple]:
+        all_methods = cls.list_all_methods()
+        if select_method is None:
+            return [
+                (func, mname, endpoint)
+                for mname, value in all_methods.items()
+                for func, endpoint in value
+            ]
+        if select_method not in all_methods:
+            return []
         return [
-            (func, mname, endpoint)
-            for func, mname, endpoint in cls.list_all_methods()
-            if select_method is None or mname == select_method
+            (func, select_method, endpoint)
+            for func, endpoint in all_methods[select_method]
         ]
 
     def execute(self, *, untrusted_payload):

--- a/qubes/api/__init__.py
+++ b/qubes/api/__init__.py
@@ -232,23 +232,29 @@ class AbstractQubesAPI:
 
     @classmethod
     @functools.cache
-    def list_methods(cls, select_method=None):
+    def list_all_methods(cls) -> list[tuple]:
         result = []
         for attr in dir(cls):
             func = getattr(cls, attr)
             if not callable(func):
                 continue
-
             try:
                 # pylint: disable=protected-access
                 rpcnames = func.rpcnames
             except AttributeError:
                 continue
-
             for mname, endpoint in rpcnames:
-                if select_method is None or mname == select_method:
-                    result.append((func, mname, endpoint))
+                result.append((func, mname, endpoint))
         return result
+
+    @classmethod
+    @functools.cache
+    def list_methods(cls, select_method=None) -> list[tuple]:
+        return [
+            (func, mname, endpoint)
+            for func, mname, endpoint in cls.list_all_methods()
+            if select_method is None or mname == select_method
+        ]
 
     def execute(self, *, untrusted_payload):
         """Execute management operation.


### PR DESCRIPTION
Prior to this change, executing qubes-prefs requests two API methods, and took this much time to "list_methods" (format: CALL -> SECS):

0 -> 0.000520
0 -> 0.000404
1 -> 0.000237
1 -> 0.000183
2 -> 0.000468
2 -> 0.000199
3 -> 0.000277
3 -> 0.000207

With this change:

0 -> 0.000194
0 -> 0.000133
1 -> 0.000007
1 -> 0.000006
2 -> 0.000004
2 -> 0.000003
3 -> 0.000007
3 -> 0.000004

Suggested-by: Demi Marie Obenour <demiobenour@gmail.com>
For: https://github.com/QubesOS/qubes-issues/issues/10775