### PR TITLE
Cache devices xml

### DIFF
--- a/qubes/ext/block.py
+++ b/qubes/ext/block.py
@@ -236,10 +236,8 @@ class BlockDevice(qubes.device_protocol.DeviceInfo):
             if not info:
                 continue
             backend_domain, port_id = info
-
             if backend_domain.name != self.backend_domain.name:
                 continue
-
             if self.port_id == port_id:
                 return True
         return False
@@ -315,6 +313,12 @@ def _try_get_block_device_info(app, disk):
 
 class BlockDeviceExtension(qubes.ext.Extension):
 
+    def __init__(self):
+        super().__init__()
+        # TODO: ben: https://github.com/QubesOS/qubes-core-admin/pull/819#discussion_r3537683559
+        self._attachments = {}
+        self._attachments_with_options = {}
+
     @qubes.ext.handler("domain-init", "domain-load")
     def on_domain_init_load(self, vm, event):
         """Initialize watching for changes"""
@@ -335,6 +339,24 @@ class BlockDeviceExtension(qubes.ext.Extension):
         else:
             self.devices_cache[vm.name] = {}
 
+    @qubes.ext.handler("device-attach:block")
+    def on_device_block_attach(self, vm, event, device, options):
+        # pylint: disable=unused-argument
+        self._attachments[device.port_id] = device.backend_domain
+
+    @qubes.ext.handler("device-detach:block")
+    def on_device_block_detach(self, vm, event, port):
+        # pylint: disable=unused-argument
+        if port in self._attachments:
+            self._attachments.pop(port)
+        if vm not in self._attachments_with_options:
+            return
+        if port not in self._attachments_with_options[vm]:
+            return
+        for device, _options in self._attachments_with_options[vm].items():
+            if device.port_id == port:
+                self._attachments_with_options[vm].pop(device)
+
     @qubes.ext.handler("domain-qdb-change:/qubes-block-devices")
     def on_qdb_change(self, vm, event, path):
         """A change in QubesDB means a change in a device list."""
@@ -346,8 +368,7 @@ class BlockDeviceExtension(qubes.ext.Extension):
         )
         utils.device_list_change(self, current_devices, vm, path, BlockDevice)
 
-    @staticmethod
-    def get_device_attachments(vm_):
+    def get_device_attachments(self, vm_):
         result = {}
         for vm in vm_.app.domains:
             if not vm.is_running() or isinstance(vm, RemoteVM):
@@ -355,6 +376,10 @@ class BlockDeviceExtension(qubes.ext.Extension):
 
             if vm.app.vmm.offline_mode:
                 return result
+
+            if vm in self._attachments:
+                result = self._attachments[vm]
+                continue
 
             xml_desc = lxml.etree.fromstring(vm.libvirt_domain.XMLDesc())
 
@@ -367,6 +392,7 @@ class BlockDeviceExtension(qubes.ext.Extension):
                     continue
 
                 result[port_id] = vm
+            self._attachments[vm] = result
         return result
 
     @staticmethod
@@ -430,6 +456,11 @@ class BlockDeviceExtension(qubes.ext.Extension):
         if not vm.is_running():
             return
 
+        if vm in self._attachments_with_options:
+            yield from self._attachments_with_options[vm]
+            return
+        self._attachments_with_options[vm] = []
+
         system_disks = SYSTEM_DISKS
         if getattr(vm, "kernel", None):
             system_disks = SYSTEM_DISKS_DOM0_KERNEL
@@ -476,7 +507,9 @@ class BlockDeviceExtension(qubes.ext.Extension):
 
             port_id = port_id.replace("/", "_")
 
-            yield BlockDevice(Port(backend_domain, port_id, "block")), options
+            dev = BlockDevice(Port(backend_domain, port_id, "block")), options
+            yield dev
+            self._attachments_with_options[vm].append(dev)
 
     @staticmethod
     def _is_block(vm, block: str) -> bool:

--- a/qubes/ext/block.py
+++ b/qubes/ext/block.py
@@ -25,6 +25,7 @@ import asyncio
 import re
 import string
 import sys
+import libvirt
 from typing import Optional, List
 
 import lxml.etree
@@ -478,24 +479,31 @@ class BlockDeviceExtension(qubes.ext.Extension):
             yield BlockDevice(Port(backend_domain, port_id, "block")), options
 
     @staticmethod
