### PR TITLE
firewall: reject empty destination address instead of crashing

### DIFF
--- a/qubes/firewall.py
+++ b/qubes/firewall.py
@@ -99,6 +99,8 @@ class DstHost(RuleOption):
     """Represent host/network address: either IPv4, IPv6, or DNS name"""
 
     def __init__(self, untrusted_value, prefixlen=None):
+        if untrusted_value is None:
+            raise ValueError("Destination address cannot be empty")
         if untrusted_value.count("/") > 1:
             raise ValueError("Too many /: " + untrusted_value)
         if not untrusted_value.count("/"):

--- a/qubes/tests/firewall.py
+++ b/qubes/tests/firewall.py
@@ -209,6 +209,10 @@ class TC_02_DstHost(qubes.tests.QubesTestCase):
         with self.assertRaises(ValueError):
             qubes.firewall.DstHost("https://qubes-os.org")
 
+    def test_021_none_value(self):
+        with self.assertRaises(ValueError):
+            qubes.firewall.DstHost(None)
+
 
 class TC_03_DstPorts(qubes.tests.QubesTestCase):
     def test_000_single_str(self):
@@ -648,3 +652,22 @@ class TC_10_Firewall(qubes.tests.QubesTestCase):
         self.loop.run_until_complete(asyncio.sleep(3))
         # expect new rules
         self.assertEqual(fw.rules, rules)
+
+    def test_007_load_v2_empty_dsthost(self):
+        xml_txt = """<firewall version="2">
+            <rules>
+                <rule>
+                    <properties>
+                        <property name="action">accept</property>
+                        <property name="proto">tcp</property>
+                        <property name="dstports">443</property>
+                        <property name="dsthost"/>
+                    </properties>
+                </rule>
+            </rules>
+        </firewall>
+        """
+        with open(os.path.join("/tmp", self.vm.firewall_conf), "w") as f:
+            f.write(xml_txt)
+        with self.assertRaises(ValueError):
+            qubes.firewall.Firewall(self.vm)


### PR DESCRIPTION
Fixes QubesOS/qubes-issues#11095

## Problem
Leaving the destination address blank while creating a "limit outgoing
connections" firewall rule in Qube Manager saves a rule with an empty
dsthost. On the next qubesd start/reload, `Firewall.load_v2()` reads
this back from XML, the property setter passes `None` into
`DstHost.__init__()`, and `untrusted_value.count("/")` raises
`AttributeError`. This crashes admin.vm.firewall.Get, which prevents
the affected qube from starting and blocks reopening the firewall
editor to fix the rule.

## Fix
Add an explicit None check in `DstHost.__init__()` that raises
`ValueError`.

## Testing
- `TC_02_DstHost.test_021_none_value`: DstHost(None)
  raises ValueError
- `TC_10_Firewall.test_007_load_v2_empty_dsthost`: a XML rule with an
  empty dsthost property loaded via Firewall(vm)

Both tests fail with the original AttributeError against unpatched
code and pass against the fix. Full qubes/tests/firewall.py suite
passes (55 passed, 2 xfailed - pre-existing, unrelated).