### PR TITLE
Skip RemoteVM when suspending the system

### DIFF
--- a/qubes/api/internal.py
+++ b/qubes/api/internal.py
@@ -310,6 +310,8 @@ class QubesInternalAPI(qubes.api.AbstractQubesAPI):
         for vm in self.app.domains:
             if isinstance(vm, qubes.vm.adminvm.AdminVM):
                 continue
+            if not isinstance(vm, qubes.vm.LocalVM):
+                continue
             if not vm.is_running():
                 continue
             if vm.name in previously_paused:
@@ -351,6 +353,8 @@ class QubesInternalAPI(qubes.api.AbstractQubesAPI):
         # then suspend/pause VMs
         for vm in self.app.domains:
             if isinstance(vm, qubes.vm.adminvm.AdminVM):
+                continue
+            if not isinstance(vm, qubes.vm.LocalVM):
                 continue
             if vm.name in previously_paused:
                 continue
@@ -395,6 +399,8 @@ class QubesInternalAPI(qubes.api.AbstractQubesAPI):
         for vm in self.app.domains:
             if isinstance(vm, qubes.vm.adminvm.AdminVM):
                 continue
+            if not isinstance(vm, qubes.vm.LocalVM):
+                continue
             if vm.name in previously_paused:
                 continue
             if vm.get_power_state() in ["Paused", "Suspended"]:
@@ -406,6 +412,8 @@ class QubesInternalAPI(qubes.api.AbstractQubesAPI):
         processes = []
         for vm in self.app.domains:
             if isinstance(vm, qubes.vm.adminvm.AdminVM):
+                continue
+            if not isinstance(vm, qubes.vm.LocalVM):
                 continue
             if not vm.is_running():
                 continue

--- a/qubes/tests/api_internal.py
+++ b/qubes/tests/api_internal.py
@@ -64,15 +64,19 @@ class TC_00_API_Misc(qubes.tests.QubesTestCase):
     def create_mockvm(self, features=None):
         if features is None:
             features = {}
-        vm = mock.Mock()
+        vm = mock.Mock(spec=qubes.vm.LocalVM)
+        vm.configure_mock(
+            features=mock.Mock(),
+            run_service=mock.AsyncMock(),
+            suspend=mock.AsyncMock(),
+            resume=mock.AsyncMock(),
+            is_running=mock.Mock(),
+            get_power_state=mock.Mock(),
+            remove_preload_excess=mock.Mock(),
+        )
         vm.features.check_with_template.side_effect = features.get
         vm.features.get.side_effect = features.get
-        vm.run_service.return_value.wait = mock_coro(
-            vm.run_service.return_value.wait
-        )
-        vm.run_service = mock_coro(vm.run_service)
-        vm.suspend = mock_coro(vm.suspend)
-        vm.resume = mock_coro(vm.resume)
+        vm.run_service.return_value.wait = mock.AsyncMock()
         return vm
 
     def call_mgmt_func(self, method, arg=b"", payload=b""):


### PR DESCRIPTION
Perform suspend-related actions only on LocalVMs.

Fixes QubesOS/qubes-issues#11001