-    def find_unused_frontend(vm, devtype="disk"):
+    def _is_block(vm, block: str) -> bool:
+        try:
+            # TODO: ben: Marek mention that when backend is not dom0, this
+            # won't work.
+            # blockInfo() is not supported by libxl.
+            value = bool(vm.libvirt_domain.blockStats(block))
+        except libvirt.libvirtError as e:
+            if e.get_error_code() == libvirt.VIR_ERR_OPERATION_INVALID:
+                value = False
+            else:
+                raise
+        return value
+
+    def find_unused_frontend(self, vm, devtype="disk"):
         """
         Find unused block frontend device node for <target dev=.../> parameter
         """
         assert vm.is_running()
 
-        xml = vm.libvirt_domain.XMLDesc()
-        parsed_xml = lxml.etree.fromstring(xml)
-        used = [
-            target.get("dev", None)
-            for target in parsed_xml.xpath("//domain/devices/disk/target")
-        ]
-        if devtype == "cdrom" and "xvdd" not in used:
+        if devtype == "cdrom" and self._is_block(vm, "xvdd"):
             # prefer 'xvdd' for CDROM if available; only first 4 disks are
             # emulated in HVM, which means only those are bootable
             return "xvdd"
         for dev in Storage.AVAILABLE_FRONTENDS:
-            if dev not in used:
+            if not self._is_block(vm, dev):
                 return dev
         return None
 

--- a/qubes/ext/pci.py
+++ b/qubes/ext/pci.py
@@ -159,6 +159,9 @@ class PCIDevice(qubes.device_protocol.DeviceInfo):
                 port_id=port_id,
                 devclass="pci",
             )
+        self._hostdev_details = None
+        self._hostdev_details_xmldesc = None
+        self._all_attached = None
 
         super().__init__(port)
 
@@ -218,6 +221,21 @@ class PCIDevice(qubes.device_protocol.DeviceInfo):
             result = self._product
         return result
 
