### PR TITLE
Cache event handlers

### DIFF
--- a/qubes/events.py
+++ b/qubes/events.py
@@ -27,6 +27,7 @@ etc.
 import asyncio
 import collections
 import fnmatch
+import functools
 import itertools
 
 from typing import Callable
@@ -109,6 +110,7 @@ class Emitter(metaclass=EmitterMeta):
 
     def close(self):
         self.events_enabled = False
+        self._get_handler_funcs.cache_clear()
 
     def add_handler(self, event, func):
         """Add event handler to subject's class.
@@ -163,6 +165,23 @@ class Emitter(metaclass=EmitterMeta):
                 effects.extend(effect)
         return effects
 
+    @staticmethod
+    @functools.cache
+    def _get_handler_funcs(handlers) -> tuple[list, list]:
+        sync_funcs = []
+        async_funcs = []
+        sorted_handlers = sorted(
+            handlers,
+            key=(lambda handler: hasattr(handler, "ha_bound")),
+            reverse=True,
+        )
+        for func in sorted_handlers:
+            if asyncio.iscoroutinefunction(func):
+                async_funcs.append(func)
+            else:
+                sync_funcs.append(func)
+        return sync_funcs, async_funcs
+
     def _get_event_funcs(
         self, event: str, pre_event: bool = False
     ) -> tuple[list, list]:
@@ -183,24 +202,24 @@ class Emitter(metaclass=EmitterMeta):
         async_funcs = []
         for i in order:
             try:
-                handlers_dict = i.__handlers__
+                handlers_tuple = tuple(i.__handlers__.items())
             except AttributeError:
                 continue
-            handlers = [
+            if not handlers_tuple:
+                continue
+            handlers = tuple(
                 h_func
-                for h_name, h_func_set in handlers_dict.items()
+                for h_name, h_func_set in handlers_tuple
                 for h_func in h_func_set
                 if fnmatch.fnmatch(event, h_name)
-            ]
-            for func in sorted(
-                handlers,
-                key=(lambda handler: hasattr(handler, "ha_bound")),
-                reverse=True,
-            ):
-                if asyncio.iscoroutinefunction(func):
-                    async_funcs.append(func)
-                else:
-                    sync_funcs.append(func)
+            )
+            curr_sync_funcs, curr_async_funcs = self._get_handler_funcs(
+                handlers
+            )
+            if curr_sync_funcs:
+                sync_funcs.extend(curr_sync_funcs)
+            if curr_async_funcs:
+                async_funcs.extend(curr_async_funcs)
         return sync_funcs, async_funcs
 
     def fire_event(self, event, pre_event=False, **kwargs):

--- a/qubes/events.py
+++ b/qubes/events.py
@@ -110,6 +110,7 @@ class Emitter(metaclass=EmitterMeta):
 
     def close(self):
         self.events_enabled = False
+        self._match_event_handlers.cache_clear()
         self._get_handler_funcs.cache_clear()
 
     def add_handler(self, event, func):
@@ -167,6 +168,17 @@ class Emitter(metaclass=EmitterMeta):
 
     @staticmethod
     @functools.cache
+    def _match_event_handlers(handlers_tuple: tuple, event: str) -> tuple:
+        handlers = tuple(
+            h_func
+            for h_name, h_func_set in handlers_tuple
+            for h_func in h_func_set
+            if fnmatch.fnmatch(event, h_name)
+        )
+        return handlers
+
+    @staticmethod
+    @functools.cache
     def _get_handler_funcs(handlers) -> tuple[list, list]:
         sync_funcs = []
         async_funcs = []
@@ -202,16 +214,16 @@ class Emitter(metaclass=EmitterMeta):
         async_funcs = []
         for i in order:
             try:
-                handlers_tuple = tuple(i.__handlers__.items())
+                handlers_tuple = tuple(
+                    (h_name, tuple(h_func_set))
+                    for h_name, h_func_set in i.__handlers__.items()
+                )
             except AttributeError:
                 continue
             if not handlers_tuple:
                 continue
-            handlers = tuple(
-                h_func
-                for h_name, h_func_set in handlers_tuple
-                for h_func in h_func_set
-                if fnmatch.fnmatch(event, h_name)
+            handlers = self._match_event_handlers(
+                handlers_tuple=handlers_tuple, event=event
             )
             curr_sync_funcs, curr_async_funcs = self._get_handler_funcs(
                 handlers

--- a/qubes/events.py
+++ b/qubes/events.py
@@ -27,8 +27,9 @@ etc.
 import asyncio
 import collections
 import fnmatch
-
 import itertools
+
+from typing import Callable
 
 
 def handler(*events):
@@ -136,10 +137,39 @@ class Emitter(metaclass=EmitterMeta):
         # pylint: disable=no-member
         self.__handlers__[event].remove(func)
 
-    def _fire_event(self, event, kwargs, pre_event=False):
-        """Fire event for classes in given order.
+    def _get_sync_effects(
+        self, funcs: list[Callable], event: str, kwargs
+    ) -> list:
+        effects = []
+        for func in funcs:
+            effect = func(self, event, **kwargs)
+            if effect is not None:
+                effects.extend(effect)
+        return effects
 
