### PR TITLE
Filter backup info

### DIFF
--- a/qubes/api/admin.py
+++ b/qubes/api/admin.py
@@ -2488,11 +2488,10 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
             "/" not in self.arg,
             reason="Backup profile ID must not contain forward slash character",
         )
-
-        self.fire_event_for_permission()
-
+        domains = self.fire_event_for_filter(self.app.domains)
         backup = await self._load_backup_profile(self.arg, skip_passphrase=True)
-        return backup.get_backup_summary()
+        summary = backup.get_backup_summary(filtered_domains=domains)
+        return summary
 
     def _send_stats_single(self, info_time, info, only_vm, filters):
         """A single iteration of sending VM stats

--- a/qubes/api/admin.py
+++ b/qubes/api/admin.py
@@ -2480,7 +2480,7 @@ class QubesAdminAPI(qubes.api.AbstractQubesAPI):
         wants_arg=True,
         wants_payload=False,
         dest_adminvm=True,
-        scope="local",
+        scope="global",
         read=True,
     )
     async def backup_info(self):

--- a/qubes/backup.py
+++ b/qubes/backup.py
@@ -482,7 +482,7 @@ class Backup:
         )
         return files_to_backup
 
-    def get_backup_summary(self):
+    def get_backup_summary(self, filtered_domains):
         summary = ""
 
         fields_to_display = [
@@ -568,14 +568,13 @@ class Backup:
         summary += "\n"
 
         vms_not_for_backup = [
-            vm.name for vm in self.app.domains if vm not in self.vms_for_backup
+            vm.name for vm in filtered_domains if vm not in self.vms_for_backup
         ]
         summary += (
             "VMs not selected for backup:\n - "
             + "\n - ".join(sorted(vms_not_for_backup))
             + "\n"
         )
-
         return summary
 
     async def _prepare_backup_header(self):

--- a/qubes/ext/admin.py
+++ b/qubes/ext/admin.py
@@ -88,7 +88,10 @@ class AdminExtension(qubes.ext.Extension):
 
     # TODO create that tag here (need to figure out how to pass mgmtvm name)
 
-    @qubes.ext.handler("admin-permission:admin.vm.List")
+    @qubes.ext.handler(
+        "admin-permission:admin.vm.List",
+        "admin-permission:admin.backup.Info",
+    )
     def admin_vm_list(self, vm, event, arg, **kwargs):
         """When called with target 'dom0' (aka "get full list"), exclude domains
         that the caller don't have permission to list


### PR DESCRIPTION
Non-dom0 should not know more information than necessary. If the call to `admin.backup.Info` is allowed, it is okay to show qubes in the `include` section, but it is not necessary to show `exclude`d qubes that caller is not aware of.

For: https://github.com/qubesos/qubes-issues/issues/11062