### PR TITLE
Test that packagekit works via proxy

### DIFF
--- a/qubes/tests/integ/vm_update.py
+++ b/qubes/tests/integ/vm_update.py
@@ -755,6 +755,13 @@ SHA256:
                 self.testvm1, "pkcon install -y test-pkg", self.ret_code_ok
             )
 
+            # verify if it was really installed
+            self.assertRunCommandReturnCode(
+                self.testvm1,
+                self.install_test_cmd.format("test-pkg"),
+                self.ret_code_ok,
+            )
+
     def upgrade_status_notify(self):
         """
         Run upgrades-status-notify at test vm.

--- a/qubes/tests/integ/vm_update.py
+++ b/qubes/tests/integ/vm_update.py
@@ -729,6 +729,32 @@ SHA256:
         """
         self.update_via_proxy_qubes_vm_update_impl()
 
+    def test_011_pkcon_via_proxy(self):
+        """
+        Test that packagekit works via proxy
+
+        :type self: qubes.tests.SystemTestCase | VmUpdatesMixin
+        """
+
+        self.start_vm_with_proxy_repo()
+
+        with self.qrexec_policy(
+            "qubes.UpdatesProxy",
+            self.testvm1,
+            "@default",
+            action="allow target=" + self.netvm_repo.name,
+        ):
+
+            # update repository metadata
+            self.assertRunCommandReturnCode(
+                self.testvm1, "pkcon refresh", self.ret_code_ok
+            )
+
+            # install test package
+            self.assertRunCommandReturnCode(
+                self.testvm1, "pkcon install -y test-pkg", self.ret_code_ok
+            )
+
     def upgrade_status_notify(self):
         """
         Run upgrades-status-notify at test vm.


### PR DESCRIPTION
Here is the [requested](https://github.com/QubesOS/qubes-core-agent-linux/pull/659#issuecomment-4972251476) test.

Packagekit still needs to be installed in the template before the test. Should it be installed in the test function or somewhere else?

I'm also not sure about the right location to place the test, or test number.