-        Do not use this method. Use :py:meth:`fire_event`.
+    async def _get_async_effects(
+        self, funcs: list[Callable], event: str, kwargs
+    ) -> list:
+        if not funcs:
+            return []
+        coros = []
+        for func in funcs:
+            coros.append(func(self, event, **kwargs))
+        async_tasks, _ = await asyncio.wait(map(asyncio.create_task, coros))
+        effects = []
+        for task in async_tasks:
+            effect = task.result()
+            if effect is not None:
+                effects.extend(effect)
+        return effects
+
+    def _get_event_funcs(
+        self, event: str, pre_event: bool = False
+    ) -> tuple[list, list]:
+        """Get all functions for a give event.
+
+        Do not use this method. Use :py:meth:`fire_event` or
+        :py:meth:`fire_event_async`.
         """
 
         if not self.events_enabled:
@@ -149,8 +179,8 @@ class Emitter(metaclass=EmitterMeta):
         if not pre_event:
             order = reversed(list(order))
 
-        effects = []
-        async_effects = []
+        sync_funcs = []
+        async_funcs = []
         for i in order:
             try:
                 handlers_dict = i.__handlers__
@@ -167,12 +197,11 @@ class Emitter(metaclass=EmitterMeta):
                 key=(lambda handler: hasattr(handler, "ha_bound")),
                 reverse=True,
             ):
-                effect = func(self, event, **kwargs)
                 if asyncio.iscoroutinefunction(func):
-                    async_effects.append(effect)
-                elif effect is not None:
-                    effects.extend(effect)
-        return effects, async_effects
+                    async_funcs.append(func)
+                else:
+                    sync_funcs.append(func)
+        return sync_funcs, async_funcs
 
     def fire_event(self, event, pre_event=False, **kwargs):
         """Call all handlers for an event.
@@ -198,15 +227,18 @@ class Emitter(metaclass=EmitterMeta):
         events.
         """
 
