### PR TITLE
Fix https://github.com/QubesOS/qubes-issues/issues/11045

### DIFF
--- a/qubes/utils.py
+++ b/qubes/utils.py
@@ -163,9 +163,9 @@ def parse_bool(value):
     """Deserialize bool property, handling usual encodings"""
     if isinstance(value, bool):
         return value
-    if value in ("True", "1", "on"):
+    if value in ("True", "true", "1", "on"):
         return True
-    if value in ("False", "0", "off", ""):
+    if value in ("False", "false", "0", "off", ""):
         return False
     raise ValueError(f"invalid bool: {value}")
 


### PR DESCRIPTION
Fix [issue 11045](https://github.com/QubesOS/qubes-issues/issues/11045)**

qubes.property.bool lowers string so it accepts true/false, while qubes.utils.parse_bool only accepts capitalized True/False, this fix modifed parse_bool to accept "true" and "false"

This was breaking qubesd and was caused in [this commit](https://github.com/QubesOS/qubes-core-admin/commit/6f23c689b53f25a8f137e952e70a67d5621d2596)