### PR TITLE
Deferred template

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -59,10 +59,10 @@ const-rgx=(([A-Za-z_][A-Za-z0-9_]*)|(__.*__))$
 class-rgx=([A-Z_][a-zA-Z0-9]+|TC_\d\d_[a-zA-Z0-9_]+)$
 
 # Regular expression which should only match correct function names
-function-rgx=(test_[0-9]{3}_[a-z0-9_]{2,50}|[a-z_][a-z0-9_]{2,50})$
+function-rgx=(test_[0-9]{3}_[a-z0-9_]{2,60}|[a-z_][a-z0-9_]{2,60})$
 
 # Regular expression which should only match correct method names
-method-rgx=(setUp|setUpClass|tearDown|tearDownClass|test_[0-9]{3}_[a-z0-9_]{2,50}|[a-z_][a-z0-9_]{2,50})$
+method-rgx=(setUp|setUpClass|tearDown|tearDownClass|test_[0-9]{3}_[a-z0-9_]{2,60}|[a-z_][a-z0-9_]{2,60})$
 
 # Regular expression which should only match correct instance attribute names
 attr-rgx=(maxDiff|[a-z_][a-z0-9_]{2,40})$

--- a/qubes/api/admin.py
+++ b/qubes/api/admin.py
@@ -1401,6 +1401,16 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
             raise qubes.exc.QubesFeatureNotFoundError(self.dest, self.arg)
         return value
 
