### PR TITLE
tests: be less strict about audio tests on whonix in nested virt

### DIFF
--- a/qubes/tests/integ/audio.py
+++ b/qubes/tests/integ/audio.py
@@ -203,6 +203,11 @@ admin.vm.feature.CheckWithTemplate  +audio-model   {vm}     @tag:audiovm-{vm}  a
             # be less strict on HVM tests in nested virt, the test environment
             # has huge overhead already
             margin = 0.50
+        if in_qemu and "whonix" in self.template:
+            # similarly treat Whonix, which has extra overhead (mostly memory
+            # usage, and sdwdate looping) - too much to get clean audio
+            # on nested virt
+            margin = 0.50
         if rec_size < margin * 441000:
             fname = f"/tmp/audio-sample-{self.id()}.raw"
             with open(fname, "wb") as f:


### PR DESCRIPTION
Similar to HVM tests, Whonix has extra overhead and combined with nested
virt it's too much for getting clean audio. Accept some glitches, but do
require some samples to be heard.

Tests on real hw still require full output.