+    def hostdev_details_xmldesc(self) -> str:
+        if self._hostdev_details is None:
+            assert self.backend_domain
+            assert self.libvirt_name
+            self._hostdev_details = (
+                self.backend_domain.app.vmm.libvirt_conn.nodeDeviceLookupByName(
+                    self.libvirt_name
+                )
+            )
+        assert self._hostdev_details
+        if self._hostdev_details_xmldesc is None:
+            self._hostdev_details_xmldesc = self._hostdev_details.XMLDesc()
+        assert self._hostdev_details_xmldesc
+        return self._hostdev_details_xmldesc
+
     @property
     def interfaces(self) -> List[qubes.device_protocol.DeviceInterface]:
         """
@@ -233,13 +251,8 @@ class PCIDevice(qubes.device_protocol.DeviceInfo):
                         "******", devclass="pci"
                     )
                 ]
-            hostdev_details = (
-                self.backend_domain.app.vmm.libvirt_conn.nodeDeviceLookupByName(
-                    self.libvirt_name
-                )
-            )
             interface_encoding = pcidev_interface(
-                lxml.etree.fromstring(hostdev_details.XMLDesc())
+                lxml.etree.fromstring(self.hostdev_details_xmldesc())
             )
             self._interfaces = [
                 qubes.device_protocol.DeviceInterface(
@@ -266,14 +279,10 @@ class PCIDevice(qubes.device_protocol.DeviceInfo):
     @property
     def description(self):
         if self._description is None:
-            hostdev_details = (
-                self.backend_domain.app.vmm.libvirt_conn.nodeDeviceLookupByName(
-                    self.libvirt_name
-                )
-            )
             self._description = _device_desc(
-                lxml.etree.fromstring(hostdev_details.XMLDesc())
+                lxml.etree.fromstring(self.hostdev_details_xmldesc())
             )
+
         return self._description
 
     @property  # type: ignore[misc]
@@ -315,14 +324,9 @@ class PCIDevice(qubes.device_protocol.DeviceInfo):
         ):
             # don't cache these values
             return result
-        hostdev_details = (
-            self.backend_domain.app.vmm.libvirt_conn.nodeDeviceLookupByName(
-                self.libvirt_name
-            )
-        )
 
         # Data successfully loaded, cache these values
-        hostdev_xml = lxml.etree.fromstring(hostdev_details.XMLDesc())
+        hostdev_xml = lxml.etree.fromstring(self.hostdev_details_xmldesc())
 
         self._vendor = result["vendor"] = (
             hostdev_xml.findtext("capability/vendor") or unknown
@@ -341,9 +345,11 @@ class PCIDevice(qubes.device_protocol.DeviceInfo):
 
     @property
     def frontend_domain(self):
-        # TODO: cache this
-        all_attached = attached_devices(self.backend_domain.app)
-        return all_attached.get(self.port_id, None)
+        if self._all_attached is None:
+            # TODO: reload cache on hotplug with
+            # VIR_DOMAIN_EVENT_ID_DEVICE_(ADDED|REMOVED)?
+            self._all_attached = attached_devices(self.backend_domain.app)
+        return self._all_attached.get(self.port_id, None)
 
 
 class PCIDeviceExtension(qubes.ext.Extension):

--- a/qubes/ext/pci.py
+++ b/qubes/ext/pci.py
@@ -357,12 +357,19 @@ class PCIDeviceExtension(qubes.ext.Extension):
         super().__init__()
         # lazy load this
         self.pci_classes = {}
+        # TODO: ben: https://github.com/QubesOS/qubes-core-admin/pull/819#discussion_r3537672500
+        self._all_devices = []
+        self._attached = {}
 
     @qubes.ext.handler("device-list:pci")
     def on_device_list_pci(self, vm, event):
         # pylint: disable=unused-argument
         # only dom0 expose PCI devices
         if vm.qid != 0:
+            return
+
+        if self._all_devices:
+            yield from self._all_devices
             return
 
         for dev in vm.app.vmm.libvirt_conn.listAllDevices():
@@ -372,10 +379,12 @@ class PCIDeviceExtension(qubes.ext.Extension):
             xml_desc = lxml.etree.fromstring(dev.XMLDesc())
             libvirt_name = xml_desc.findtext("name")
             try:
-                yield PCIDevice(
+                dev = PCIDevice(
                     Port(backend_domain=vm, port_id=None, devclass="pci"),
                     libvirt_name=libvirt_name,
                 )
+                yield dev
+                self._all_devices.append(dev)
             except UnsupportedDevice:
                 if libvirt_name not in unsupported_devices_warned:
                     vm.log.warning("Unsupported device: %s", libvirt_name)
@@ -387,11 +396,33 @@ class PCIDeviceExtension(qubes.ext.Extension):
         if not vm.app.vmm.offline_mode:
             yield _cache_get(vm, port_id)
 
+    @qubes.ext.handler("device-attach:pci")
+    def on_device_attach(self, vm, event, device, options):
+        # pylint: disable=unused-argument
+        self._attached.setdefault(vm, {}).append(device)
+
+    @qubes.ext.handler("device-detach:pci")
+    def on_device_detach(self, vm, event, port):
+        # pylint: disable=unused-argument
+        for dev in self._attached[vm]:
+            if dev.port_id == port:
+                self._attached[vm].remove(dev)
+
     @qubes.ext.handler("device-list-attached:pci")
     def on_device_list_attached(self, vm, event, **kwargs):
         # pylint: disable=unused-argument
-        if not vm.is_running() or isinstance(vm, qubes.vm.adminvm.AdminVM):
+        if (
+            vm.virt_mode == "pvh"
+            or not vm.is_running()
+            or isinstance(vm, qubes.vm.adminvm.AdminVM)
+        ):
             return
+
+        if vm in self._attached:
+            yield from self._attached[vm]
+            return
+
+        self._attached[vm] = []
         xml_desc = lxml.etree.fromstring(vm.libvirt_domain.XMLDesc())
 
         for hostdev in xml_desc.findall("devices/hostdev"):
@@ -409,14 +440,19 @@ class PCIDeviceExtension(qubes.ext.Extension):
                 device=device,
                 function=function,
             )
-            yield PCIDevice(
-                Port(
-                    backend_domain=vm.app.domains[0],
-                    port_id=None,
-                    devclass="pci",
+            dev = (
+                PCIDevice(
+                    Port(
+                        backend_domain=vm.app.domains[0],
+                        port_id=None,
+                        devclass="pci",
+                    ),
+                    libvirt_name=libvirt_name,
                 ),
-                libvirt_name=libvirt_name,
-            ), {}
+                {},
+            )
+            yield dev
+            self._attached[vm].append(dev)
 
     @qubes.ext.handler("device-pre-attach:pci")
     def on_device_pre_attached_pci(self, vm, event, device, options):


### PR DESCRIPTION
Moved problematic commits from https://github.com/QubesOS/qubes-core-admin/pull/852 to this PR, to not block the other from being merged.

TODO:

- [ ] support device manipulation outside of qubesd, such as using virsh or xl directly
```
VIR_DOMAIN_EVENT_ID_DEVICE_REMOVED	= 	15 (0xf) virConnectDomainEventDeviceRemovedCallback
VIR_DOMAIN_EVENT_ID_DEVICE_ADDED	= 	19 (0x13) virConnectDomainEventDeviceAddedCallback
VIR_DOMAIN_EVENT_ID_DEVICE_REMOVAL_FAILED	= 	22 (0x16) virConnectDomainEventDeviceRemovalFailedCallback
``` 
- [ ] add unit tests
- [ ] add integ tests