### PR TITLE
tests/extra: add timeout= argument to run.communicate()

### DIFF
--- a/qubes/tests/extra.py
+++ b/qubes/tests/extra.py
@@ -42,9 +42,19 @@ class ProcessWrapper(object):
             return super(ProcessWrapper, self).__setattr__(key, value)
         return setattr(self._proc, key, value)
 
-    def communicate(self, input=None):
+    def communicate(self, input=None, timeout=None):
         if self._proc.stdin is not None and input is None:
             input = b""
+        if timeout is not None:
+            try:
+                return self._loop.run_until_complete(
+                    asyncio.wait_for(
+                        self._proc.communicate(input),
+                        timeout=timeout,
+                    )
+                )
+            except asyncio.TimeoutError:
+                raise subprocess.TimeoutExpired(None, timeout)
         return self._loop.run_until_complete(self._proc.communicate(input))
 
     def wait(self):


### PR DESCRIPTION
(non-asyncio) subprocess.Popen.communicate() does have a timeout
argument. Since the extra tests wrapper minic the non-asyncio version,
add this parameter too.
