### PR TITLE
Revert "Cleanup disposable on failed startup"

### DIFF
--- a/qubes/vm/dispvm.py
+++ b/qubes/vm/dispvm.py
@@ -1011,7 +1011,7 @@ class DispVM(qubes.vm.qubesvm.QubesVM):
             await super().start(**kwargs)
         except:
             # Cleanup also on failed startup
-            await self.cleanup(force=True)
+            await self.cleanup()
             raise
 
     def create_qdb_entries(self) -> None:


### PR DESCRIPTION
This introduces an issue with named disposables being removed - worse
than the original issue. Proper fix turned out to be more complicated,
so revert offending commit for now.

This reverts commit a82f4f2affcf083f7e7ac24414a7464f00d08ed0.
