### PR TITLE
qvm-console-dispvm: clarify error when management DispVM has no guivm

### DIFF
--- a/qvm-tools/qvm-console-dispvm
+++ b/qvm-tools/qvm-console-dispvm
@@ -42,4 +42,11 @@ DISPVM="$(qvm-prefs -- "$QREXEC_REQUESTED_TARGET" management_dispvm)"
 
 [[ "x$DISPVM" == "x" ]] && { echo "Error: cannot determine management DispVM of domain '$QREXEC_REQUESTED_TARGET'">&2; exit 1; }
 
+GUIVM="$(qvm-prefs -- "$DISPVM" guivm)"
+
+if [[ -z "$GUIVM" ]]; then
+    echo "Error: management DispVM '$DISPVM' does not have a GUI domain" >&2
+    exit 1
+fi
+
 sudo qvm-run -p --localcmd="QREXEC_REQUESTED_TARGET=$QREXEC_REQUESTED_TARGET QREXEC_REMOTE_DOMAIN=dom0 /etc/qubes-rpc/admin.vm.Console" --service --dispvm="$DISPVM" -- qubes.ShowInTerminal


### PR DESCRIPTION
qvm-console-dispvm starts qubes.ShowInTerminal without checking whether the selected management DispVM has a GUI domain. This leaves users with an unclear xterm display error.

The fix checks the management DispVM's guivm property first and reports a direct error when it is empty.

Fixes QubesOS/qubes-issues#10894

AI DISCLOSURE: Generative AI was utilized in testing, writing, and assisting in review of this code. I signed and personally reviewed the code myself and take responsibility for its contents.