### PR TITLE
tests: wait for user session for qvm-template test

### DIFF
--- a/qubes/tests/integ/dom0_update.py
+++ b/qubes/tests/integ/dom0_update.py
@@ -663,7 +663,7 @@ class TC_10_QvmTemplateMixin(object):
                 self.whonix_gw_setup_async(self.updatevm)
             )
         else:
-            self.loop.run_until_complete(self.updatevm.start())
+            self.loop.run_until_complete(self.start_vm(self.updatevm))
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)


### PR DESCRIPTION
Better simulate user running the command from the user session directly.
This especially ensures the same environment, including PATH is
present.