-        sync_effects, async_effects = self._fire_event(
-            event, kwargs, pre_event=pre_event
+        sync_funcs, async_funcs = self._get_event_funcs(
+            event, pre_event=pre_event
         )
-        if async_effects:
+        if async_funcs:
             raise RuntimeError(
                 "unexpected async-handler(s) {!r} for sync event {!s}".format(
-                    async_effects, event
+                    async_funcs, event
                 )
             )
+        sync_effects = self._get_sync_effects(
+            funcs=sync_funcs, event=event, kwargs=kwargs
+        )
         return sync_effects
 
     async def fire_event_async(self, event, pre_event=False, **kwargs):
@@ -232,16 +264,13 @@ class Emitter(metaclass=EmitterMeta):
         events.
         """
 
-        sync_effects, async_effects = self._fire_event(
-            event, kwargs, pre_event=pre_event
+        sync_funcs, async_funcs = self._get_event_funcs(
+            event=event, pre_event=pre_event
         )
-        effects = sync_effects
-        if async_effects:
-            async_tasks, _ = await asyncio.wait(
-                map(asyncio.create_task, async_effects)
-            )
-            for task in async_tasks:
-                effect = task.result()
-                if effect is not None:
-                    effects.extend(effect)
-        return effects
+        sync_effects = self._get_sync_effects(
+            funcs=sync_funcs, event=event, kwargs=kwargs
+        )
+        async_effects = await self._get_async_effects(
+            funcs=async_funcs, event=event, kwargs=kwargs
+        )
+        return sync_effects + async_effects

--- a/qubes/events.py
+++ b/qubes/events.py
@@ -28,7 +28,6 @@ import asyncio
 import collections
 import fnmatch
 import functools
-import itertools
 
 from typing import Callable
 
@@ -110,6 +109,7 @@ class Emitter(metaclass=EmitterMeta):
 
     def close(self):
         self.events_enabled = False
+        self._get_ordered_mro.cache_clear()
         self._match_event_handlers.cache_clear()
         self._get_handler_funcs.cache_clear()
 
@@ -168,6 +168,14 @@ class Emitter(metaclass=EmitterMeta):
 
     @staticmethod
     @functools.cache
+    def _get_ordered_mro(mro, pre_event: bool) -> tuple:
+        order = tuple(klass for klass in mro if hasattr(klass, "__handlers__"))
+        if not pre_event:
+            order = tuple(reversed(order))
+        return order
+
+    @staticmethod
+    @functools.cache
     def _match_event_handlers(handlers_tuple: tuple, event: str) -> tuple:
         handlers = tuple(
             h_func
@@ -206,20 +214,19 @@ class Emitter(metaclass=EmitterMeta):
         if not self.events_enabled:
             return [], []
 
-        order = itertools.chain((self,), self.__class__.__mro__)
-        if not pre_event:
-            order = reversed(list(order))
-
+        mro = self.__class__.__mro__
+        order = self._get_ordered_mro(mro=mro, pre_event=pre_event)
+        if pre_event:
+            order = (self,) + order
+        else:
+            order = order + (self,)
         sync_funcs = []
         async_funcs = []
         for i in order:
-            try:
-                handlers_tuple = tuple(
-                    (h_name, tuple(h_func_set))
-                    for h_name, h_func_set in i.__handlers__.items()
-                )
-            except AttributeError:
-                continue
+            handlers_tuple = tuple(
+                (h_name, tuple(h_func_set))
+                for h_name, h_func_set in i.__handlers__.items()
+            )
             if not handlers_tuple:
                 continue
             handlers = self._match_event_handlers(


### PR DESCRIPTION
Speed up collecting event handlers.

**Without the changes**:

% ~/stats.py -r 30 -b QubesCollectOldHandlers
['0.000558', '0.000465', '0.000459', '0.000391', '0.000374', '0.000432', '0.000420', '0.000435', '0.000382', '0.000373', '0.000426', '0.000411', '0.000448', '0.000414', '0.000375', '0.000432', '0.000407', '0.000420', '0.000426', '0.000399', '0.000460', '0.000424', '0.000416', '0.000379', '0.000393', '0.000387', '0.000434', '0.000428', '0.000375', '0.000384']

- 1st: 0.000558
- Max: 0.000558
- Min: 0.000373
- Avg: 0.000418
- Med: 0.000418

**With the changes**:

% PYTHONPATH=. ~/stats.py -r 30 -b QubesCollectNewHandlers
['0.000255', '0.000075', '0.000045', '0.000042', '0.000041', '0.000040', '0.000040', '0.000040', '0.000040', '0.000385', '0.000043', '0.000041', '0.000041', '0.000040', '0.000040', '0.000049', '0.000042', '0.000046', '0.000041', '0.000041', '0.000040', '0.000040', '0.000040', '0.000040', '0.000049', '0.000040', '0.000040', '0.000040', '0.000040', '0.000045']

- 1st: 0.000255
- Max: 0.000385
- Min: 0.000040
- Avg: 0.000061
- Med: 0.000041

---

Didn't run tests, so it is draft.

To benchmark, I used: https://github.com/ben-grande/bench, with something similar to:

```python3
class QubesCollectOldHandlers(QubesPerf):
    """
    Benchmark time to collect event handlers
    """

    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        self.qube = self.app.domains["default-dvm"]

    def test(self, previous_value=None) -> tuple[list, list]:
        # pylint: disable=unused-argument
        sync_funcs, async_funcs = self.qube._get_event_funcs(
            event="domain-feature-set:internal",
            kwargs={"oldvalue": None, "value": True, "feature": "internal"},
            pre_event=False,
        )
        return sync_funcs, async_funcs

class QubesCollectNewHandlers(QubesPerf):
    """
    Benchmark time to collect event handlers
    """

    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        self.qube = self.app.domains["default-dvm"]

    def test(self, previous_value=None) -> tuple[list, list]:
        # pylint: disable=unused-argument
        sync_funcs, async_funcs = self.qube._get_event_funcs(
            event="domain-feature-set:internal", pre_event=False
        )
        return sync_funcs, async_funcs
```

Note that the old code does not have `_get_event_funcs`, because it runs the synchornous funcs in `_fire_event`, I had to copy from one function to the other, and remove the event handling from `_get_event_funcs`.