### PR TITLE
q-dev: expose device assignment modes

### DIFF
--- a/qubes/api/admin.py
+++ b/qubes/api/admin.py
@@ -1786,19 +1786,60 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
 
     @qubes.api.method(
         "admin.deviceclass.List",
-        wants_arg=False,
+        wants_arg=None,
         wants_payload=False,
         dest_adminvm=True,
         scope="global",
         read=True,
     )
     async def deviceclass_list(self):
-        """List all DEVICES classes"""
+        """List all DEVICE classes.
+
+        Returns one `deviceclass` name per line.
+
+        ``admin.deviceclass.List+details`` returns the same list, but
+        each line additionally carries space-separated ``key=value`` metadata.
+        Currently, it's: <class> assignment_modes=<mode>[,<mode>...]
+        The ``key=value`` format allows further properties to be added.
+        """
+        self.enforce_arg(
+            wants=["", "details"],
+            short_reason="'', 'details'",
+        )
+        details: bool = self.arg == "details"
+
         entrypoints = self.fire_event_for_filter(
             importlib.metadata.entry_points(group="qubes.devices")
         )
 
-        return "".join("{}\n".format(ep.name) for ep in entrypoints)
+        if not details:
+            return "".join("{}\n".format(ep.name) for ep in entrypoints)
+
+        lines = []
+        for entry_point in entrypoints:
+            modes = ""
+            try:
+                device_info = entry_point.load()
+                modes = ",".join(
+                    sorted(
+                        mode.value
+                        for mode in device_info.SUPPORTED_ASSIGNMENT_MODES
+                    )
+                )
+            # pylint: disable=broad-exception-caught
+            except Exception:
+                # a class that fails to load or does not expose the metadata
+                # is still listed, just without the extra properties
+                self.app.log.warning(
+                    "Cannot get assignment modes for device class %s",
+                    entry_point.name,
+                    exc_info=True,
+                )
+            if modes:
+                lines.append(f"{entry_point.name} assignment_modes={modes}\n")
+            else:
+                lines.append(f"{entry_point.name}\n")
+        return "".join(lines)
 
     @qubes.api.method(
         "admin.vm.device.{endpoint}.Available",

--- a/qubes/device_protocol.py
+++ b/qubes/device_protocol.py
@@ -899,8 +899,24 @@ class DeviceInterface:
         return True
 
 
+class AssignmentMode(Enum):
+    """
+    Device assignment modes
+    """
+
+    MANUAL = "manual"
+    ASK = "ask-to-attach"
+    AUTO = "auto-attach"
+    REQUIRED = "required"
+
+
 class DeviceInfo(VirtualDevice):
     """Holds all information about a device"""
+
+    # Subclasses should override this.
+    SUPPORTED_ASSIGNMENT_MODES: "frozenset[AssignmentMode]" = frozenset(
+        {AssignmentMode.ASK, AssignmentMode.AUTO}
+    )
 
     def __init__(
         self,
@@ -1225,17 +1241,6 @@ class UnknownDevice(DeviceInfo):
         Return `UnknownDevice` based on any virtual device.
         """
         return UnknownDevice(device.port, device_id=device.device_id)
-
-
-class AssignmentMode(Enum):
-    """
-    Device assignment modes
-    """
-
-    MANUAL = "manual"
-    ASK = "ask-to-attach"
-    AUTO = "auto-attach"
-    REQUIRED = "required"
 
 
 class DeviceAssignment:

--- a/qubes/device_protocol.py
+++ b/qubes/device_protocol.py
@@ -915,7 +915,7 @@ class DeviceInfo(VirtualDevice):
 
     # Subclasses should override this.
     SUPPORTED_ASSIGNMENT_MODES: "frozenset[AssignmentMode]" = frozenset(
-        {AssignmentMode.ASK, AssignmentMode.AUTO}
+        {AssignmentMode.MANUAL, AssignmentMode.ASK, AssignmentMode.AUTO}
     )
 
     def __init__(

--- a/qubes/devices.py
+++ b/qubes/devices.py
@@ -196,6 +196,11 @@ class DeviceCollection:
                 f"when {self._bus} device expected."
             )
 
+        if AssignmentMode.MANUAL not in self.supported_assignment_modes:
+            raise qubes.exc.QubesValueError(
+                f"{self._bus} devices cannot be attached manually."
+            )
+
         if self._vm.is_halted():
             raise qubes.exc.QubesVMNotRunningError(
                 self._vm,

--- a/qubes/devices.py
+++ b/qubes/devices.py
@@ -178,6 +178,13 @@ class DeviceCollection:
             "qubes.devices", self._bus
         )
 
+    @property
+    def supported_assignment_modes(self):
+        """
+        Assignment modes allowed for this device class.
+        """
+        return self.devclass.SUPPORTED_ASSIGNMENT_MODES
+
     async def attach(self, assignment: DeviceAssignment):
         """
         Attach device to domain.
@@ -235,6 +242,17 @@ class DeviceCollection:
             options=assignment.options,
         )
 
+    def _validate_mode_supported(self, mode: AssignmentMode):
+        if mode in self.supported_assignment_modes:
+            return
+        allowed = ", ".join(
+            sorted(m.value for m in self.supported_assignment_modes)
+        )
+        raise qubes.exc.QubesValueError(
+            f"{self._bus} devices cannot be assigned in "
+            f"'{mode.value}' mode; allowed modes: {allowed}."
+        )
+
     async def assign(self, assignment: DeviceAssignment):
         """
         Assign device to domain.
@@ -252,9 +270,11 @@ class DeviceCollection:
                 f"already assigned to {self._vm!s}"
             )
 
+        # avoid putting MANUAL assigment to qubes.xml
         if not assignment.attach_automatically:
             raise ValueError("Only auto-attachable devices can be assigned.")
 
+        self._validate_mode_supported(assignment.mode)
         self._set.add(assignment)
 
         await self._vm.fire_event_async(
@@ -293,6 +313,7 @@ class DeviceCollection:
             raise qubes.exc.QubesValueError(
                 "Cannot change assignment mode to 'manual'"
             )
+        self._validate_mode_supported(mode)
         assignments = [
             a for a in self.get_assigned_devices() if a.virtual_device == device
         ]

--- a/qubes/ext/block.py
+++ b/qubes/ext/block.py
@@ -51,6 +51,13 @@ SYSTEM_DISKS_DOM0_KERNEL = SYSTEM_DISKS + ("xvdd",)
 
 
 class BlockDevice(qubes.device_protocol.DeviceInfo):
+    SUPPORTED_ASSIGNMENT_MODES = frozenset(
+        {
+            qubes.device_protocol.AssignmentMode.ASK,
+            qubes.device_protocol.AssignmentMode.AUTO,
+            qubes.device_protocol.AssignmentMode.REQUIRED,
+        }
+    )
 
     def __init__(self, port: qubes.device_protocol.Port):
         if port.devclass != "block":

--- a/qubes/ext/block.py
+++ b/qubes/ext/block.py
@@ -53,6 +53,7 @@ SYSTEM_DISKS_DOM0_KERNEL = SYSTEM_DISKS + ("xvdd",)
 class BlockDevice(qubes.device_protocol.DeviceInfo):
     SUPPORTED_ASSIGNMENT_MODES = frozenset(
         {
+            qubes.device_protocol.AssignmentMode.MANUAL,
             qubes.device_protocol.AssignmentMode.ASK,
             qubes.device_protocol.AssignmentMode.AUTO,
             qubes.device_protocol.AssignmentMode.REQUIRED,

--- a/qubes/ext/pci.py
+++ b/qubes/ext/pci.py
@@ -34,7 +34,7 @@ import lxml.etree
 import qubes.device_protocol
 import qubes.devices
 import qubes.ext
-from qubes.device_protocol import Port, UnknownDevice
+from qubes.device_protocol import AssignmentMode, Port, UnknownDevice
 from qubes.exc import DeviceNotFound
 from qubes.utils import sbdf_to_path, path_to_sbdf, is_pci_path
 
@@ -147,6 +147,8 @@ class PCIDevice(qubes.device_protocol.DeviceInfo):
         r"\Apci_(?P<segment>[0-9a-f]{4})_(?P<bus>[0-9a-f]{2})_"
         r"(?P<device>[0-9a-f]{2})_(?P<function>[0-9a-f])\Z"
     )
+
+    SUPPORTED_ASSIGNMENT_MODES = frozenset({AssignmentMode.REQUIRED})
 
     def __init__(self, port: Port, libvirt_name=None):
         if libvirt_name:

--- a/qubes/tests/api_admin.py
+++ b/qubes/tests/api_admin.py
@@ -5101,6 +5101,34 @@ running and private volume snapshots are disabled. Backup will fail!\n"
             "mem=512 mem_static_max=1024 cputime=100 power_state=Running",
         )
 
+    def test_910_deviceclass_list(self):
+        value = self.call_mgmt_func(b"admin.deviceclass.List", b"dom0")
+        classes = value.splitlines()
+        for line in classes:
+            self.assertNotIn("=", line)
+        self.assertIn("pci", classes)
+        self.assertIn("block", classes)
+
+    def test_911_deviceclass_list_details(self):
+        value = self.call_mgmt_func(
+            b"admin.deviceclass.List", b"dom0", b"details"
+        )
+        parsed = {}
+        for line in value.splitlines():
+            name, _, rest = line.partition(" ")
+            parsed[name] = rest
+        self.assertIn("pci", parsed)
+        self.assertIn("block", parsed)
+        self.assertEqual(parsed["pci"], "assignment_modes=required")
+        self.assertEqual(
+            parsed["block"],
+            "assignment_modes=ask-to-attach,auto-attach,required",
+        )
+
+    def test_912_deviceclass_list_bad_argument(self):
+        with self.assertRaises(qubes.exc.PermissionDenied):
+            self.call_mgmt_func(b"admin.deviceclass.List", b"dom0", b"badarg")
+
     def test_990_vm_unexpected_payload(self):
         methods_with_no_payload = [
             b"admin.vm.List",
@@ -5176,7 +5204,6 @@ running and private volume snapshots are disabled. Backup will fail!\n"
             b"admin.vm.firewall.Get",
             b"admin.vm.firewall.Set",
             b"admin.vm.firewall.Reload",
-            b"admin.deviceclass.List",
             b"admin.vm.device.denied.List",
             b"admin.vm.volume.List",
             b"admin.vm.Start",
@@ -5256,7 +5283,6 @@ running and private volume snapshots are disabled. Backup will fail!\n"
 
     def test_993_dom0_unexpected_argument(self):
         methods_with_no_argument = [
-            b"admin.deviceclass.List",
             b"admin.vmclass.List",
             b"admin.vm.List",
             b"admin.label.List",

--- a/qubes/tests/devices.py
+++ b/qubes/tests/devices.py
@@ -38,7 +38,13 @@ import qubes.tests
 
 class TestDevice(DeviceInfo):
     # pylint: disable=too-few-public-methods
-    pass
+    SUPPORTED_ASSIGNMENT_MODES = frozenset(
+        {
+            AssignmentMode.ASK,
+            AssignmentMode.AUTO,
+            AssignmentMode.REQUIRED,
+        }
+    )
 
 
 class TestVMCollection(dict):
@@ -290,6 +296,37 @@ class TC_00_DeviceCollection(qubes.tests.QubesTestCase):
         self.assertEqual(
             {self.assignment}, set(self.collection.get_assigned_devices())
         )
+
+    def test_023_assign_unsupported_mode(self):
+        original = TestDevice.SUPPORTED_ASSIGNMENT_MODES
+        TestDevice.SUPPORTED_ASSIGNMENT_MODES = frozenset(
+            {AssignmentMode.ASK, AssignmentMode.AUTO}
+        )
+        self.addCleanup(
+            setattr, TestDevice, "SUPPORTED_ASSIGNMENT_MODES", original
+        )
+        self.assignment = self.assignment.clone(mode="required")
+        with self.assertRaises(qubes.exc.QubesValueError):
+            self.loop.run_until_complete(
+                self.collection.assign(self.assignment)
+            )
+
+    def test_024_update_assignment_unsupported_mode(self):
+        self.assignment = self.assignment.clone(mode="auto-attach")
+        self.loop.run_until_complete(self.collection.assign(self.assignment))
+        original = TestDevice.SUPPORTED_ASSIGNMENT_MODES
+        TestDevice.SUPPORTED_ASSIGNMENT_MODES = frozenset(
+            {AssignmentMode.ASK, AssignmentMode.AUTO}
+        )
+        self.addCleanup(
+            setattr, TestDevice, "SUPPORTED_ASSIGNMENT_MODES", original
+        )
+        with self.assertRaises(qubes.exc.QubesValueError):
+            self.loop.run_until_complete(
+                self.collection.update_assignment(
+                    self.device, AssignmentMode.REQUIRED
+                )
+            )
 
     def test_030_assign(self):
         self.emitter.running = True

--- a/qubes/tests/devices.py
+++ b/qubes/tests/devices.py
@@ -40,6 +40,7 @@ class TestDevice(DeviceInfo):
     # pylint: disable=too-few-public-methods
     SUPPORTED_ASSIGNMENT_MODES = frozenset(
         {
+            AssignmentMode.MANUAL,
             AssignmentMode.ASK,
             AssignmentMode.AUTO,
             AssignmentMode.REQUIRED,
@@ -326,6 +327,20 @@ class TC_00_DeviceCollection(qubes.tests.QubesTestCase):
                 self.collection.update_assignment(
                     self.device, AssignmentMode.REQUIRED
                 )
+            )
+
+    def test_026_attach_manual_not_supported(self):
+        original = TestDevice.SUPPORTED_ASSIGNMENT_MODES
+        TestDevice.SUPPORTED_ASSIGNMENT_MODES = frozenset(
+            {AssignmentMode.REQUIRED}
+        )
+        self.addCleanup(
+            setattr, TestDevice, "SUPPORTED_ASSIGNMENT_MODES", original
+        )
+        self.emitter.running = True
+        with self.assertRaises(qubes.exc.QubesValueError):
+            self.loop.run_until_complete(
+                self.collection.attach(self.assignment)
             )
 
     def test_030_assign(self):


### PR DESCRIPTION
Until now, the available assignment modes were hidden in code without an endpoint in the API.

related: QubesOS/qubes-core-admin-client/pull/487
related: QubesOS/qubes-app-linux-usb-proxy/pull/61