+    def _get_template_feature_options(self):
+        active = True
+        if "+" in self.arg:
+            untrusted_feature, untrusted_options = self.arg.split("+", 1)
+            if untrusted_options == "deferred":
+                active = False
+        else:
+            untrusted_feature = self.arg
+        return untrusted_feature, active
+
     @qubes.api.method(
         "admin.vm.feature.CheckWithTemplate",
         wants_arg=True,
@@ -1413,10 +1423,15 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
         # validation of self.arg done by qrexec-policy is enough
 
         self.fire_event_for_permission()
+        untrusted_feature, active = self._get_template_feature_options()
         try:
-            value = self.dest.features.check_with_template(self.arg)
+            value = self.dest.features.check_with_template(
+                untrusted_feature, active=active
+            )
         except KeyError:
-            raise qubes.exc.QubesFeatureNotFoundError(self.dest, self.arg)
+            raise qubes.exc.QubesFeatureNotFoundError(
+                self.dest, untrusted_feature
+            )
         return value
 
     @qubes.api.method(
@@ -1467,10 +1482,15 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
         # validation of self.arg done by qrexec-policy is enough
 
         self.fire_event_for_permission()
+        untrusted_feature, active = self._get_template_feature_options()
         try:
-            value = self.dest.features.check_with_template_and_adminvm(self.arg)
+            value = self.dest.features.check_with_template_and_adminvm(
+                untrusted_feature, active=active
+            )
         except KeyError:
-            raise qubes.exc.QubesFeatureNotFoundError(self.dest, self.arg)
+            raise qubes.exc.QubesFeatureNotFoundError(
+                self.dest, untrusted_feature
+            )
         return value
 
     @qubes.api.method(

--- a/qubes/app.py
+++ b/qubes/app.py
@@ -864,9 +864,7 @@ class VMCollection:
         return set(
             vm
             for vm in self
-            if hasattr(vm, "template")
-            and getattr(vm, "active_template", getattr(vm, "template"))
-            == template
+            if qubes.vm.qubesvm.get_active_template(vm) == template
         )
 
     def get_vms_connected_to(self, netvm):

--- a/qubes/app.py
+++ b/qubes/app.py
@@ -864,7 +864,9 @@ class VMCollection:
         return set(
             vm
             for vm in self
-            if hasattr(vm, "template") and vm.template == template
+            if hasattr(vm, "template")
+            and getattr(vm, "active_template", getattr(vm, "template"))
+            == template
         )
 
     def get_vms_connected_to(self, netvm):

--- a/qubes/ext/admin.py
+++ b/qubes/ext/admin.py
@@ -34,6 +34,10 @@ PROHIBITED_FEATURES = [
     "preload-dispvm-in-progress",
 ]
 
+PROHIBITED_PROPERTIES = [
+    "active_template",
+]
+
 
 class JustEvaluateAskResolution(parser.AskResolution):
     async def execute(self):
@@ -66,6 +70,21 @@ class AdminExtension(qubes.ext.Extension):
         if arg in PROHIBITED_FEATURES:
             raise qubes.exc.PermissionDenied(
                 "changing this feature is prohibited by {}.{}".format(
+                    __name__, type(self).__name__
+                )
+            )
+
+    @qubes.ext.handler(
+        "admin-permission:admin.vm.property.Set",
+        "admin-permission:admin.vm.property.Reset",
+        "admin-permission:admin.vm.property.Remove",
+    )
+    def on_property_set_or_remove(self, vm, event, arg, **kwargs):
+        """Forbid changing specific properties"""
+        # pylint: disable=unused-argument
+        if arg in PROHIBITED_PROPERTIES:
+            raise qubes.exc.PermissionDenied(
+                "changing this property is prohibited by {}.{}".format(
                     __name__, type(self).__name__
                 )
             )

--- a/qubes/features.py
+++ b/qubes/features.py
@@ -173,7 +173,12 @@ class Features(dict):
             except KeyError:
                 if attr is None:
                     break
-                subject = getattr(subject, attr, None)
+                if attr == "active_template":
+                    subject = getattr(
+                        subject, "active_template", getattr(subject, attr, None)
+                    )
+                else:
+                    subject = getattr(subject, attr, None)
 
         if check_adminvm:
             adminvm = self.subject.app.domains["dom0"]
@@ -190,12 +195,14 @@ class Features(dict):
 
         raise KeyError(feature)
 
-    def check_with_template(self, feature, default=_NO_DEFAULT):
+    def check_with_template(self, feature, default=_NO_DEFAULT, active=True):
         """Check for the specified feature; if this VM does not have it,
         it checks with its template."""
-        return self._recursive_check(
-            "template", feature=feature, default=default
-        )
+        if active:
+            prop = "active_template"
+        else:
+            prop = "template"
+        return self._recursive_check(prop, feature=feature, default=default)
 
     def check_with_netvm(self, feature, default=_NO_DEFAULT):
         """Check for the specified feature; if this VM does not have it,
@@ -209,10 +216,16 @@ class Features(dict):
             check_adminvm=True, feature=feature, default=default
         )
 
-    def check_with_template_and_adminvm(self, feature, default=_NO_DEFAULT):
+    def check_with_template_and_adminvm(
+        self, feature, default=_NO_DEFAULT, active=True
+    ):
         """Check for the specified feature; if this VM does not have it,
         it checks with its template. If the template does not have it, it
         checks with the AdminVM."""
+        if active:
+            prop = "active_template"
+        else:
+            prop = "template"
         return self._recursive_check(
-            "template", check_adminvm=True, feature=feature, default=default
+            prop, check_adminvm=True, feature=feature, default=default
         )

--- a/qubes/tests/__init__.py
+++ b/qubes/tests/__init__.py
@@ -64,6 +64,8 @@ import qubes.events
 import qubes.exc
 import qubes.ext.pci
 import qubes.tests.never_awaited
+import qubes.vm.appvm
+import qubes.vm.dispvm
 import qubes.vm.standalonevm
 import qubes.vm.templatevm
 
@@ -1722,6 +1724,96 @@ class SystemTestCase(QubesTestCase):
         """Start a VM and wait for it to be fully up"""
         await vm.start()
         await self.wait_for_session(vm)
+
+    async def defer_tpl(
+        self, qube: qubes.vm.appvm.AppVM | qubes.vm.dispvm.DispVM
+    ) -> None:
+        template = qube.template
+        if qube.klass == "AppVM":
+            template_alt = self.app.add_new_vm(
+                qubes.vm.templatevm.TemplateVM,
+                name=self.make_vm_name("defer-tpl-alt"),
+                label="red",
+            )
+        elif qube.klass == "DispVM":
+            template_alt = self.app.add_new_vm(
+                qubes.vm.appvm.AppVM,
+                name=self.make_vm_name("defer-tpl-alt"),
+                label="red",
+                template_for_dispvms=True,
+            )
+        else:
+            raise TypeError("Received invalid qube class")
+
+        await template_alt.create_on_disk()
+        template.features["template-name"] = template.name
+        template_alt.features["template-name"] = template_alt.name
+
+        def get_tpl_vol_vid(qube):
+            if qube.klass == "DispVM":
+                volume = "private"
+            else:
+                volume = "root"
+            vid = qube.volumes[volume].source.vid
+            return vid
+
+        def get_tpl_vol_path(qube):
+            if getattr(qube, "template_for_dispvms", False):
+                volume = "private"
+            else:
+                volume = "root"
+            vid = qube.volumes[volume].vid
+            return vid
+
+        def check_deferred(qube, active, deferred):
+            self.assertEqual(qube.template, deferred)
+            self.assertEqual(qube.active_template, active)
+            self.assertEqual(get_tpl_vol_vid(qube), get_tpl_vol_path(active))
+            self.assertEqual(
+                qube.features.check_with_template("template-name"), active.name
+            )
+            self.assertEqual(
+                qube.features.check_with_template(
+                    "template-name", active=False
+                ),
+                deferred.name,
+            )
+            self.assertEqual(
+                qube.features.check_with_template_and_adminvm("template-name"),
+                active.name,
+            )
+            self.assertEqual(
+                qube.features.check_with_template_and_adminvm(
+                    "template-name", active=False
+                ),
+                deferred.name,
+            )
+            self.assertTrue(
+                qube in qube.app.domains.get_vms_based_on(qube.active_template)
+            )
+            if active != deferred:
+                self.assertTrue(
+                    qube not in qube.app.domains.get_vms_based_on(qube.template)
+                )
+                self.assertFalse(qube.property_is_default("active_template"))
+            else:
+                self.assertTrue(qube.property_is_default("active_template"))
+
+        self.log.warning("Testing prop is sane")
+        check_deferred(qube, active=template, deferred=template)
+
+        self.log.warning("Testing changing template when halted")
+        qube.template = template_alt
+        check_deferred(qube, active=template_alt, deferred=template_alt)
+
+        self.log.warning("Test changing template when running is deferred")
+        await qube.start()
+        qube.template = template
+        check_deferred(qube, active=template_alt, deferred=template)
+
+        self.log.warning("Test deferred template is applied on shutdown")
+        await qube.shutdown(wait=True)
+        check_deferred(qube, active=template, deferred=template)
 
 
 _templates = None

--- a/qubes/tests/ext.py
+++ b/qubes/tests/ext.py
@@ -2714,21 +2714,36 @@ class TC_50_Admin(qubes.tests.QubesTestCase):
 
     def test_000_features_permission(self):
         feature = qubes.ext.admin.PROHIBITED_FEATURES[0]
-        with self.assertRaises(qubes.exc.PermissionDenied):
-            self.ext.on_feature_set_or_remove(
-                "test-vm1",
-                "admin-permission:admin.vm.feature.Set",
-                feature,
-            )
+        for mode in ["Set", "Remove"]:
+            with self.subTest(mode=mode):
+                with self.assertRaises(qubes.exc.PermissionDenied):
+                    self.ext.on_feature_set_or_remove(
+                        "test-vm1",
+                        f"admin-permission:admin.vm.feature.{mode}",
+                        feature,
+                    )
+
+    def test_000_properties_permission(self):
+        prop = qubes.ext.admin.PROHIBITED_PROPERTIES[0]
+        for mode in ["Set", "Reset", "Remove"]:
+            with self.subTest(mode=mode):
+                with self.assertRaises(qubes.exc.PermissionDenied):
+                    self.ext.on_property_set_or_remove(
+                        "test-vm1",
+                        f"admin-permission:admin.vm.property.{mode}",
+                        prop,
+                    )
 
     def test_000_tags_permission(self):
         tag = "created-by-test"
-        with self.assertRaises(qubes.exc.PermissionDenied):
-            self.ext.on_tag_set_or_remove(
-                "test-vm1",
-                "admin-permission:admin.vm.tag.Set",
-                tag,
-            )
+        for mode in ["Set", "Remove"]:
+            with self.subTest(mode=mode):
+                with self.assertRaises(qubes.exc.PermissionDenied):
+                    self.ext.on_tag_set_or_remove(
+                        "test-vm1",
+                        f"admin-permission:admin.vm.tag.{mode}",
+                        tag,
+                    )
 
 
 class TC_60_Audio(qubes.tests.QubesTestCase):

--- a/qubes/tests/integ/basic.py
+++ b/qubes/tests/integ/basic.py
@@ -586,6 +586,19 @@ qvm-features-request boot-mode.active="defuser"
         self.app.save()
         self.loop.run_until_complete(self._test_bootmode_default_user(self.vm))
 
+    def test_300_deferred_template(self) -> None:
+        self.loop.run_until_complete(self._test_300_deferred_template())
+
+    async def _test_300_deferred_template(self) -> None:
+        appvm = self.app.add_new_vm(
+            qubes.vm.appvm.AppVM,
+            name=self.make_vm_name("appvm"),
+            template=self.app.default_template,
+            label="red",
+        )
+        await appvm.create_on_disk()
+        await self.defer_tpl(appvm)
+
 
 class TC_01_Properties(qubes.tests.SystemTestCase):
     # pylint: disable=attribute-defined-outside-init

--- a/qubes/tests/integ/dispvm.py
+++ b/qubes/tests/integ/dispvm.py
@@ -1061,6 +1061,84 @@ class TC_21_DispVM_Preload(DispVMHelpersMixin, qubes.tests.SystemTestCase):
         self.setup_dispvm_nodes()
         logger.info("end")
 
+    def test_000_defer_tpl_of_disp_tpl(self):
+        """Test deferred template of disposable template."""
+        self.loop.run_until_complete(self._test_000_defer_tpl_of_disp_tpl())
+
+    async def _test_000_defer_tpl_of_disp_tpl(self):
+        await self.defer_tpl(self.disp_base)
+
+    def test_001_defer_tpl_of_disp_tpl_with_running_disp(self):
+        """Test deferred template of disposable template while there are
+        disposables running."""
+        self.loop.run_until_complete(
+            self._test_001_defer_tpl_of_disp_tpl_with_running_disp()
+        )
+
+    async def _test_001_defer_tpl_of_disp_tpl_with_running_disp(self):
+        dispvm = self.app.add_new_vm(
+            qubes.vm.dispvm.DispVM,
+            template=self.disp_base,
+            auto_cleanup=False,
+            name=self.make_vm_name("named-disp"),
+        )
+        assert isinstance(dispvm, qubes.vm.dispvm.DispVM)
+        await dispvm.create_on_disk()
+        await dispvm.start()
+        await self.defer_tpl(self.disp_base)
+
+    def test_002_defer_tpl_of_unnamed_disp(self):
+        """Test deferred template of unnamed disposable."""
+        self.loop.run_until_complete(self._test_002_defer_tpl_of_unnamed_disp())
+
+    async def _test_002_defer_tpl_of_unnamed_disp(self):
+        dispvm = await qubes.vm.dispvm.DispVM.from_appvm(self.disp_base)
+        assert isinstance(dispvm, qubes.vm.dispvm.DispVM)
+        self.assertTrue(dispvm.auto_cleanup)
+        dispvm.template = self.disp_base_alt
+        await dispvm.start()
+        with self.assertRaises(qubes.exc.QubesVMNotHaltedError):
+            dispvm.template = self.disp_base
+
+    def test_002_defer_tpl_of_disp(self):
+        """Test deferred template of disposable."""
+        self.loop.run_until_complete(self._test_002_defer_tpl_of_disp())
+
+    async def _test_002_defer_tpl_of_disp(self):
+        dispvm = self.app.add_new_vm(
+            qubes.vm.dispvm.DispVM,
+            template=self.disp_base,
+            auto_cleanup=False,
+            name=self.make_vm_name("named-disp"),
+        )
+        assert isinstance(dispvm, qubes.vm.dispvm.DispVM)
+        await dispvm.create_on_disk()
+        await self.defer_tpl(dispvm)
+
+    def test_003_defer_tpl_of_disp_with_standalone_template(self):
+        """Test deferred template of disposable with standalone as template."""
+        self.loop.run_until_complete(
+            self._test_003_defer_tpl_of_disp_with_standalone_template()
+        )
+
+    async def _test_003_defer_tpl_of_disp_with_standalone_template(self):
+        standalone_disposable_template = self.app.add_new_vm(
+            qubes.vm.standalonevm.StandaloneVM,
+            name=self.make_vm_name("std-dvm"),
+            label="red",
+            template_for_dispvms=True,
+        )
+        await standalone_disposable_template.create_on_disk()
+        dispvm = self.app.add_new_vm(
+            qubes.vm.dispvm.DispVM,
+            template=self.disp_base,
+            auto_cleanup=False,
+            name=self.make_vm_name("named-disp"),
+        )
+        assert isinstance(dispvm, qubes.vm.dispvm.DispVM)
+        await dispvm.create_on_disk()
+        await self.defer_tpl(dispvm)
+
     def test_011_preload_reject_max(self):
         """Test preloading when max has been reached"""
         self.loop.run_until_complete(

--- a/qubes/tests/vm/__init__.py
+++ b/qubes/tests/vm/__init__.py
@@ -63,6 +63,16 @@ class TestVMsCollection(dict):
     def __iter__(self):
         return iter(set(self.values()))
 
+    def get_vms_based_on(self, template):
+        template = self[template]
+        return set(
+            vm
+            for vm in self
+            if hasattr(vm, "template")
+            and getattr(vm, "active_template", getattr(vm, "template"))
+            == template
+        )
+
 
 class TestVolume(object):
     def __init__(self, pool, **kwargs):

--- a/qubes/tests/vm/appvm.py
+++ b/qubes/tests/vm/appvm.py
@@ -77,6 +77,76 @@ class TestPool(qubes.storage.Pool):
         return self._volumes[vid]
 
 
+def defer_tpl(self, qube, template_alt):
+    assert not qube.template == template_alt
+    template_orig = qube.template
+    self.assertTrue(qube.property_is_default("active_template"))
+
+    if getattr(qube, "auto_cleanup", False):
+        with mock.patch.object(qube, "get_power_state") as mock_power:
+            mock_power.return_value = "Running"
+            # Change active template while qube is running.
+            with self.assertRaises(qubes.exc.QubesVMNotHaltedError):
+                qube.template = template_alt
+            return
+
+    with mock.patch.object(qube, "get_power_state") as mock_power:
+        mock_power.return_value = "Running"
+        # Change active template while qube is running.
+        qube.template = template_alt
+        self.assertNotEqual(qube.template, qube.active_template)
+        self.assertEqual(qube.template, template_alt)
+        self.assertEqual(qube.active_template, template_orig)
+        self.assertFalse(qube.property_is_default("active_template"))
+
+        # Get back to original template while qube is running.
+        qube.template = template_orig
+        self.assertEqual(qube.template, template_orig)
+        self.assertEqual(qube.template, qube.active_template)
+        self.assertTrue(qube.property_is_default("active_template"))
+
+        # Change active template again.
+        qube.template = template_alt
+        self.assertNotEqual(qube.template, qube.active_template)
+        self.assertEqual(qube.template, template_alt)
+        self.assertEqual(qube.active_template, template_orig)
+        self.assertFalse(qube.property_is_default("active_template"))
+
+    with mock.patch.object(qube, "get_power_state") as mock_power:
+        mock_power.return_value = "Halted"
+        qubes.vm.appvm.apply_deferred_template(qube)
+        self.assertEqual(qube.template, template_alt)
+        self.assertEqual(qube.template, qube.active_template)
+        self.assertTrue(qube.property_is_default("active_template"))
+
+    with mock.patch.object(
+        qubes.vm.appvm, "template_changed_update_storage"
+    ) as mock_storage:
+        with mock.patch.object(qube, "is_halted", return_value=False):
+            qubes.vm.appvm.apply_deferred_template(qube)
+            mock_storage.assert_not_called()
+        with mock.patch.object(qube, "is_halted", return_value=True):
+            self.assertEqual(qube.template, qube.active_template)
+            qubes.vm.appvm.apply_deferred_template(qube)
+            mock_storage.assert_not_called()
+
+    with mock.patch.object(qube, "get_power_state") as mock_power:
+        mock_power.return_value = "Running"
+        # Change active template while qube is running.
+        qube.template = template_orig
+        self.assertNotEqual(qube.template, qube.active_template)
+        self.assertEqual(qube.template, template_orig)
+        self.assertEqual(qube.active_template, template_alt)
+        self.assertFalse(qube.property_is_default("active_template"))
+
+        with mock.patch.object(
+            qubes.vm.appvm, "apply_deferred_template"
+        ) as mock_apply:
+            qube.fire_event("domain-load")
+            mock_apply.assert_called_once_with(qube)
+            mock_apply.reset_mock()
+
+
 class TC_90_AppVM(
     qubes.tests.vm.qubesvm.QubesVMTestsMixin, qubes.tests.QubesTestCase
 ):
@@ -89,13 +159,20 @@ class TC_90_AppVM(
         self.template = qubes.vm.templatevm.TemplateVM(
             self.app, None, qid=1, name=qubes.tests.VMPREFIX + "template"
         )
-        self.app.domains[self.template.name] = self.template
-        self.app.domains[self.template] = self.template
+        self.template_alt = qubes.vm.templatevm.TemplateVM(
+            self.app, None, qid=20, name=qubes.tests.VMPREFIX + "template-alt"
+        )
+
+        for template in [self.template, self.template_alt]:
+            self.app.domains[template.name] = template
+            self.app.domains[template] = template
         self.addCleanup(self.cleanup_appvm)
 
     def cleanup_appvm(self):
         self.template.close()
+        self.template_alt.close()
         del self.template
+        del self.template_alt
         self.app.domains.clear()
         self.app.pools.clear()
 
@@ -161,10 +238,9 @@ class TC_90_AppVM(
 
     def test_003_template_change_running(self):
         vm = self.get_vm()
-        with mock.patch.object(vm, "get_power_state") as mock_power:
-            mock_power.return_value = "Running"
-            with self.assertRaises(qubes.exc.QubesVMNotHaltedError):
-                vm.template = self.template
+        self.assertEqual(vm.template, self.template)
+        self.assertEqual(vm.template, vm.active_template)
+        defer_tpl(self=self, qube=vm, template_alt=self.template_alt)
 
     def test_004_template_reset(self):
         vm = self.get_vm()

--- a/qubes/tests/vm/dispvm.py
+++ b/qubes/tests/vm/dispvm.py
@@ -195,7 +195,7 @@ class TC_00_DispVM(qubes.tests.QubesTestCase):
             self.app, "domains", wraps=self.app.domains
         ) as mock_domains:
             mock_qube = mock.Mock()
-            mock_qube.template = self.appvm
+            mock_qube.template = mock_qube.active_template = self.appvm
             mock_qube.qrexec_timeout = self.appvm.qrexec_timeout
             mock_qube.preload_complete = mock.Mock(spec=asyncio.Event)
             mock_qube.preload_complete.is_set.return_value = True
@@ -266,7 +266,7 @@ class TC_00_DispVM(qubes.tests.QubesTestCase):
         ) as mock_events:
             mock_events.assert_not_called()
             mock_qube = mock.Mock()
-            mock_qube.template = self.appvm
+            mock_qube.template = mock_qube.active_template = self.appvm
             mock_qube.qrexec_timeout = self.appvm.qrexec_timeout
             mock_qube.preload_complete = mock.Mock(spec=asyncio.Event)
             mock_qube.preload_complete.is_set.return_value = True
@@ -696,7 +696,7 @@ class TC_00_DispVM(qubes.tests.QubesTestCase):
             self.app, "domains", wraps=self.app.domains
         ) as mock_domains:
             mock_qube = mock.Mock()
-            mock_qube.template = self.appvm
+            mock_qube.template = mock_qube.active_template = self.appvm
             mock_domains.configure_mock(
                 **{
                     "get_new_unused_dispid": mock.Mock(return_value=42),

--- a/qubes/tests/vm/dispvm.py
+++ b/qubes/tests/vm/dispvm.py
@@ -348,9 +348,21 @@ class TC_00_DispVM(qubes.tests.QubesTestCase):
                 qubes.vm.dispvm.DispVM.from_appvm(self.appvm)
             )
 
-    @unittest.skip("test is broken")
-    def test_007_template_change(self):
+    @mock.patch("qubes.vm.qubesvm.QubesVM.start")
+    @mock.patch("os.symlink")
+    @mock.patch("os.makedirs")
+    @mock.patch("qubes.storage.Storage")
+    def test_007_template_change(
+        self,
+        mock_storage,
+        _mock_makedirs,
+        _mock_symlink,
+        mock_start,
+    ):
+        mock_storage.return_value.create.side_effect = self.mock_coro
+        mock_start.side_effect = self.mock_coro
         self.appvm.template_for_dispvms = True
+        self.appvm_alt.template_for_dispvms = True
         orig_getitem = self.app.domains.__getitem__
         with mock.patch.object(
             self.app, "domains", wraps=self.app.domains
@@ -364,17 +376,15 @@ class TC_00_DispVM(qubes.tests.QubesTestCase):
             dispvm = self.app.add_new_vm(
                 qubes.vm.dispvm.DispVM, name="test-dispvm", template=self.appvm
             )
-
-            dispvm.template = self.appvm
-            self.loop.run_until_complete(dispvm.start())
-            if not self.app.vmm.offline_mode:
-                assert not dispvm.is_halted()
-                with self.assertRaises(qubes.exc.QubesVMNotHaltedError):
-                    dispvm.template = self.appvm
-            with self.assertRaises(qubes.exc.QubesValueError):
-                dispvm.template = qubes.property.DEFAULT
-            self.loop.run_until_complete(dispvm.kill())
-            dispvm.template = self.appvm
+            qubes.tests.vm.appvm.defer_tpl(
+                self=self, qube=dispvm, template_alt=self.appvm_alt
+            )
+            dispvm = self.loop.run_until_complete(
+                qubes.vm.dispvm.DispVM.from_appvm(self.appvm)
+            )
+            qubes.tests.vm.appvm.defer_tpl(
+                self=self, qube=dispvm, template_alt=self.appvm_alt
+            )
 
     def test_008_dvmtemplate_template_change(self):
         self.appvm.template_for_dispvms = True

--- a/qubes/tests/vm/mix/dvmtemplate.py
+++ b/qubes/tests/vm/mix/dvmtemplate.py
@@ -235,7 +235,7 @@ class TC_00_DVMTemplateMixin(
             self.app, "domains", wraps=self.app.domains
         ) as mock_domains:
             mock_qube = mock.Mock()
-            mock_qube.template = self.appvm
+            mock_qube.template = mock_qube.active_template = self.appvm
             mock_domains.configure_mock(
                 **{
                     "get_new_unused_dispid": mock.Mock(return_value=42),

--- a/qubes/tests/vm/mix/dvmtemplate.py
+++ b/qubes/tests/vm/mix/dvmtemplate.py
@@ -373,31 +373,47 @@ class TC_00_DVMTemplateMixin(
             dispid=43,
         )
 
-        # Can switch templates even if not all running disposable are preloads.
+        # Preloads are refreshed if disposable template is halted.
         mock_remove.reset_mock()
         self.appvm.features["preload-dispvm-max"] = "1"
         self.appvm.features["preload-dispvm"] = self.dispvm.name
         with (
             mock.patch.object(self.dispvm, "is_running", return_value=True),
             mock.patch.object(self.dispvm_alt, "is_running", return_value=True),
-            mock.patch.object(self.appvm, "is_running", return_value=False),
         ):
-            self.appvm.template = self.template_alt
-        mock_remove.assert_called_once_with(0, reason=mock.ANY)
-        mock_events.assert_called_once_with(
-            "domain-preload-dispvm-start", reason=mock.ANY
-        )
 
-        # TODO: ben: fix broken test
-        # Preloaded disposables are refreshed if disposable template is halted.
-        with (
-            mock.patch.object(self.dispvm, "is_running", return_value=True),
-            mock.patch.object(self.dispvm_alt, "is_running", return_value=True),
-            mock.patch.object(self.appvm, "is_running", return_value=True),
-        ):
-            self.appvm.template = self.template
-        mock_remove.assert_not_called()
-        mock_events.assert_not_called()
+            with (
+                mock.patch.object(
+                    self.appvm, "get_power_state", return_value="Halted"
+                ),
+                mock.patch.object(self.appvm, "is_running", return_value=False),
+                mock.patch.object(self.appvm, "can_preload", return_value=True),
+            ):
+                self.appvm.template = self.template_alt
+                self.assertEqual(self.appvm.template, self.template_alt)
+                self.assertEqual(self.appvm.active_template, self.template_alt)
+                mock_remove.assert_called_once_with(0, reason=mock.ANY)
+                mock_events.assert_called_once_with(
+                    "domain-preload-dispvm-start", reason=mock.ANY
+                )
+                mock_remove.reset_mock()
+                mock_events.reset_mock()
+
+            # Preloads are NOT refreshed if disposable template is running.
+            with (
+                mock.patch.object(
+                    self.appvm, "get_power_state", return_value="Running"
+                ),
+                mock.patch.object(self.appvm, "is_running", return_value=True),
+                mock.patch.object(
+                    self.appvm, "can_preload", return_value=False
+                ),
+            ):
+                self.appvm.template = self.template
+                self.assertEqual(self.appvm.template, self.template)
+                self.assertEqual(self.appvm.active_template, self.template_alt)
+                mock_remove.assert_not_called()
+                mock_events.assert_not_called()
 
     @mock.patch("qubes.events.Emitter.fire_event_async")
     @mock.patch(

--- a/qubes/tests/vm/mix/dvmtemplate.py
+++ b/qubes/tests/vm/mix/dvmtemplate.py
@@ -372,40 +372,32 @@ class TC_00_DVMTemplateMixin(
             label="red",
             dispid=43,
         )
-        # Can't switch templates if disposable is running.
-        mock_remove.reset_mock()
-        mock_events.reset_mock()
-        with mock.patch.object(self.dispvm, "is_running", return_value=True):
-            with self.assertRaises(qubes.exc.QubesVMInUseError):
-                self.appvm.template = self.template_alt
-        mock_remove.assert_not_called()
-        mock_events.assert_not_called()
 
-        # Can't switch templates if not all running disposable are preloads.
+        # Can switch templates even if not all running disposable are preloads.
         mock_remove.reset_mock()
         self.appvm.features["preload-dispvm-max"] = "1"
         self.appvm.features["preload-dispvm"] = self.dispvm.name
-        with mock.patch.object(
-            self.dispvm, "is_running", return_value=True
-        ), mock.patch.object(self.dispvm_alt, "is_running", return_value=True):
-            with self.assertRaises(qubes.exc.QubesVMInUseError):
-                self.appvm.template = self.template_alt
-        mock_remove.assert_not_called()
-        mock_events.assert_not_called()
-
-        # Can switch templates if all running disposable are preloads.
-        self.appvm.features["preload-dispvm-max"] = "2"
-        self.appvm.features["preload-dispvm"] = (
-            self.dispvm.name + " " + self.dispvm_alt.name
-        )
-        with mock.patch.object(
-            self.dispvm, "is_running", return_value=True
-        ), mock.patch.object(self.dispvm_alt, "is_running", return_value=True):
+        with (
+            mock.patch.object(self.dispvm, "is_running", return_value=True),
+            mock.patch.object(self.dispvm_alt, "is_running", return_value=True),
+            mock.patch.object(self.appvm, "is_running", return_value=False),
+        ):
             self.appvm.template = self.template_alt
         mock_remove.assert_called_once_with(0, reason=mock.ANY)
         mock_events.assert_called_once_with(
             "domain-preload-dispvm-start", reason=mock.ANY
         )
+
+        # TODO: ben: fix broken test
+        # Preloaded disposables are refreshed if disposable template is halted.
+        with (
+            mock.patch.object(self.dispvm, "is_running", return_value=True),
+            mock.patch.object(self.dispvm_alt, "is_running", return_value=True),
+            mock.patch.object(self.appvm, "is_running", return_value=True),
+        ):
+            self.appvm.template = self.template
+        mock_remove.assert_not_called()
+        mock_events.assert_not_called()
 
     @mock.patch("qubes.events.Emitter.fire_event_async")
     @mock.patch(

--- a/qubes/vm/appvm.py
+++ b/qubes/vm/appvm.py
@@ -40,6 +40,36 @@ def template_changed_update_storage(self):
             self.storage.init_volume(volume_name, config)
 
 
+def template_changed(self, oldvalue=None, newvalue=None):
+    if oldvalue == newvalue:
+        return
+    if not self.is_halted():
+        if self.property_is_default("active_template"):
+            self.active_template = oldvalue
+        elif newvalue == self.active_template:
+            del self.active_template
+        return
+    template_changed_update_storage(self)
+    if not getattr(self, "template_for_dispvms", False):
+        return
+    for qube in self.app.domains.get_vms_based_on(self):
+        template_changed_update_storage(qube)
+
+
+def apply_deferred_template(self):
+    if not self.is_halted():
+        return
+    if self.active_template == self.template:
+        return
+    del self.active_template
+    template_changed_update_storage(self)
+
+
+def domain_loaded(self):
+    assert self.template
+    apply_deferred_template(self)
+
+
 class AppVM(
     qubes.vm.mix.dvmtemplate.DVMTemplateMixin, qubes.vm.qubesvm.QubesVM
 ):
@@ -49,7 +79,16 @@ class AppVM(
         "template",
         load_stage=4,
         vmclass=qubes.vm.templatevm.TemplateVM,
-        doc="Template, on which this AppVM is based.",
+        doc="Template, on which this AppVM is based or will be based after"
+        "restart",
+    )
+
+    active_template = qubes.VMProperty(
+        "active_template",
+        load_stage=4,
+        vmclass=qubes.vm.templatevm.TemplateVM,
+        default=(lambda self: self.template),
+        doc="Template in use.",
     )
 
     default_volume_config = {
@@ -123,7 +162,14 @@ class AppVM(
     @qubes.events.handler("domain-load")
     def on_domain_loaded(self, event):
         """When domain is loaded assert that this vm has a template."""  # pylint: disable=unused-argument
-        assert self.template
+        domain_loaded(self)
+
+    @qubes.events.handler("domain-shutdown")
+    async def on_domain_shutdown(self, _event, **_kwargs) -> None:
+        """
+        Apply deferred template.
+        """
+        apply_deferred_template(self)
 
     @qubes.events.handler("property-pre-reset:template")
     def on_property_pre_reset_template(self, event, name, oldvalue=None):
@@ -137,21 +183,9 @@ class AppVM(
             )
         raise qubes.exc.QubesValueError("Cannot unset template")
 
-    @qubes.events.handler("property-pre-set:template")
-    def on_property_pre_set_template(
-        self, event, name, newvalue, oldvalue=None
-    ):
-        """Forbid changing template of running VM"""  # pylint: disable=unused-argument
-        if not self.is_halted():
-            raise qubes.exc.QubesVMNotHaltedError(
-                self, "Cannot change template while qube is running"
-            )
-
     @qubes.events.handler("property-set:template")
     def on_property_set_template(self, event, name, newvalue, oldvalue=None):
         """Adjust root (and possibly other snap_on_start=True) volume
         on template change.
         """  # pylint: disable=unused-argument
-        template_changed_update_storage(self)
-        for vm in self.dispvms:
-            vm.on_property_set_template(event, name, newvalue, oldvalue)
+        template_changed(self, oldvalue=oldvalue, newvalue=newvalue)

--- a/qubes/vm/dispvm.py
+++ b/qubes/vm/dispvm.py
@@ -290,7 +290,7 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
         "default_dispvm",
         load_stage=4,
         allow_none=True,
-        default=(lambda self: self.template),
+        default=qubes.vm.qubesvm.get_active_template,
         setter=qubes.vm.setter_disposable_template,
         doc="""Default disposable template to be used for spawning disposable
             qubes for service calls.""",
@@ -452,7 +452,7 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
 
         :rtype: bool
         """
-        appvm = self.template
+        appvm = qubes.vm.qubesvm.get_active_template(self)
         preload_dispvm = appvm.get_feat_preload()
         if self.name in preload_dispvm or self.preload_requested:
             return True
@@ -468,7 +468,7 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
         if not self.is_preload:
             return differed
 
-        appvm = self.template
+        appvm = qubes.vm.qubesvm.get_active_template(self)
         if self.volumes["private"].size != appvm.volumes["private"].size:
             differed["volumes_size"] = ["private"]
             return differed
@@ -531,7 +531,13 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
             raise qubes.exc.QubesException(
                 "Timed out call to '%s' after '%d' seconds during preload "
                 "startup. To debug, run the following on a new disposable of "
-                "'%s': %s" % (service, timeout, self.template, debug_msg)
+                "'%s': %s"
+                % (
+                    service,
+                    timeout,
+                    qubes.vm.qubesvm.get_active_template(self),
+                    debug_msg,
+                )
             )
         except subprocess.CalledProcessError as e:
             raise qubes.exc.QubesException(
@@ -871,7 +877,7 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
         """
         Mark disposable as a preload.
         """
-        appvm = self.template
+        appvm = qubes.vm.qubesvm.get_active_template(self)
         self.log.info("Marking preloaded qube")
         self.features["preload-dispvm-in-progress"] = True
         preload_dispvm = appvm.get_feat_preload()
@@ -914,7 +920,7 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
         """
         Mark preloaded disposable as requested.
         """
-        appvm = self.template
+        appvm = qubes.vm.qubesvm.get_active_template(self)
         self.log.info("Requesting preloaded qube")
         self.features["preload-dispvm-in-progress"] = True
         appvm.remove_preload_from_list([self.name], reason="qube was requested")
@@ -928,7 +934,7 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
         """
         if not self.is_preload:
             raise qubes.exc.QubesException("Disposable is not preloaded")
-        appvm = self.template
+        appvm = qubes.vm.qubesvm.get_active_template(self)
         if self.preload_requested:
             self.log.info("Using preloaded qube")
             if not appvm.features.get("internal", None):
@@ -961,15 +967,15 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
         Cleanup preload from list.
         """
         name = getattr(self, "name", None)
-        template = getattr(self, "template", None)
+        template = qubes.vm.qubesvm.get_active_template(self)
         if not (name and template):
             # Objects from self may be absent.
             return
         if name in template.get_feat_preload():
-            self.template.remove_preload_from_list(
+            template.remove_preload_from_list(
                 [self.name], reason="automatic cleanup was called"
             )
-            self.template.remove_preload_from_list([self.name])
+            template.remove_preload_from_list([self.name])
 
     async def _auto_cleanup(self, force: bool = False) -> None:
         """
@@ -1017,12 +1023,13 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
         Start disposable qube, but if it fails, make sure to clean it up.
         """
         # pylint: disable=arguments-differ
+        template = qubes.vm.qubesvm.get_active_template(self)
         try:
             # sanity check, if template_for_dispvm got changed in the meantime
-            if not self.template.template_for_dispvms:
+            if not template.template_for_dispvms:
                 raise qubes.exc.QubesException(
                     "template for disposable ({}) needs to have "
-                    "template_for_dispvms=True".format(self.template.name)
+                    "template_for_dispvms=True".format(template.name)
                 )
             await super().start(**kwargs)
         except:

--- a/qubes/vm/dispvm.py
+++ b/qubes/vm/dispvm.py
@@ -32,6 +32,7 @@ import qubes.vm.appvm
 import qubes.vm.qubesvm
 
 PRELOAD_OUTDATED_IGNORED_PROPERTIES = [
+    "active_template",
     "autostart",
     "backup_timestamp",
     "default_dispvm",
@@ -251,7 +252,16 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
         "template",
         load_stage=4,
         setter=_setter_template,
-        doc="AppVM, on which this disposable is based.",
+        doc="Template, on which this AppVM is based or will be based after"
+        "restart",
+    )
+
+    active_template = qubes.VMProperty(
+        "active_template",
+        load_stage=4,
+        setter=_setter_template,
+        default=(lambda self: self.template),
+        doc="Template in use.",
     )
 
     dispid = qubes.property(
@@ -488,7 +498,7 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
         When qube is loaded, assert that this qube has a template.
         """
         # pylint: disable=unused-argument
-        assert self.template
+        qubes.vm.appvm.domain_loaded(self)
 
     async def wait_operational_preload(
         self, service: str, timeout: int | float
@@ -699,9 +709,11 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
     @qubes.events.handler("domain-shutdown")
     async def on_domain_shutdown(self, _event, **_kwargs) -> None:
         """
-        Do auto cleanup if enabled.
+        Do auto cleanup if enabled. Apply deferred template.
         """
         await self._auto_cleanup()
+        if not self.auto_cleanup:
+            qubes.vm.appvm.apply_deferred_template(self)
 
     @qubes.events.handler("domain-remove-from-disk")
     def on_domain_remove_from_disk(self, _event, **_kwargs) -> None:
@@ -734,7 +746,8 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
         self, event, name, newvalue, oldvalue=None
     ):
         """
-        Forbid changing template of running qube.
+        Forbid changing template of running disposable with ``auto_cleanup``
+        enabled.
 
         :param str event: Event which was fired.
         :param str name: Property name.
@@ -744,7 +757,7 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
             of the property.
         """
         # pylint: disable=unused-argument
-        if not self.is_halted():
+        if self.auto_cleanup and not self.is_halted():
             raise qubes.exc.QubesVMNotHaltedError(
                 self, "Cannot change template while qube is running"
             )
@@ -765,7 +778,10 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
             of the property.
         """
         # pylint: disable=unused-argument
-        qubes.vm.appvm.template_changed_update_storage(self)
+        if not self.auto_cleanup:
+            qubes.vm.appvm.template_changed(
+                self, oldvalue=oldvalue, newvalue=newvalue
+            )
 
     @classmethod
     async def from_appvm(

--- a/qubes/vm/mix/dvmtemplate.py
+++ b/qubes/vm/mix/dvmtemplate.py
@@ -430,19 +430,7 @@ class DVMTemplateMixin(qubes.events.Emitter):
             return
         if newvalue == oldvalue:
             return
-        dependencies = [
-            disp.name
-            for disp in self.dispvms
-            if disp.is_running() and not disp.is_preload
-        ]
-        if dependencies:
-            msg = (
-                "Cannot change template while there are running disposables"
-                " based on this disposable template",
-            )
-            self.log.error("%s: %s", msg, ", ".join(dependencies))
-            raise qubes.exc.QubesVMInUseError(self, msg)
-        self.remove_preload_excess(0, reason="template will change")
+        self.remove_preload_excess(0, reason="template has changed")
 
     @qubes.events.handler("property-set:template")
     def __on_property_set_template(

--- a/qubes/vm/mix/dvmtemplate.py
+++ b/qubes/vm/mix/dvmtemplate.py
@@ -50,7 +50,7 @@ class DVMTemplateMixin(qubes.events.Emitter):
         """
         assert isinstance(self, qubes.vm.BaseVM)
         for vm in self.app.domains:
-            if getattr(vm, "template", None) == self:
+            if qubes.vm.qubesvm.get_active_template(vm) == self:
                 yield vm
 
     @qubes.events.handler("domain-load")
@@ -313,7 +313,8 @@ class DVMTemplateMixin(qubes.events.Emitter):
         nonderived = [
             qube
             for qube in new_list_diff
-            if getattr(self.app.domains[qube], "template") != self
+            if qubes.vm.qubesvm.get_active_template(self.app.domains[qube])
+            != self
         ]
         if nonderived:
             raise qubes.exc.QubesValueError(

--- a/qubes/vm/mix/dvmtemplate.py
+++ b/qubes/vm/mix/dvmtemplate.py
@@ -431,17 +431,20 @@ class DVMTemplateMixin(qubes.events.Emitter):
             return
         if newvalue == oldvalue:
             return
-        self.remove_preload_excess(0, reason="template has changed")
 
     @qubes.events.handler("property-set:template")
     def __on_property_set_template(
         self, event, name, newvalue, oldvalue=None
     ) -> None:
         # pylint: disable=unused-argument
+        assert isinstance(self, qubes.vm.qubesvm.QubesVM)
         if newvalue == oldvalue:
             return
         if not getattr(self, "template_for_dispvms"):
             return
+        if self.is_running():
+            return
+        self.remove_preload_excess(0, reason="template has changed")
         if not self.can_preload():
             return
         asyncio.ensure_future(

--- a/qubes/vm/qubesvm.py
+++ b/qubes/vm/qubesvm.py
@@ -254,7 +254,8 @@ def _default_virt_mode(self):
     if list(self.devices["pci"].get_assigned_devices()):
         return "hvm"
     try:
-        return self.template.virt_mode
+        template = get_active_template(self)
+        return template.virt_mode
     except AttributeError:
         return "pvh"
 
@@ -266,7 +267,7 @@ def _default_with_template(prop, default):
 
     def _func(self):
         try:
-            return getattr(self.template, prop)
+            return getattr(get_active_template(self), prop)
         except AttributeError:
             if callable(default):
                 return default(self)
@@ -332,6 +333,10 @@ def _default_kernelopts(self):
             if any_pci_assigned
             else qubes.config.defaults["kernelopts"]
         ) + extra_opts
+
+
+def get_active_template(self):
+    return getattr(self, "active_template", getattr(self, "template", None))
 
 
 class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.LocalVM):
@@ -2845,7 +2850,9 @@ class QubesVM(qubes.vm.mix.net.NetVMMixin, qubes.vm.LocalVM):
         )
         self.untrusted_qdb.write("/qubes-debug-mode", str(int(self.debug)))
         try:
-            self.untrusted_qdb.write("/qubes-base-template", self.template.name)
+            self.untrusted_qdb.write(
+                "/qubes-base-template", get_active_template(self).name
+            )
         except AttributeError:
             self.untrusted_qdb.write("/qubes-base-template", "")
 


### PR DESCRIPTION
Add ability for template based qubes (AppVM and DispVM) to be able to change the template while running. When the qube is running and you modify the `template` property, it is set to the `newvalue`, while the `active_template` changes to the `oldvalue` if it is still the default.

The use of separate properties doesn't break new clients. For example, Qube Manager reacts to `property-set:template` and adapts the field to the current value, despite it not being the active one. This is what happens for other properties also, such as `virt_mode` and `kernel`, you may change it live, but it only applies on the next boot.

Fixes: https://github.com/qubesos/qubes-issues/issues/8070

Clients should deal with the new property this way:

- react to `property-(re)?set:(active_)?template)`
- if `active_template` property is default, show only it, else, show it alongside the `template` indicating that it is deferred, this is for a minimal view with less clutter. On clients that would be better to show two columns containing both values, that is also fine.