### PR TITLE
tests: make qubesd-query mock work with dash

### DIFF
--- a/qubes/tests/rpc_import.py
+++ b/qubes/tests/rpc_import.py
@@ -47,7 +47,7 @@ fi
 
 if [ "$1" = --single-line ] && [ "$2" = --max-bytes=21 ]; then
     shift 2
-    read -r -n 21 val
+    IFS= read -r val
     method=$4
     printf %s "$val" > "payload-$method"
 elif [ "$1" = --empty ]; then


### PR DESCRIPTION
The qubesd-query mock in rpc_import.py uses `read -n`, which is a bash extension, but the script has a #!/bin/sh shebang. On Debian/Ubuntu /bin/sh is dash, so read fails with "Illegal option -n", admin.vm.volume.ImportWithSize exits with status 2 and test_01_import_with_size fails.

Fedora CI is unaffected because /bin/sh is bash there.

Reading a whole line instead of limiting to 21 bytes is equivalent here: the payload is a single line, and bash's read -n stops at the newline anyway.

Verified on Debian 13: all 4 tests in qubes.tests.rpc_import pass.