### PR TITLE
tests: fix setting xterm title

### DIFF
--- a/qubes/tests/integ/vm_qrexec_gui.py
+++ b/qubes/tests/integ/vm_qrexec_gui.py
@@ -85,7 +85,9 @@ class TC_20_NonAudio(TC_00_AppVMMixin):
         self.loop.run_until_complete(self.wait_for_session(self.testvm1))
         title = "user@{}".format(self.testvm1.name)
         p = self.loop.run_until_complete(
-            self.testvm1.run(f"xterm -title {title}")
+            self.testvm1.run(
+                f"xterm -xrm 'xterm*allowTitleOps: false' -title {title}"
+            )
         )
         try:
             self.wait_for_window(title)


### PR DESCRIPTION
Disable dynamic titles, so Whonix doesn't override the title back to
user@host.
